### PR TITLE
Streaming Audio

### DIFF
--- a/source/base/StarMemoryAssetSource.cpp
+++ b/source/base/StarMemoryAssetSource.cpp
@@ -57,6 +57,12 @@ IODevicePtr MemoryAssetSource::open(String const& path) {
         assetPos = clamp<StreamOffset>(assetPos - p, 0, assetSize);
     }
 
+    IODevicePtr clone() override {
+      auto cloned = make_shared<AssetReader>(assetData, assetSize, name);
+      cloned->assetPos = assetPos;
+      return cloned;
+    }
+
     char* assetData;
     size_t assetSize;
     StreamOffset assetPos = 0;

--- a/source/base/StarPackedAssetSource.cpp
+++ b/source/base/StarPackedAssetSource.cpp
@@ -136,6 +136,12 @@ IODevicePtr PackedAssetSource::open(String const& path) {
         assetPos = clamp<StreamOffset>(assetSize - p, 0, assetSize);
     }
 
+    IODevicePtr clone() override {
+      auto cloned = make_shared<AssetReader>(file, path, fileOffset, assetSize);
+      cloned->assetPos = assetPos;
+      return cloned;
+    }
+
     FilePtr file;
     String path;
     StreamOffset fileOffset;

--- a/source/core/CMakeLists.txt
+++ b/source/core/CMakeLists.txt
@@ -10,6 +10,7 @@ SET (star_core_HEADERS
     StarAssetPath.hpp
     StarAtomicSharedPtr.hpp
     StarAudio.hpp
+    StarIODeviceCallbacks.hpp
     StarBTree.hpp
     StarBTreeDatabase.hpp
     StarBiMap.hpp
@@ -141,6 +142,7 @@ SET (star_core_SOURCES
     StarBuffer.cpp
     StarByteArray.cpp
     StarColor.cpp
+    StarIODeviceCallbacks.cpp
     StarCompression.cpp
     StarCurve25519.cpp
     StarDataStream.cpp

--- a/source/core/StarBuffer.cpp
+++ b/source/core/StarBuffer.cpp
@@ -2,6 +2,7 @@
 #include "StarMathCommon.hpp"
 #include "StarIODevice.hpp"
 #include "StarFormat.hpp"
+#include "StarLogging.hpp"
 
 namespace Star {
 
@@ -271,6 +272,18 @@ void ExternalBuffer::reset(char const* externalData, size_t len) {
   m_pos = 0;
   m_bytes = externalData;
   m_size = len;
+}
+
+IODevicePtr Buffer::clone() {
+  auto cloned = make_shared<Buffer>(*this);
+  // Reset position to 0 while preserving mode and data
+  cloned->seek(0);
+  return cloned;
+}
+
+IODevicePtr ExternalBuffer::clone() {
+  Logger::info("Cloning ExternalBuffer from position {}");
+  return make_shared<ExternalBuffer>(*this);
 }
 
 size_t ExternalBuffer::doRead(size_t pos, char* data, size_t len) {

--- a/source/core/StarBuffer.hpp
+++ b/source/core/StarBuffer.hpp
@@ -34,6 +34,8 @@ public:
   String deviceName() const override;
 
   StreamOffset size() override;
+  
+  IODevicePtr clone() override;
 
   ByteArray& data();
   ByteArray const& data() const;
@@ -95,6 +97,8 @@ public:
   String deviceName() const override;
 
   StreamOffset size() override;
+  
+  IODevicePtr clone() override;
 
   // Returns a pointer to the beginning of the Buffer.
   char const* ptr() const;

--- a/source/core/StarCompression.cpp
+++ b/source/core/StarCompression.cpp
@@ -233,4 +233,16 @@ void CompressedFile::close() {
   setMode(IOMode::Closed);
 }
 
+IODevicePtr CompressedFile::clone() {
+  auto cloned = make_shared<CompressedFile>(m_filename);
+  cloned->setCompression(m_compression);
+  if (isOpen()) {
+    // Open with same mode
+    cloned->open(mode());
+    // Seek to same position
+    cloned->seek(pos());
+  }
+  return cloned;
+}
+
 }

--- a/source/core/StarCompression.hpp
+++ b/source/core/StarCompression.hpp
@@ -49,6 +49,8 @@ public:
   void sync() override;
   void close() override;
 
+  IODevicePtr clone() override;
+
 private:
   String m_filename;
   void* m_file;

--- a/source/core/StarFile.cpp
+++ b/source/core/StarFile.cpp
@@ -243,4 +243,15 @@ String File::deviceName() const {
     return m_filename;
 }
 
+IODevicePtr File::clone() {
+  auto cloned = make_shared<File>(m_filename);
+  if (isOpen()) {
+    // Open with same mode
+    cloned->open(mode());
+    // Seek to same position
+    cloned->seek(pos());
+  }
+  return cloned;
+}
+
 }

--- a/source/core/StarFile.hpp
+++ b/source/core/StarFile.hpp
@@ -127,6 +127,8 @@ public:
 
   String deviceName() const override;
 
+  IODevicePtr clone() override;
+
 private:
   static void* fopen(char const* filename, IOMode mode);
   static void fseek(void* file, StreamOffset offset, IOSeek seek);

--- a/source/core/StarIODevice.hpp
+++ b/source/core/StarIODevice.hpp
@@ -70,6 +70,9 @@ public:
   // Default implementation is a no-op
   virtual void sync();
 
+  // Returns a clone of this device with the same mode
+  virtual IODevicePtr clone() = 0;
+
   // Default implementation just prints address of generic IODevice
   virtual String deviceName() const;
 

--- a/source/core/StarIODeviceCallbacks.cpp
+++ b/source/core/StarIODeviceCallbacks.cpp
@@ -1,0 +1,39 @@
+#include "StarIODeviceCallbacks.hpp"
+#include "vorbis/vorbisfile.h"
+
+namespace Star {
+
+IODeviceCallbacks::IODeviceCallbacks(IODevicePtr device) 
+  : m_device(std::move(device)) {
+  if (!m_device->isOpen())
+    m_device->open(IOMode::Read);
+}
+
+IODevicePtr const& IODeviceCallbacks::device() const {
+  return m_device;
+}
+
+size_t IODeviceCallbacks::readFunc(void* ptr, size_t size, size_t nmemb, void* datasource) {
+  auto* callbacks = static_cast<IODeviceCallbacks*>(datasource);
+  return callbacks->m_device->read((char*)ptr, size * nmemb) / size;
+}
+
+int IODeviceCallbacks::seekFunc(void* datasource, ogg_int64_t offset, int whence) {
+  auto* callbacks = static_cast<IODeviceCallbacks*>(datasource);
+  callbacks->m_device->seek(offset, (IOSeek)whence);
+  return 0;
+}
+
+long int IODeviceCallbacks::tellFunc(void* datasource) {
+  auto* callbacks = static_cast<IODeviceCallbacks*>(datasource);
+  return (long int)callbacks->m_device->pos();
+}
+
+void IODeviceCallbacks::setupOggCallbacks(ov_callbacks& callbacks) {
+  callbacks.read_func = readFunc;
+  callbacks.seek_func = seekFunc;
+  callbacks.tell_func = tellFunc;
+  callbacks.close_func = nullptr;
+}
+
+}

--- a/source/core/StarIODeviceCallbacks.hpp
+++ b/source/core/StarIODeviceCallbacks.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "StarIODevice.hpp"
+#include "vorbis/codec.h"
+#include "vorbis/vorbisfile.h"
+
+namespace Star {
+
+// Provides callbacks for interfacing IODevice with ogg vorbis callbacks
+class IODeviceCallbacks {
+public:
+  explicit IODeviceCallbacks(IODevicePtr device);
+  
+  // No copying
+  IODeviceCallbacks(IODeviceCallbacks const&) = delete;
+  IODeviceCallbacks& operator=(IODeviceCallbacks const&) = delete;
+  
+  // Moving is ok
+  IODeviceCallbacks(IODeviceCallbacks&&) = default;
+  IODeviceCallbacks& operator=(IODeviceCallbacks&&) = default;
+
+  // Get the underlying device
+  IODevicePtr const& device() const;
+  
+  // Callback functions for Ogg Vorbis
+  static size_t readFunc(void* ptr, size_t size, size_t nmemb, void* datasource);
+  static int seekFunc(void* datasource, ogg_int64_t offset, int whence);
+  static long int tellFunc(void* datasource);
+  
+  // Sets up callbacks for Ogg Vorbis
+  void setupOggCallbacks(ov_callbacks& callbacks);
+
+private:
+  IODevicePtr m_device;
+};
+
+}


### PR DESCRIPTION
Problem: The current implementation reads the entire sound file in to memory in order to play it. For OGG background music, this uses 91 Megs of RAM by injesting all ogg songs as well as all wav assets.

Solution: Change StarAudio to play the asset from a file handle and stream it off the disk. This results in a massive savings of RAM and doesn't really affect audio quality unless you're doing a lot of disk operations such as compiling Starbound.