### PR TITLE
this is a refresh filter

### DIFF
--- a/source/game/StarItemDatabase.cpp
+++ b/source/game/StarItemDatabase.cpp
@@ -144,7 +144,7 @@ void ItemDatabase::cleanup() {
   {
     MutexLocker locker(m_cacheMutex);
     m_itemCache.cleanup([](ItemCacheEntry const&, ItemPtr const& item) {
-      return !item.unique();
+      return item.unique();
     });
   }
 }


### PR DESCRIPTION
someone was having stuttering issues, I was told this was why.
Further investigation into the cache type supports that, in fact, the item cache was only cleaning out unique items.