### PR TITLE
Make assets load only once

### DIFF
--- a/source/client/StarClientApplication.cpp
+++ b/source/client/StarClientApplication.cpp
@@ -221,12 +221,12 @@ void ClientApplication::applicationInit(ApplicationControllerPtr appController) 
   m_mainMixer = make_shared<MainMixer>(audioFormat.sampleRate, audioFormat.channels);
   m_mainMixer->setVolume(0.5);
   
+  auto assets = loadAssets();
   m_worldPainter = make_shared<WorldPainter>();
   m_guiContext = make_shared<GuiContext>(m_mainMixer->mixer(), appController);
   m_input = make_shared<Input>();
   m_voice = make_shared<Voice>(appController);  
     
-  auto assets = m_root->assets();
   m_minInterfaceScale = assets->json("/interface.config:minInterfaceScale").toInt();
   m_maxInterfaceScale = assets->json("/interface.config:maxInterfaceScale").toInt();
   m_crossoverRes = jsonToVec2F(assets->json("/interface.config:interfaceCrossoverRes"));

--- a/source/client/StarClientApplication.hpp
+++ b/source/client/StarClientApplication.hpp
@@ -74,7 +74,7 @@ private:
   void setError(String const& error);
   void setError(String const& error, std::exception const& e);
 
-  void updateMods(float dt);
+  AssetsConstPtr loadAssets();
   void updateModsWarning(float dt);
   void updateSplash(float dt);
   void updateError(float dt);

--- a/source/game/StarRoot.cpp
+++ b/source/game/StarRoot.cpp
@@ -302,10 +302,9 @@ void Root::reload() {
   m_reloadListeners.trigger();
 }
 
-void Root::reloadWithMods(StringList modDirectories) {
-  MutexLocker locker(m_modsMutex);
+void Root::loadMods(StringList& modDirectories) {
+  MutexLocker assetsLock(m_assetsMutex);
   m_modDirectories = std::move(modDirectories);
-  reload();
 }
 
 void Root::fullyLoad() {

--- a/source/game/StarRoot.hpp
+++ b/source/game/StarRoot.hpp
@@ -120,7 +120,7 @@ public:
   // Reloads with the given mod sources applied on top of the base mod source
   // specified in the settings.  Mods in the base mod source will override mods
   // in the given mod sources
-  void reloadWithMods(StringList modDirectories);
+  void loadMods(StringList& modDirectories);
 
   // Ensures all Root members are loaded without waiting for them to be auto
   // loaded.


### PR DESCRIPTION
This will include UGC content if present and not require a reload that also loads non-UGC content again, causing certain cases like the post load scripts to run a second time. 

I have not noticed any issues, loading to main screen and into a character works fine with no warnings about missing content. I don't know if this has any potential issues somewhere. 

Additionally it skips the "Mods" state because of the changes I made, unsure if they were necessary.