### PR TITLE
fixed IME support and added lua invoke when player enters/leaves the world.

### DIFF
--- a/source/application/StarMainApplication_sdl.cpp
+++ b/source/application/StarMainApplication_sdl.cpp
@@ -235,6 +235,8 @@ public:
       SDL_free(basePath);
     }
 
+    SDL_SetHint(SDL_HINT_IME_SHOW_UI, "1");
+
     m_signalHandler.setHandleInterrupt(true);
     m_signalHandler.setHandleFatal(true);
 

--- a/source/game/StarWorldServer.cpp
+++ b/source/game/StarWorldServer.cpp
@@ -268,6 +268,9 @@ bool WorldServer::addClient(ConnectionId clientId, SpawnTarget const& spawnTarge
 
   clientInfo->outgoingPackets.append(make_shared<CentralStructureUpdatePacket>(m_centralStructure.store()));
 
+  for (auto& p : m_scriptContexts)
+    p.second->invoke("addClient", clientId, isLocal);
+
   return true;
 }
 
@@ -296,6 +299,9 @@ List<PacketPtr> WorldServer::removeClient(ConnectionId clientId) {
   m_clientInfo.remove(clientId);
 
   packets.append(make_shared<WorldStopPacket>("Removed"));
+
+  for (auto& p : m_scriptContexts)
+    p.second->invoke("removeClient", clientId);
 
   return packets;
 }


### PR DESCRIPTION
Enable the `SDL_HINT_IME_SHOW_UI` macro to fix the input method support in **windowed mode**. 
Add Lua invoke `addClient` and `removeClient` when the client enters/leaves the world.