### PR TITLE
MMap Audio Assets

### DIFF
--- a/source/base/StarAssetSource.hpp
+++ b/source/base/StarAssetSource.hpp
@@ -27,6 +27,9 @@ public:
 
   // Read the entirety of the given path into a buffer.
   virtual ByteArray read(String const& path) = 0;
+
+  // Return the given asset as a ByteArray representing its mmap'd data
+  virtual ByteArray mmap(String const& path) = 0;
 };
 
 }

--- a/source/base/StarAssets.hpp
+++ b/source/base/StarAssets.hpp
@@ -278,6 +278,7 @@ private:
 
   IODevicePtr open(String const& basePath) const;
   ByteArray read(String const& basePath) const;
+  IODevicePtr mmap(String const& basePath) const;
   ImageConstPtr readImage(String const& path) const;
 
   Json readJson(String const& basePath) const;

--- a/source/base/StarDirectoryAssetSource.cpp
+++ b/source/base/StarDirectoryAssetSource.cpp
@@ -50,6 +50,10 @@ ByteArray DirectoryAssetSource::read(String const& path) {
   return device->readBytes(device->size());
 }
 
+ByteArray DirectoryAssetSource::mmap(String const& path) {
+  return File::mmapFile(toFilesystem(path));
+}
+
 String DirectoryAssetSource::toFilesystem(String const& path) const {
   if (!path.beginsWith("/"))
     throw AssetSourceException::format("Asset path '{}' must be absolute in DirectoryAssetSource::toFilesystem", path);

--- a/source/base/StarDirectoryAssetSource.hpp
+++ b/source/base/StarDirectoryAssetSource.hpp
@@ -18,6 +18,7 @@ public:
 
   IODevicePtr open(String const& path) override;
   ByteArray read(String const& path) override;
+  ByteArray mmap(String const& path) override;
 
   // Converts an asset path to the path on the filesystem
   String toFilesystem(String const& path) const;

--- a/source/base/StarMemoryAssetSource.cpp
+++ b/source/base/StarMemoryAssetSource.cpp
@@ -110,6 +110,11 @@ ByteArray MemoryAssetSource::read(String const& path) {
   }
 }
 
