### PR TITLE
PR: Memory leak fix for OpenStarbound.

### DIFF
--- a/source/core/StarImage.cpp
+++ b/source/core/StarImage.cpp
@@ -244,7 +244,7 @@ void Image::reset(unsigned width, unsigned height, Maybe<PixelFormat> pf) {
   if (!pf)
     pf = m_pixelFormat;
 
-  if (m_data && m_width == width && m_height == height && m_pixelFormat == *pf)
+  if (/* m_data && */ m_width == width && m_height == height && m_pixelFormat == *pf) // Fixed memory ballooning.
     return;
 
   size_t imageSize = width * height * Star::bytesPerPixel(*pf);


### PR DESCRIPTION
Checking for `m_data` on line 247 causes unnecessary (and unfreed) `malloc`s for empty image data on line 259, which causes a lot of memory fragmentation and thus the memory ballooning in OpenStarbound. This pull request fixes that. Note that `Image::reset` doesn't get called on an object that's moved *from*, but instead on the object moved *to*. `Image::~Image` is what gets called on moved-from objects.