### PR TITLE
Add ClipboardLuaBindings and make them available only when "safeScripts" is false.

### DIFF
--- a/source/client/StarClientApplication.cpp
+++ b/source/client/StarClientApplication.cpp
@@ -21,6 +21,7 @@
 #include "StarInterfaceLuaBindings.hpp"
 #include "StarInputLuaBindings.hpp"
 #include "StarVoiceLuaBindings.hpp"
+#include "StarClipboardLuaBindings.hpp"
 
 #if defined STAR_SYSTEM_WINDOWS
 #include <windows.h>
@@ -516,6 +517,8 @@ void ClientApplication::changeState(MainAppState newState) {
 
     m_universeClient->setLuaCallbacks("input", LuaBindings::makeInputCallbacks());
     m_universeClient->setLuaCallbacks("voice", LuaBindings::makeVoiceCallbacks());
+    if(!m_root->configuration()->get("safeScripts").toBool())
+      m_universeClient->setLuaCallbacks("clipboard", LuaBindings::makeClipboardCallbacks(appController()));
 
     auto heldScriptPanes = make_shared<List<MainInterface::ScriptPaneInfo>>();
 

--- a/source/frontend/CMakeLists.txt
+++ b/source/frontend/CMakeLists.txt
@@ -23,6 +23,7 @@ SET (star_frontend_HEADERS
     StarChatBubbleManager.hpp
     StarCinematic.hpp
     StarClientCommandProcessor.hpp
+    StarClipboardLuaBindings.hpp
     StarCodexInterface.hpp
     StarConfirmationDialog.hpp
     StarContainerInterface.hpp
@@ -74,6 +75,7 @@ SET (star_frontend_SOURCES
     StarChatBubbleManager.cpp
     StarCinematic.cpp
     StarClientCommandProcessor.cpp
+    StarClipboardLuaBindings.cpp
     StarCodexInterface.cpp
     StarConfirmationDialog.cpp
     StarContainerInterface.cpp

--- a/source/frontend/StarClipboardLuaBindings.cpp
+++ b/source/frontend/StarClipboardLuaBindings.cpp
@@ -1,0 +1,24 @@
+#include "StarClipboardLuaBindings.hpp"
+#include "StarLuaConverters.hpp"
+
+#include "SDL2/SDL.h"
+
+namespace Star {
+
+LuaCallbacks LuaBindings::makeClipboardCallbacks(ApplicationControllerPtr appController) {
+  LuaCallbacks callbacks;
+
+  callbacks.registerCallback("hasText", []() -> bool { return SDL_HasClipboardText() == SDL_TRUE;});
+
+  callbacks.registerCallback("getText", [appController]() -> Maybe<String> {
+    return appController->getClipboard();
+  });
+
+  callbacks.registerCallback("setText", [appController](String const& text) {
+    appController->setClipboard(text);
+  });
+
+  return callbacks;
+};
+
+}// namespace Star

--- a/source/frontend/StarClipboardLuaBindings.hpp
+++ b/source/frontend/StarClipboardLuaBindings.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "StarLua.hpp"
+#include "StarApplicationController.hpp"
+
+namespace Star {
+
+namespace LuaBindings {
+LuaCallbacks makeClipboardCallbacks(ApplicationControllerPtr appController);
+}
+
+}// namespace Star


### PR DESCRIPTION
Add ClipboardLuabindings, which is basically consistent with the clipboard Lua bindings of StarExtensions.And now the ClipboardLuaBindings are only available when "safeScripts" is false.