### PR TITLE
fixed the deadlock problem of universe.sendPacket and added world.sendPacket function

### DIFF
--- a/source/game/StarUniverseServer.cpp
+++ b/source/game/StarUniverseServer.cpp
@@ -475,7 +475,8 @@ bool UniverseServer::updatePlanetType(CelestialCoordinate const& coordinate, Str
 
 void UniverseServer::sendPacket(ConnectionId clientId, PacketPtr packet) {
   RecursiveMutexLocker locker(m_mainLock);
-  m_connectionServer->sendPackets(clientId, {packet});
+  if (m_clients.contains(clientId))
+    m_connectionServer->sendPackets(clientId, {packet});
 }
 
 void UniverseServer::run() {

--- a/source/game/StarWorldServer.cpp
+++ b/source/game/StarWorldServer.cpp
@@ -544,6 +544,11 @@ List<PacketPtr> WorldServer::getOutgoingPackets(ConnectionId clientId) {
   return std::move(clientInfo->outgoingPackets);
 }
 
+void WorldServer::sendPacket(ConnectionId clientId, PacketPtr const& packet) {
+  if (auto const& clientInfo = m_clientInfo.get(clientId))
+    clientInfo->outgoingPackets.append(packet);
+}
+
 Maybe<Json> WorldServer::receiveMessage(ConnectionId fromConnection, String const& message, JsonArray const& args) {
   Maybe<Json> result;
   for (auto& p : m_scriptContexts) {
@@ -2084,7 +2089,7 @@ float WorldServer::lightLevel(Vec2F const& pos) const {
 }
 
 void WorldServer::setDungeonBreathable(DungeonId dungeonId, Maybe<bool> breathable) {
-  Maybe<float> current = m_dungeonIdBreathable.maybe(dungeonId);
+  Maybe<bool> current = m_dungeonIdBreathable.maybe(dungeonId);
   if (breathable != current) {
     if (breathable)
       m_dungeonIdBreathable[dungeonId] = *breathable;

--- a/source/game/StarWorldServer.hpp
+++ b/source/game/StarWorldServer.hpp
@@ -104,6 +104,7 @@ public:
 
   void handleIncomingPackets(ConnectionId clientId, List<PacketPtr> const& packets);
   List<PacketPtr> getOutgoingPackets(ConnectionId clientId);
+  void sendPacket(ConnectionId clientId, PacketPtr const& packet);
 
   Maybe<Json> receiveMessage(ConnectionId fromConnection, String const& message, JsonArray const& args);
 

--- a/source/game/scripting/StarWorldLuaBindings.cpp
+++ b/source/game/scripting/StarWorldLuaBindings.cpp
@@ -390,6 +390,7 @@ namespace LuaBindings {
       callbacks.registerCallbackWithSignature<List<EntityId>>("players", bind(ServerWorldCallbacks::players, world));
       callbacks.registerCallbackWithSignature<LuaString, LuaEngine&>("fidelity", bind(ServerWorldCallbacks::fidelity, world, _1));
       callbacks.registerCallbackWithSignature<Maybe<LuaValue>, String, String, LuaVariadic<LuaValue>>("callScriptContext", bind(ServerWorldCallbacks::callScriptContext, world, _1, _2, _3));
+      callbacks.registerCallbackWithSignature<void, ConnectionId, String, Json>("sendPacket", bind(ServerWorldCallbacks::sendPacket, world, _1, _2, _3));
 
       callbacks.registerCallbackWithSignature<double>("skyTime", [serverWorld]() {
           return serverWorld->sky()->epochTime();
@@ -1184,6 +1185,12 @@ namespace LuaBindings {
     if (!context)
       throw StarException::format("Context {} does not exist", contextName);
     return context->invoke(function, args);
+  }
+
+  void ServerWorldCallbacks::sendPacket(WorldServer* world, ConnectionId clientId, String const& packetType, Json const& packetData) {
+    PacketType type = PacketTypeNames.getLeft(packetType);
+    auto packet = createPacket(type, packetData);
+    world->sendPacket(clientId, packet);
   }
 
   void WorldDebugCallbacks::debugPoint(Vec2F const& arg1, Color const& arg2) {

--- a/source/game/scripting/StarWorldLuaBindings.cpp
+++ b/source/game/scripting/StarWorldLuaBindings.cpp
@@ -390,7 +390,7 @@ namespace LuaBindings {
       callbacks.registerCallbackWithSignature<List<EntityId>>("players", bind(ServerWorldCallbacks::players, world));
       callbacks.registerCallbackWithSignature<LuaString, LuaEngine&>("fidelity", bind(ServerWorldCallbacks::fidelity, world, _1));
       callbacks.registerCallbackWithSignature<Maybe<LuaValue>, String, String, LuaVariadic<LuaValue>>("callScriptContext", bind(ServerWorldCallbacks::callScriptContext, world, _1, _2, _3));
-      callbacks.registerCallbackWithSignature<void, ConnectionId, String, Json>("sendPacket", bind(ServerWorldCallbacks::sendPacket, world, _1, _2, _3));
+      callbacks.registerCallbackWithSignature<void, ConnectionId, String, Json>("sendPacket", bind(ServerWorldCallbacks::sendPacket, serverWorld, _1, _2, _3));
 
       callbacks.registerCallbackWithSignature<double>("skyTime", [serverWorld]() {
           return serverWorld->sky()->epochTime();

--- a/source/game/scripting/StarWorldLuaBindings.hpp
+++ b/source/game/scripting/StarWorldLuaBindings.hpp
@@ -88,6 +88,7 @@ namespace LuaBindings {
     List<EntityId> players(World* world);
     LuaString fidelity(World* world, LuaEngine& engine);
     Maybe<LuaValue> callScriptContext(World* world, String const& contextName, String const& function, LuaVariadic<LuaValue> const& args);
+    void sendPacket(WorldServer* world, ConnectionId clientId, String const& packetType, Json const& packetData);
   }
 
   namespace WorldDebugCallbacks {


### PR DESCRIPTION
`world.sendPacket` function is same as  `world.sendPacket` ,but it will not destroy the order of packets and will only be sent to the player after the player is fully loaded.