### PR TITLE
implement lazy font loading

### DIFF
--- a/source/core/StarFont.hpp
+++ b/source/core/StarFont.hpp
@@ -43,6 +43,7 @@ private:
   unsigned m_pixelSize;
   uint8_t m_alphaThreshold;
 
+  void loadFontImpl();
   HashMap<pair<String::Char, unsigned>, unsigned> m_widthCache;
 };
 


### PR DESCRIPTION
Problem: OpenStarbound uses nearly 300MB to hold a ton of font information in memory.

Reason: There are two TextPainter instances, one in GuiContext and one in WorldPainter.  Both of these walk the assets directory and load every font they find into memory.  FT_New_Memory_Face allocates quite a bit of memory for each font loaded, probably because it renders every glyph into a bitmap at the given size.

Solution: This only half-fixes the problem, but it implements a lazy instantiation of FT_New_Memory_Face where the font is only rendered to memory if it's actually used.

A further solution would be to unify TextPainter via a singleton or something, but I'm not sure what the correct idiom for this project would be to solve the problem of double-loading these assets.