### PR TITLE
Elaborate on dungeon air vs ground error message

### DIFF
--- a/source/game/StarDungeonGenerator.cpp
+++ b/source/game/StarDungeonGenerator.cpp
@@ -654,12 +654,13 @@ namespace Dungeon {
     });
     ground[1] = max(ground[1], liquid[1]);
     if (air.y() < ground.y())
-      throw DungeonException("Invalid ground vs air contraint. Ground at: " + toString(ground.y()) + " Air at: "
+      throw DungeonException("Invalid ground vs air constraint. Ground at: " + toString(ground.y()) + ". Air at: "
           + toString(air.y())
-          + " Pixels: highest ground:"
+          + ". Pixels: highest ground:"
           + toString(ground)
-          + " lowest air:"
-          + toString(air));
+          + ", lowest air:"
+          + toString(air)
+          + ". Try moving your 'require there be air here' anchors above any other 'require there be (something) here' anchors.");
     return air.y();
   }
 


### PR DESCRIPTION
Make the error message actually explain that you can't have an air anchor below a ground anchor