### PR TITLE
Allow buying/crafting more than 1000 items at once

### DIFF
--- a/assets/opensb/interface/windowconfig/crafting.config.patch
+++ b/assets/opensb/interface/windowconfig/crafting.config.patch
@@ -4,7 +4,11 @@
   // Disables the crafting timer if true.
   "disableTimer" : false,
 
-   // This is only used if the crafting timer is enabled.
-   // This is how many crafts are ran when the crafting timer wraps.
-  "craftCount" : 1
+  // This is only used if the crafting timer is enabled.
+  // This is how many crafts are ran when the crafting timer wraps.
+  "craftCount" : 1,
+
+  // This is how many of any item can be crafted at once.
+  // This is also used by merchants.
+  "maxSpinCount" : 9999
 } }

--- a/source/frontend/StarCraftingInterface.cpp
+++ b/source/frontend/StarCraftingInterface.cpp
@@ -41,6 +41,7 @@ CraftingPane::CraftingPane(WorldClientPtr worldClient, PlayerPtr player, Json co
   m_settings = jsonMerge(assets->json("/interface/windowconfig/crafting.config:default"), 
                jsonMerge(assets->fetchJson(baseConfig), settings));
 
+  m_maxSpinCount = m_settings.get("maxSpinCount", 1000);
   m_filter = StringSet::from(jsonToStringList(m_settings.get("filter", JsonArray())));
 
   GuiReader reader;
@@ -752,14 +753,14 @@ List<ItemRecipe> CraftingPane::determineRecipes() {
 
 int CraftingPane::maxCraft() {
   if (m_player->isAdmin())
-    return 1000;
+    return m_maxSpinCount;
   auto itemDb = Root::singleton().itemDatabase();
   int res = 0;
   if (m_guiList->selectedItem() != NPos && m_guiList->selectedItem() < m_recipes.size()) {
     HashMap<ItemDescriptor, uint64_t> normalizedBag = m_player->inventory()->availableItems();
     auto selectedRecipe = recipeFromSelectedWidget();
     res = itemDb->maxCraftableInBag(normalizedBag, m_player->inventory()->availableCurrencies(), selectedRecipe);
-    res = std::min(res, 1000);
+    res = std::min(res, m_maxSpinCount);
   }
   return res;
 }

--- a/source/frontend/StarCraftingInterface.cpp
+++ b/source/frontend/StarCraftingInterface.cpp
@@ -41,8 +41,8 @@ CraftingPane::CraftingPane(WorldClientPtr worldClient, PlayerPtr player, Json co
   m_settings = jsonMerge(assets->json("/interface/windowconfig/crafting.config:default"), 
                jsonMerge(assets->fetchJson(baseConfig), settings));
 
-  m_maxSpinCount = m_settings.get("maxSpinCount", 1000);
   m_filter = StringSet::from(jsonToStringList(m_settings.get("filter", JsonArray())));
+  m_maxSpinCount = m_settings.get("maxSpinCount", 1000);
 
   GuiReader reader;
   reader.registerCallback("spinCount.up", [=](Widget*) {

--- a/source/frontend/StarCraftingInterface.cpp
+++ b/source/frontend/StarCraftingInterface.cpp
@@ -42,7 +42,7 @@ CraftingPane::CraftingPane(WorldClientPtr worldClient, PlayerPtr player, Json co
                jsonMerge(assets->fetchJson(baseConfig), settings));
 
   m_filter = StringSet::from(jsonToStringList(m_settings.get("filter", JsonArray())));
-  m_maxSpinCount = m_settings.get("maxSpinCount", 1000);
+  m_maxSpinCount = m_settings.getInt("maxSpinCount", 1000);
 
   GuiReader reader;
   reader.registerCallback("spinCount.up", [=](Widget*) {

--- a/source/frontend/StarCraftingInterface.cpp
+++ b/source/frontend/StarCraftingInterface.cpp
@@ -42,7 +42,7 @@ CraftingPane::CraftingPane(WorldClientPtr worldClient, PlayerPtr player, Json co
                jsonMerge(assets->fetchJson(baseConfig), settings));
 
   m_filter = StringSet::from(jsonToStringList(m_settings.get("filter", JsonArray())));
-  m_maxSpinCount = m_settings.getInt("maxSpinCount", 1000);
+  m_maxSpinCount = m_settings.getUInt("maxSpinCount", 1000);
 
   GuiReader reader;
   reader.registerCallback("spinCount.up", [=](Widget*) {

--- a/source/frontend/StarCraftingInterface.hpp
+++ b/source/frontend/StarCraftingInterface.hpp
@@ -69,6 +69,8 @@ private:
 
   StringSet m_filter;
 
+  int m_maxSpinCount;
+
   int m_recipeAutorefreshCooldown;
 
   HashMap<ItemDescriptor, ItemPtr> m_itemCache;

--- a/source/frontend/StarMerchantInterface.cpp
+++ b/source/frontend/StarMerchantInterface.cpp
@@ -38,7 +38,7 @@ MerchantPane::MerchantPane(
 
   m_itemBag = make_shared<ItemBag>(m_settings.getUInt("sellContainerSize"));
 
-  m_maxBuyCount = m_settings.getUInt("maxBuyCount");
+  m_maxBuyCount = m_settings.getUInt("maxBuyCount", 1000);
 
   GuiReader reader;
   reader.registerCallback("spinCount.up", [=](Widget*) {

--- a/source/frontend/StarMerchantInterface.cpp
+++ b/source/frontend/StarMerchantInterface.cpp
@@ -38,7 +38,7 @@ MerchantPane::MerchantPane(
 
   m_itemBag = make_shared<ItemBag>(m_settings.getUInt("sellContainerSize"));
 
-  m_maxBuyCount = m_settings.getUInt("maxBuyCount", 1000);
+  m_maxBuyCount = assets->json("/interface/windowconfig/crafting.config:default").getUInt("maxSpinCount", 1000);
 
   GuiReader reader;
   reader.registerCallback("spinCount.up", [=](Widget*) {

--- a/source/frontend/StarMerchantInterface.cpp
+++ b/source/frontend/StarMerchantInterface.cpp
@@ -38,6 +38,8 @@ MerchantPane::MerchantPane(
 
   m_itemBag = make_shared<ItemBag>(m_settings.getUInt("sellContainerSize"));
 
+  m_maxBuyCount = m_settings.getUInt("maxBuyCount");
+
   GuiReader reader;
   reader.registerCallback("spinCount.up", [=](Widget*) {
       if (m_selectedIndex != NPos) {
@@ -360,8 +362,8 @@ int MerchantPane::maxBuyCount() {
     auto assets = Root::singleton().assets();
     auto unitPrice = selected->data().toUInt();
     if (unitPrice == 0)
-      return 1000;
-    return min(1000, (int)floor(m_player->currency("money") / unitPrice));
+      return m_maxBuyCount;
+    return min(m_maxBuyCount, (int)floor(m_player->currency("money") / unitPrice));
   } else {
     return 0;
   }

--- a/source/frontend/StarMerchantInterface.cpp
+++ b/source/frontend/StarMerchantInterface.cpp
@@ -38,7 +38,7 @@ MerchantPane::MerchantPane(
 
   m_itemBag = make_shared<ItemBag>(m_settings.getUInt("sellContainerSize"));
 
-  m_maxBuyCount = assets->json("/interface/windowconfig/crafting.config:default").getUInt("maxSpinCount", 1000);
+  m_maxBuyCount = m_settings.getUInt("maxSpinCount", assets->json("/interface/windowconfig/crafting.config:default").getUInt("maxSpinCount", 1000));
 
   GuiReader reader;
   reader.registerCallback("spinCount.up", [=](Widget*) {

--- a/source/frontend/StarMerchantInterface.hpp
+++ b/source/frontend/StarMerchantInterface.hpp
@@ -76,6 +76,7 @@ private:
   ItemBagPtr m_itemBag;
 
   int m_buyCount;
+  int m_maxBuyCount;
 };
 
 }


### PR DESCRIPTION
Sets the default limit to 9999
Also allows mods to change how many items can be crafted, either globally or per merchant/crafting interface by specifying 'maxSpinCount'