### PR TITLE
Prevent crashes when player has techs that don't exist

### DIFF
--- a/source/game/StarPlayerTech.cpp
+++ b/source/game/StarPlayerTech.cpp
@@ -9,9 +9,13 @@ PlayerTech::PlayerTech() {}
 PlayerTech::PlayerTech(Json const& json) {
   m_availableTechs = jsonToStringSet(json.get("availableTechs"));
   m_enabledTechs = jsonToStringSet(json.get("enabledTechs"));
-  m_equippedTechs = jsonToMapKV<HashMap<TechType, String>>(json.get("equippedTechs"), [](Json t) {
-      return TechTypeNames.getLeft(t.toString());
-    }, mem_fn(&Json::toString));
+  auto techDatabase = Root::singleton().techDatabase();
+  for (auto p : json.get("equippedTechs", JsonObject()).iterateObject()) {
+    if (techDatabase->contains(p.second.toString()))
+      m_equippedTechs.set(TechTypeNames.getLeft(p.first), p.second.toString());
+    else
+      Logger::warn("Missing tech '%s' in slot '%s'", p.second.toString(), p.first);
+  }
 }
 
 Json PlayerTech::toJson() const {


### PR DESCRIPTION
while the tech controller already checks if the tech exists before loading scripts and other data, player inventory and other various things accessing the tech database reference tech's stored in equippedTechs() rather than the active techs in the tech controller, and equippedTechs() has no extant guarding against loading a tech that doesn't exist

these crashes occur on inventory screens and other various panes