+// you can't mmap what's already memory
+ByteArray MemoryAssetSource::mmap(String const& path) {
+  return read(path);
+}
+
 ImageConstPtr MemoryAssetSource::image(String const& path) {
   auto p = m_files.ptr(path);
   if (!p)

--- a/source/base/StarMemoryAssetSource.hpp
+++ b/source/base/StarMemoryAssetSource.hpp
@@ -26,6 +26,7 @@ public:
   void set(String const& path, Image const& image);
   void set(String const& path, Image&& image);
   ByteArray read(String const& path) override;
+  ByteArray mmap(String const& path) override;
   ImageConstPtr image(String const& path);
 private:
   typedef Variant<ByteArray, ImagePtr> FileEntry;

--- a/source/base/StarPackedAssetSource.cpp
+++ b/source/base/StarPackedAssetSource.cpp
@@ -1,4 +1,6 @@
 #include "StarPackedAssetSource.hpp"
+#include "StarByteArray.hpp"
+#include "StarConfig.hpp"
 #include "StarDirectoryAssetSource.hpp"
 #include "StarOrderedSet.hpp"
 #include "StarDataStreamDevices.hpp"
@@ -91,6 +93,18 @@ JsonObject PackedAssetSource::metadata() const {
 
 StringList PackedAssetSource::assetPaths() const {
   return m_index.keys();
+}
+
+ByteArray PackedAssetSource::mmap(String const& path) {
+  auto p = m_index.ptr(path);
+  if (!p)
+    throw AssetSourceException::format("Requested file '{}' does not exist in the packed assets file", path);
+
+  StreamOffset offset = p->first;
+  StreamOffset size = p->second;
+  String fullPath = File::fullPath(m_packedFile->fileName());
+
+  return File::mmapFilePartial(fullPath, offset, size);
 }
 
 IODevicePtr PackedAssetSource::open(String const& path) {

--- a/source/base/StarPackedAssetSource.hpp
+++ b/source/base/StarPackedAssetSource.hpp
@@ -32,6 +32,7 @@ public:
 
   IODevicePtr open(String const& path) override;
   ByteArray read(String const& path) override;
+  ByteArray mmap(String const& path) override;
 
 private:
   FilePtr m_packedFile;

--- a/source/core/StarBuffer.hpp
+++ b/source/core/StarBuffer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "StarByteArray.hpp"
 #include "StarIODevice.hpp"
 #include "StarString.hpp"
 
@@ -117,5 +118,6 @@ private:
   char const* m_bytes;
   size_t m_size;
 };
+
 
 }

--- a/source/core/StarByteArray.hpp
+++ b/source/core/StarByteArray.hpp
@@ -7,6 +7,7 @@
 namespace Star {
 
 STAR_CLASS(ByteArray);
+STAR_CLASS(MappedByteArray);
 
 // Class to hold an array of bytes.  Contains an internal buffer that may be
 // larger than what is reported by size(), to avoid repeated allocations when a
@@ -22,8 +23,12 @@ public:
   static ByteArray fromCString(char const* str);
   // Same, but includes the trailing '\0'
   static ByteArray fromCStringWithNull(char const* str);
-  static ByteArray withReserve(size_t capacity);
+  
+  // mmap from file saves memory space over reading
+  static ByteArray fromMMap(const char* path, size_t offset = 0, size_t length = -1);
 
+  static ByteArray withReserve(size_t capacity);
+  
   ByteArray();
   ByteArray(size_t dataSize, char c);
   ByteArray(char const* data, size_t dataSize);
@@ -114,6 +119,12 @@ private:
   char* m_data;
   size_t m_capacity;
   size_t m_size;
+
+  // Mmap-specific metadata
+  void* m_mapped_addr;     // Original aligned address from mmap
+  size_t m_mapped_len;  // Full length of the mmap region
+  enum class AllocationType { Heap, Mapped };
+  AllocationType m_allocation = AllocationType::Heap;
 };
 
 template <>

--- a/source/core/StarFile.cpp
+++ b/source/core/StarFile.cpp
@@ -1,7 +1,9 @@
 #include "StarFile.hpp"
+#include "StarByteArray.hpp"
 #include "StarFormat.hpp"
 
 #include <fstream>
+#include <pthread.h>
 
 namespace Star {
 
@@ -79,6 +81,14 @@ String File::readFileString(String const& filename) {
 
 StreamOffset File::fileSize(String const& filename) {
   return File::open(filename, IOMode::Read)->size();
+}
+
+ByteArray File::mmapFile(String const& filename) {
+  return ByteArray::fromMMap(filename.utf8Ptr());
+}
+
+ByteArray File::mmapFilePartial(String const& filename, size_t offset, size_t len) {
+  return ByteArray::fromMMap(filename.utf8Ptr(), offset, len);
 }
 
 void File::writeFile(char const* data, size_t len, String const& filename) {

--- a/source/core/StarFile.hpp
+++ b/source/core/StarFile.hpp
@@ -77,6 +77,10 @@ public:
   static String readFileString(String const& filename);
   static StreamOffset fileSize(String const& filename);
 
+  // return all or part of a file as an mmapped ByteArray
+  static ByteArray mmapFile(String const& filename);
+  static ByteArray mmapFilePartial(String const& filename, size_t offset, size_t len);
+
   static void writeFile(char const* data, size_t len, String const& filename);
   static void writeFile(ByteArray const& data, String const& filename);
   static void writeFile(String const& data, String const& filename);

--- a/source/core/StarIODevice.hpp
+++ b/source/core/StarIODevice.hpp
@@ -15,7 +15,7 @@ enum class IOMode : uint8_t {
   Write = 0x2,
   ReadWrite = 0x3,
   Append = 0x4,
-  Truncate = 0x8,
+  Truncate = 0x8
 };
 
 IOMode operator|(IOMode a, IOMode b);


### PR DESCRIPTION
Problem: Audio assets like background music are fully read into memory before being played.  My profiling shows 91MB of ram is consumed by ByteArrays containing audio files.

Solution: By modifying ByteArray to represent an mmapped file, I can mmap all audio assets which would then not consume ram.  Audio assets now occupy 22k of ram.

I'm not super happy with the elegance of this solution but it was more of a proof of concept.  I think an mmapped file would be better as a Buffer object or maybe some kind of IODevice (although maybe just a regular file read would work there).