### PR TITLE
Perfectly Generic Item Improvements

### DIFF
--- a/source/game/StarCommandProcessor.cpp
+++ b/source/game/StarCommandProcessor.cpp
@@ -183,7 +183,7 @@ String CommandProcessor::warpRandom(ConnectionId connectionId, String const& typ
 				}
 			}
 		}
-			
+
 		if (size.magnitude() > 1024)
 			return "could not find a matching world";
 		size *= 2;
@@ -296,7 +296,7 @@ String CommandProcessor::spawnItem(ConnectionId connectionId, String const& argu
 
     bool done = m_universe->executeForClient(connectionId, [&](WorldServer* world, PlayerPtr const& player) {
         auto itemDatabase = Root::singleton().itemDatabase();
-        world->addEntity(ItemDrop::createRandomizedDrop(itemDatabase->item(ItemDescriptor(kind, amount, parameters), level, seed), player->aimPosition()));
+        world->addEntity(ItemDrop::createRandomizedDrop(itemDatabase->item(ItemDescriptor(kind, amount, parameters), level, seed, true), player->aimPosition()));
       });
 
     return done ? "" : "Invalid client state";

--- a/source/game/StarItemDatabase.hpp
+++ b/source/game/StarItemDatabase.hpp
@@ -117,7 +117,7 @@ public:
   // The returned item pointer will be shared. Either call ->clone() or use item() instead for a copy.
   ItemPtr itemShared(ItemDescriptor descriptor, Maybe<float> level = {}, Maybe<uint64_t> seed = {}) const;
   // Same as itemShared, but makes a copy instead. Does not cache.
-  ItemPtr item(ItemDescriptor descriptor, Maybe<float> level = {}, Maybe<uint64_t> seed = {}) const;
+  ItemPtr item(ItemDescriptor descriptor, Maybe<float> level = {}, Maybe<uint64_t> seed = {}, bool ignoreInvalid = false) const;
 
 
   bool hasRecipeToMake(ItemDescriptor const& item) const;
@@ -159,7 +159,7 @@ private:
   };
 
   static ItemPtr createItem(ItemType type, ItemConfig const& config);
-  ItemPtr tryCreateItem(ItemDescriptor const& descriptor, Maybe<float> level = {}, Maybe<uint64_t> seed = {}) const;
+  ItemPtr tryCreateItem(ItemDescriptor const& descriptor, Maybe<float> level = {}, Maybe<uint64_t> seed = {}, bool ignoreInvalid = false) const;
 
   ItemData const& itemData(String const& name) const;
   ItemRecipe makeRecipe(List<ItemDescriptor> inputs, ItemDescriptor output, float duration, StringSet groups) const;


### PR DESCRIPTION
spawnitem command won't create generic items unless you intend to

generic items will retain the data for what item they were if a mod is uninstalled, and will attempt to restore themselves if re-installed