### PR TITLE
persistent JSON assets, persistent inventory filter

### DIFF
--- a/source/base/StarAssets.hpp
+++ b/source/base/StarAssets.hpp
@@ -107,6 +107,7 @@ public:
 
     double time = 0.0;
     bool needsPostProcessing = false;
+    bool overridePersistent = false;
   };
 
   struct JsonData : AssetData {
@@ -200,6 +201,9 @@ public:
   // for deeper field access and [] notation for array access.  Example:
   // "/path/to/json:key1.key2.key3[4]".
   Json json(String const& path) const;
+  // Persistence should only be true if an asset should never unload, excluding through reloading.
+  // (For example, player-related data that's used frequently.)
+  Json json(String const& path, bool const& persistent) const;
 
   // Either returns the json v, or, if v is a string type, returns the json
   // pointed to by interpreting v as a string path.
@@ -262,6 +266,7 @@ private:
   void queueAsset(AssetId const& assetId) const;
   shared_ptr<AssetData> tryAsset(AssetId const& id) const;
   shared_ptr<AssetData> getAsset(AssetId const& id) const;
+  shared_ptr<AssetData> getAsset(AssetId const& id, bool const& persistent) const;
 
   void workerMain();
 

--- a/source/game/StarPlayerInventory.cpp
+++ b/source/game/StarPlayerInventory.cpp
@@ -953,7 +953,7 @@ bool PlayerInventory::checkInventoryFilter(ItemPtr const& items, String const& f
   }
 
   if (!filterConfig.isType(Json::Type::Object)) {
-    auto config = Root::singleton().assets()->json("/player.config:inventoryFilters");
+    auto config = Root::singleton().assets()->json("/player.config:inventoryFilters",true);
     filterConfig = config.opt(filterName).value();
     if (!filterConfig.isType(Json::Type::Object))
       filterConfig = config.get("default");


### PR DESCRIPTION
Allows loading JSON assets and forcing them to be persistent.
This allows specific assets to be loaded and never unloaded (except on reloads).
`Assets::json` now has an optional second parameter for this effect.
Lua `assets.json` also has that second parameter as well, though it seems the assets cache is cleared afterwards anyway so that might have been pointless.

As for why I did this in the first place, player.config:inventoryFilter is now loaded so it persists as some users were getting lag spikes from it loading.