### PR TITLE
config option to disable scrolling action bar

### DIFF
--- a/source/frontend/StarActionBar.cpp
+++ b/source/frontend/StarActionBar.cpp
@@ -122,43 +122,43 @@ bool ActionBar::sendEvent(InputEvent const& event) {
   auto inventory = m_player->inventory();
 
   auto customBarIndexes = inventory->customBarIndexes();
-  if (auto mouseWheel = event.ptr<MouseWheelEvent>()) {
-    auto configuration = Root::singleton().configuration();
-    if (configuration->getPath("inventory.scrollActionBar").optBool().value(true)) {
-      auto abl = inventory->selectedActionBarLocation();
 
-      int index = 0;
-      if (!abl) {
-        if (mouseWheel->mouseWheel == MouseWheel::Down)
-          index = 0;
+  auto configuration = Root::singleton().configuration();
+  if (auto mouseWheel = event.ptr<MouseWheelEvent>()) && (configuration->getPath("inventory.scrollActionBar").optBool().value(true)) {
+    auto abl = inventory->selectedActionBarLocation();
+
+    int index = 0;
+    if (!abl) {
+      if (mouseWheel->mouseWheel == MouseWheel::Down)
+        index = 0;
+      else
+        index = customBarIndexes + EssentialItemCount - 1;
+    } else {
+      if (auto cbi = abl.ptr<CustomBarIndex>()) {
+        if (*cbi < customBarIndexes / 2)
+          index = *cbi;
         else
-          index = customBarIndexes + EssentialItemCount - 1;
+          index = *cbi + EssentialItemCount;
       } else {
-        if (auto cbi = abl.ptr<CustomBarIndex>()) {
-          if (*cbi < customBarIndexes / 2)
-            index = *cbi;
-          else
-            index = *cbi + EssentialItemCount;
-        } else {
-          index = customBarIndexes / 2 + (int)abl.get<EssentialItem>();
-        }
-
-        if (mouseWheel->mouseWheel == MouseWheel::Down)
-          index = pmod(index + 1, customBarIndexes + EssentialItemCount);
-        else
-          index = pmod(index - 1, customBarIndexes + EssentialItemCount);
+        index = customBarIndexes / 2 + (int)abl.get<EssentialItem>();
       }
 
-      if (index < customBarIndexes / 2)
-        abl = (CustomBarIndex)index;
-      else if (index < customBarIndexes / 2 + EssentialItemCount)
-        abl = (EssentialItem)(index - customBarIndexes / 2);
+      if (mouseWheel->mouseWheel == MouseWheel::Down)
+        index = pmod(index + 1, customBarIndexes + EssentialItemCount);
       else
-        abl = (CustomBarIndex)(index - EssentialItemCount);
-
-      inventory->selectActionBarLocation(abl);
-      context()->playAudio(RandomSource().randFrom(m_switchSounds));
+        index = pmod(index - 1, customBarIndexes + EssentialItemCount);
     }
+
+    if (index < customBarIndexes / 2)
+      abl = (CustomBarIndex)index;
+    else if (index < customBarIndexes / 2 + EssentialItemCount)
+      abl = (EssentialItem)(index - customBarIndexes / 2);
+    else
+      abl = (CustomBarIndex)(index - EssentialItemCount);
+
+    inventory->selectActionBarLocation(abl);
+    context()->playAudio(RandomSource().randFrom(m_switchSounds));
+
     return true;
   }
 

--- a/source/frontend/StarActionBar.cpp
+++ b/source/frontend/StarActionBar.cpp
@@ -122,6 +122,7 @@ bool ActionBar::sendEvent(InputEvent const& event) {
   auto inventory = m_player->inventory();
 
   auto customBarIndexes = inventory->customBarIndexes();
+  auto configuration = Root::singleton().configuration();
   if (configuration->getPath("inventory.scrollActionBar").optBool().value(true)) {
     if (auto mouseWheel = event.ptr<MouseWheelEvent>()) {
       auto abl = inventory->selectedActionBarLocation();

--- a/source/frontend/StarActionBar.cpp
+++ b/source/frontend/StarActionBar.cpp
@@ -122,41 +122,42 @@ bool ActionBar::sendEvent(InputEvent const& event) {
   auto inventory = m_player->inventory();
 
   auto customBarIndexes = inventory->customBarIndexes();
-  if (auto mouseWheel = event.ptr<MouseWheelEvent>()) {
-    auto abl = inventory->selectedActionBarLocation();
+  if (configuration->getPath("inventory.scrollActionBar").optBool().value(true)) {
+    if (auto mouseWheel = event.ptr<MouseWheelEvent>()) {
+      auto abl = inventory->selectedActionBarLocation();
 
-    int index = 0;
-    if (!abl) {
-      if (mouseWheel->mouseWheel == MouseWheel::Down)
-        index = 0;
-      else
-        index = customBarIndexes + EssentialItemCount - 1;
-    } else {
-      if (auto cbi = abl.ptr<CustomBarIndex>()) {
-        if (*cbi < customBarIndexes / 2)
-          index = *cbi;
+      int index = 0;
+      if (!abl) {
+        if (mouseWheel->mouseWheel == MouseWheel::Down)
+          index = 0;
         else
-          index = *cbi + EssentialItemCount;
+          index = customBarIndexes + EssentialItemCount - 1;
       } else {
-        index = customBarIndexes / 2 + (int)abl.get<EssentialItem>();
+        if (auto cbi = abl.ptr<CustomBarIndex>()) {
+          if (*cbi < customBarIndexes / 2)
+            index = *cbi;
+          else
+            index = *cbi + EssentialItemCount;
+        } else {
+          index = customBarIndexes / 2 + (int)abl.get<EssentialItem>();
+        }
+
+        if (mouseWheel->mouseWheel == MouseWheel::Down)
+          index = pmod(index + 1, customBarIndexes + EssentialItemCount);
+        else
+          index = pmod(index - 1, customBarIndexes + EssentialItemCount);
       }
 
-      if (mouseWheel->mouseWheel == MouseWheel::Down)
-        index = pmod(index + 1, customBarIndexes + EssentialItemCount);
+      if (index < customBarIndexes / 2)
+        abl = (CustomBarIndex)index;
+      else if (index < customBarIndexes / 2 + EssentialItemCount)
+        abl = (EssentialItem)(index - customBarIndexes / 2);
       else
-        index = pmod(index - 1, customBarIndexes + EssentialItemCount);
+        abl = (CustomBarIndex)(index - EssentialItemCount);
+
+      inventory->selectActionBarLocation(abl);
+      context()->playAudio(RandomSource().randFrom(m_switchSounds));
     }
-
-    if (index < customBarIndexes / 2)
-      abl = (CustomBarIndex)index;
-    else if (index < customBarIndexes / 2 + EssentialItemCount)
-      abl = (EssentialItem)(index - customBarIndexes / 2);
-    else
-      abl = (CustomBarIndex)(index - EssentialItemCount);
-
-    inventory->selectActionBarLocation(abl);
-    context()->playAudio(RandomSource().randFrom(m_switchSounds));
-
     return true;
   }
 

--- a/source/frontend/StarActionBar.cpp
+++ b/source/frontend/StarActionBar.cpp
@@ -122,9 +122,9 @@ bool ActionBar::sendEvent(InputEvent const& event) {
   auto inventory = m_player->inventory();
 
   auto customBarIndexes = inventory->customBarIndexes();
-  auto configuration = Root::singleton().configuration();
-  if (configuration->getPath("inventory.scrollActionBar").optBool().value(true)) {
-    if (auto mouseWheel = event.ptr<MouseWheelEvent>()) {
+  if (auto mouseWheel = event.ptr<MouseWheelEvent>()) {
+    auto configuration = Root::singleton().configuration();
+    if (configuration->getPath("inventory.scrollActionBar").optBool().value(true)) {
       auto abl = inventory->selectedActionBarLocation();
 
       int index = 0;

--- a/source/frontend/StarActionBar.cpp
+++ b/source/frontend/StarActionBar.cpp
@@ -124,42 +124,44 @@ bool ActionBar::sendEvent(InputEvent const& event) {
   auto customBarIndexes = inventory->customBarIndexes();
 
   auto configuration = Root::singleton().configuration();
-  if (auto mouseWheel = event.ptr<MouseWheelEvent>()) && (configuration->getPath("inventory.scrollActionBar").optBool().value(true)) {
-    auto abl = inventory->selectedActionBarLocation();
+  if (configuration->getPath("inventory.scrollActionBar").optBool().value(true)) {
+    if (auto mouseWheel = event.ptr<MouseWheelEvent>()) {
+      auto abl = inventory->selectedActionBarLocation();
 
-    int index = 0;
-    if (!abl) {
-      if (mouseWheel->mouseWheel == MouseWheel::Down)
-        index = 0;
-      else
-        index = customBarIndexes + EssentialItemCount - 1;
-    } else {
-      if (auto cbi = abl.ptr<CustomBarIndex>()) {
-        if (*cbi < customBarIndexes / 2)
-          index = *cbi;
+      int index = 0;
+      if (!abl) {
+        if (mouseWheel->mouseWheel == MouseWheel::Down)
+          index = 0;
         else
-          index = *cbi + EssentialItemCount;
+          index = customBarIndexes + EssentialItemCount - 1;
       } else {
-        index = customBarIndexes / 2 + (int)abl.get<EssentialItem>();
-      }
+        if (auto cbi = abl.ptr<CustomBarIndex>()) {
+          if (*cbi < customBarIndexes / 2)
+            index = *cbi;
+          else
+            index = *cbi + EssentialItemCount;
+        } else {
+          index = customBarIndexes / 2 + (int)abl.get<EssentialItem>();
+        }
 
       if (mouseWheel->mouseWheel == MouseWheel::Down)
         index = pmod(index + 1, customBarIndexes + EssentialItemCount);
       else
         index = pmod(index - 1, customBarIndexes + EssentialItemCount);
+      }
+
+      if (index < customBarIndexes / 2)
+        abl = (CustomBarIndex)index;
+      else if (index < customBarIndexes / 2 + EssentialItemCount)
+        abl = (EssentialItem)(index - customBarIndexes / 2);
+      else
+        abl = (CustomBarIndex)(index - EssentialItemCount);
+
+      inventory->selectActionBarLocation(abl);
+      context()->playAudio(RandomSource().randFrom(m_switchSounds));
+
+      return true;
     }
-
-    if (index < customBarIndexes / 2)
-      abl = (CustomBarIndex)index;
-    else if (index < customBarIndexes / 2 + EssentialItemCount)
-      abl = (EssentialItem)(index - customBarIndexes / 2);
-    else
-      abl = (CustomBarIndex)(index - EssentialItemCount);
-
-    inventory->selectActionBarLocation(abl);
-    context()->playAudio(RandomSource().randFrom(m_switchSounds));
-
-    return true;
   }
 
   if (event.is<MouseMoveEvent>()) {


### PR DESCRIPTION
Setting `inventory.scrollActionBar` in starbound.config to false (defaults to true) prevents the player from scrolling the action bar with the mouse wheel. Required for a custom action bar I'm working on, since I need the default scrolling to be disabled