### PR TITLE
Default point light for objects

### DIFF
--- a/assets/opensb/objects/apex/teslaspike/teslaspike.object.patch
+++ b/assets/opensb/objects/apex/teslaspike/teslaspike.object.patch
@@ -1,0 +1,3 @@
+{
+  "pointLight" : false // set this to true to enjoy 10 fps in apex dungeons
+}

--- a/assets/opensb/objects/biome/brain/brainsynapse1/brainsynapse1.object.patch
+++ b/assets/opensb/objects/biome/brain/brainsynapse1/brainsynapse1.object.patch
@@ -1,0 +1,3 @@
+{
+  "disableParticleLights" : false
+}

--- a/assets/opensb/objects/defaultParameters.config.patch
+++ b/assets/opensb/objects/defaultParameters.config.patch
@@ -1,0 +1,4 @@
+{
+  "pointLight" : true,
+  "disableParticleLights" : true // removes flashing from some objects caused by particle lights, recommended to set to true if pointLight is true
+}


### PR DESCRIPTION
Adds 2 parameters to default object config:
- pointLight : true, basically achieving what this mod (https://steamcommunity.com/sharedfiles/filedetails/?id=729467376) has achieved but without the need to patch every single light source
- disableParticleLights : true - removes light from particles emitted by light sources by setting the value to [0,0,0,0]. Reason for that is that most of the time these particle lights are way too bright and cause objects to flash (and yes, it comes from the base game, it's just not noticeable with static lighting). This is a workaround to not have to patch all of them manually (which is done by the mod above). Comparison with and without here: https://imgur.com/a/3OmUrQr