### PR TITLE
Fix images added by assets.add not working in-game.

### DIFF
--- a/source/core/StarImage.cpp
+++ b/source/core/StarImage.cpp
@@ -17,6 +17,12 @@ void readPngData(png_structp pngPtr, png_bytep data, png_size_t length) {
   ((IODevice*)png_get_io_ptr(pngPtr))->readFull((char*)data, length);
 };
 
+bool Image::isPng(IODevicePtr device) {
+  png_byte header[8];
+  device->readAbsolute(0, (char*)header, sizeof(header));
+  return !png_sig_cmp(header, 0, sizeof(header));
+}
+
 Image Image::readPng(IODevicePtr device) {
   png_byte header[8];
   device->readFull((char*)header, sizeof(header));

--- a/source/core/StarImage.hpp
+++ b/source/core/StarImage.hpp
@@ -27,6 +27,7 @@ STAR_CLASS(Image);
 class Image {
 public:
   static Image readPng(IODevicePtr device);
+  static bool isPng(IODevicePtr device);
   // Returns the size and pixel format that would be constructed from the given
   // png file, without actually loading it.
   static tuple<Vec2U, PixelFormat> readPngMetadata(IODevicePtr device);

--- a/source/game/StarImageMetadataDatabase.cpp
+++ b/source/game/StarImageMetadataDatabase.cpp
@@ -174,7 +174,11 @@ Vec2U ImageMetadataDatabase::calculateImageSize(AssetPath const& path) const {
       imageSize = *size;
     } else {
       locker.unlock();
-      imageSize = get<0>(Image::readPngMetadata(assets->openFile(path.basePath)));
+      auto file = assets->openFile(path.basePath);
+      if (Image::isPng(file))
+        imageSize = get<0>(Image::readPngMetadata(file));
+      else
+        imageSize = fallback();
       locker.lock();
       m_sizeCache[path.basePath] = imageSize;
     }


### PR DESCRIPTION
Fixes `ImageMetadataDatabase::calculateImageSize` calling `Image::readPngMetadata` on non-PNG images (i.e., `Star::Image`), which results in an error when trying to load images added by `assets.add`.

Example:
```lua
local cat = assets.image("/animations/cat/cat.png")
local redcat = cat:process("?multiply=FF0000")
assets.add("/items/active/weapons/protectorate/brokenprotectoratebroadswordblade.png", redcat)
```
Previous result:
`[Error] Could not instantiate item '[brokenprotectoratebroadsword, 1, {"primaryAbilityType":"broadswordcombo","altAbilityType":"spinslash"}]'. (ImageException) File /items/active/weapons/protectorate/brokenprotectoratebroadswordblade.png is not a png image!`

New result:
![cat](https://github.com/user-attachments/assets/298b63b1-aa13-4e88-99cb-034f6a5d4bf2)