### PR TITLE
make scrollareas updating their children optional

### DIFF
--- a/assets/opensb/interface/opensb/shaders/shaders.config
+++ b/assets/opensb/interface/opensb/shaders/shaders.config
@@ -115,6 +115,7 @@
     },
     "options" : {
       "type" : "scrollArea",
+      "updatesChildren" : true,
       "rect" : [147, 16, 398, 185],
       "children" : {},
       "buttons" : {

--- a/source/windowing/StarScrollArea.cpp
+++ b/source/windowing/StarScrollArea.cpp
@@ -385,7 +385,9 @@ bool ScrollArea::sendEvent(InputEvent const& event) {
 }
 
 void ScrollArea::update(float dt) {
-  Widget::update(dt);
+  if (m_updatesChildren)
+    Widget::update(dt);
+
   if (!m_visible)
     return;
   
@@ -441,6 +443,10 @@ int ScrollArea::advanceFactorHelper() {
   if ((t > ScrollAdvanceTimer) || (t < 0))
     t = ScrollAdvanceTimer;
   return (int)std::ceil((m_buttonAdvance * t) / (float)ScrollAdvanceTimer);
+}
+
+void ScrollArea::setUpdatesChildren(bool slop) {
+  m_updatesChildren = slop;
 }
 
 }

--- a/source/windowing/StarScrollArea.hpp
+++ b/source/windowing/StarScrollArea.hpp
@@ -98,6 +98,8 @@ public:
   bool verticalScroll() const;
   void setVerticalScroll(bool vertical);
 
+  void setUpdatesChildren(bool slop);
+
   virtual bool sendEvent(InputEvent const& event) override;
   virtual void update(float dt) override;
 
@@ -124,6 +126,8 @@ private:
 
   bool m_horizontalScroll;
   bool m_verticalScroll;
+
+  bool m_updatesChildren;
 };
 typedef shared_ptr<ScrollArea> ScrollAreaPtr;
 }

--- a/source/windowing/StarWidgetParsing.cpp
+++ b/source/windowing/StarWidgetParsing.cpp
@@ -779,6 +779,8 @@ WidgetConstructResult WidgetParser::scrollAreaHandler(String const& name, Json c
   if (config.contains("verticalScroll"))
     scrollArea->setVerticalScroll(config.getBool("verticalScroll"));
 
+  scrollArea->setUpdatesChildren(config.getBool("updatesChildren", false));
+
   common(scrollArea, config);
   return WidgetConstructResult(scrollArea, name, config.getFloat("zlevel", 0));
 }


### PR DESCRIPTION
it's kindve useful for scrollareas to be broken :3

mostly fixes stardust core scrolling 