### PR TITLE
Fix LeftStick movement StarClientApplication.cpp

### DIFF
--- a/source/client/StarClientApplication.cpp
+++ b/source/client/StarClientApplication.cpp
@@ -972,9 +972,9 @@ void ClientApplication::updateRunning(float dt) {
       config->set("zoomLevel", newZoom);
     }
 
-    //if (m_controllerLeftStick.magnitudeSquared() > 0.001f)
-    //  m_player->setMoveVector(m_controllerLeftStick);
-    //else
+    if (m_controllerLeftStick.magnitudeSquared() > 0.01f)
+      m_player->setMoveVector(m_controllerLeftStick);
+    else
       m_player->setMoveVector(Vec2F());
 
     m_voice->setInput(m_input->bindHeld("opensb", "pushToTalk"));


### PR DESCRIPTION
It no longer has that drift. The drift is caused by the controller, and this simply turns up the threshold of where the game actually accepts the input as a movement.

This fixes the issue found in [this issue.](https://github.com/OpenStarbound/OpenStarbound/issues/87)
