### PR TITLE
[fix] Use bundled libraries first

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,13 +206,13 @@ The same answer has the solution: use `padsp` to emulate dev/dsp.
 
 `#!/bin/sh
 cd "`dirname \"$0\"`"
-LD_LIBRARY_PATH="$LD_LIBRARY_PATH:./" ./starbound "$@"`
+LD_LIBRARY_PATH=".:$LD_LIBRARY_PATH" ./starbound "$@"`
 
 with 
 
 `#!/bin/sh
 cd "`dirname \"$0\"`"
-LD_LIBRARY_PATH="$LD_LIBRARY_PATH:./" padsp ./starbound "$@"`
+LD_LIBRARY_PATH=".:$LD_LIBRARY_PATH" padsp ./starbound "$@"`
 
 </details>
 

--- a/attic/gitlab-ci/linux/run-client.sh
+++ b/attic/gitlab-ci/linux/run-client.sh
@@ -2,4 +2,4 @@
 
 cd "`dirname \"$0\"`"
 
-LD_LIBRARY_PATH="$LD_LIBRARY_PATH:./" ./starbound "$@"
+LD_LIBRARY_PATH=".:$LD_LIBRARY_PATH" ./starbound "$@"

--- a/scripts/ci/linux/run-client.sh
+++ b/scripts/ci/linux/run-client.sh
@@ -2,4 +2,4 @@
 
 cd "`dirname \"$0\"`"
 
-LD_LIBRARY_PATH="$LD_LIBRARY_PATH:./" ./starbound "$@"
+LD_LIBRARY_PATH=".:$LD_LIBRARY_PATH" ./starbound "$@"


### PR DESCRIPTION
fixes ./starbound: symbol lookup error: ./starbound: undefined symbol: SteamInternal_SteamAPI_Init

caused by inconsistent versions of `libsteam_api.so` .