### PR TITLE
Post-processing layer support for mods

### DIFF
--- a/assets/opensb/client.config.patch
+++ b/assets/opensb/client.config.patch
@@ -9,5 +9,6 @@
   "deployCinematicBase" : {
     "scissor" : false,
     "letterbox" : false
-  }
+  },
+  "postProcessLayers": []
 }

--- a/assets/opensb/rendering/effects/basic.vert
+++ b/assets/opensb/rendering/effects/basic.vert
@@ -1,0 +1,7 @@
+#version 140
+
+in vec2 vertexPosition;
+
+void main() {
+  gl_Position = vec4(vertexPosition, 0.0, 1.0);
+}

--- a/source/application/StarRenderer_opengl.hpp
+++ b/source/application/StarRenderer_opengl.hpp
@@ -180,6 +180,7 @@ private:
     Json config;
     bool blitted = false;
     unsigned multisample = 0;
+    unsigned sizeDiv = 1;
 
     GlFrameBuffer(Json const& config);
     ~GlFrameBuffer();
@@ -197,6 +198,7 @@ private:
 
     GLuint getAttribute(String const& name);
     GLuint getUniform(String const& name);
+    bool includeVBTextures;
   };
 
   static bool logGlErrorSummary(String prefix);
@@ -211,7 +213,7 @@ private:
 
   void renderGlBuffer(GlRenderBuffer const& renderBuffer, Mat3F const& transformation);
 
-  void setupGlUniforms(Effect& effect);
+  void setupGlUniforms(Effect& effect, Vec2U screenSize);
 
   RefPtr<OpenGlRenderer::GlFrameBuffer> getGlFrameBuffer(String const& id);
   void blitGlFrameBuffer(RefPtr<OpenGlRenderer::GlFrameBuffer> const& frameBuffer);

--- a/source/client/StarClientApplication.hpp
+++ b/source/client/StarClientApplication.hpp
@@ -52,6 +52,11 @@ private:
     String account;
     String password;
   };
+  
+  struct PostProcessLayer {
+    List<String> effects;
+    unsigned passes;
+  };
 
   void renderReload();
 
@@ -98,6 +103,8 @@ private:
   WorldPainterPtr m_worldPainter;
   WorldRenderData m_renderData;
   MainInterfacePtr m_mainInterface;
+  
+  List<PostProcessLayer> m_postProcessLayers;
 
   // Valid if main app state == SinglePlayer
   UniverseServerPtr m_universeServer;


### PR DESCRIPTION
Code could probably use some improvements in places, but it doesn't hurt my FPS or memory usage very much, so it's probably fine.

Here's some example mods for how this can be used:
Recolour: 
[recolour.zip](https://github.com/user-attachments/files/16703238/recolour.zip)
Bloom:
[bloom.zip](https://github.com/user-attachments/files/16703240/bloom.zip)

Incompatible with super-sampled AA, enabling that at all completely breaks rendering with these even after it is turned off. Todo: either disable/prevent enabling of SSAA while these are active, or fix SSAA for these.