### PR TITLE
status properties use a net element hash map

### DIFF
--- a/source/game/StarStatusController.hpp
+++ b/source/game/StarStatusController.hpp
@@ -203,7 +203,7 @@ private:
 
   NetElementGroup m_netGroup;
   StatCollection m_statCollection;
-  NetElementData<JsonObject> m_statusProperties;
+  NetElementHashMap<String, Json> m_statusProperties;
   NetElementData<DirectivesGroup> m_parentDirectives;
 
   UniqueEffectMetadataGroup m_uniqueEffectMetadata;


### PR DESCRIPTION
make status properties use a net element hash map so that when a single property changes it doesn't send the entire jsonObject of status properties