### PR TITLE
Allow persistently preloading assets

### DIFF
--- a/assets/opensb/preload.config
+++ b/assets/opensb/preload.config
@@ -1,0 +1,6 @@
+[
+    {
+        "type": "json",
+        "path": "/player.config:inventoryFilters"
+    }
+] 

--- a/source/base/StarAssets.cpp
+++ b/source/base/StarAssets.cpp
@@ -24,6 +24,14 @@
 
 namespace Star {
 
+EnumMap<AssetType> const AssetTypeNames{
+    {AssetType::Json, "json"},
+    {AssetType::Image, "image"},
+    {AssetType::Audio, "audio"},
+    {AssetType::Font, "font"},
+    {AssetType::Bytes, "bytes"}
+};
+    
 static void validateBasePath(std::string_view const& basePath) {
   if (basePath.empty() || basePath[0] != '/')
     throw AssetException(strf("Path '{}' must be absolute", basePath));
@@ -353,6 +361,20 @@ Assets::Assets(Settings settings, StringList assetSources) {
   int workerPoolSize = m_settings.workerPoolSize;
   for (int i = 0; i < workerPoolSize; i++)
     m_workerThreads.append(Thread::invoke("Assets::workerMain", mem_fn(&Assets::workerMain), this));
+  
+  // preload.config contains an array of files which will be loaded and then told to persist
+  Json preload = json("/preload.config");
+  Logger::info("Preloading assets");
+  for (auto script : preload.iterateArray()) {
+    auto type = AssetTypeNames.getLeft(script.getString("type"));
+    auto path = script.getString("path");
+    auto components = AssetPath::split(path);
+    validatePath(components, type == AssetType::Json, type == AssetType::Image);
+
+    auto asset = getAsset(AssetId{type, std::move(components)});
+    // make this asset never unload
+    asset->forcePersist = true;
+  }
 }
 
 Assets::~Assets() {
@@ -626,23 +648,23 @@ size_t Assets::AssetIdHash::operator()(AssetId const& id) const {
 }
 
 bool Assets::JsonData::shouldPersist() const {
-  return !json.unique();
+  return forcePersist || !json.unique();
 }
 
 bool Assets::ImageData::shouldPersist() const {
-  return !alias && !image.unique();
+  return forcePersist || !alias && !image.unique();
 }
 
 bool Assets::AudioData::shouldPersist() const {
-  return !audio.unique();
+  return forcePersist || !audio.unique();
 }
 
 bool Assets::FontData::shouldPersist() const {
-  return !font.unique();
+  return forcePersist || !font.unique();
 }
 
 bool Assets::BytesData::shouldPersist() const {
-  return !bytes.unique();
+  return forcePersist || !bytes.unique();
 }
 
 FramesSpecification Assets::parseFramesSpecification(Json const& frameConfig, String path) {

--- a/source/base/StarAssets.hpp
+++ b/source/base/StarAssets.hpp
@@ -38,6 +38,15 @@ struct FramesSpecification {
   StringMap<String> aliases;
 };
 
+enum class AssetType {
+  Json,
+  Image,
+  Audio,
+  Font,
+  Bytes
+};
+extern EnumMap<AssetType> const AssetTypeNames;
+
 // The assets system can load image, font, json, and data assets from a set of
 // sources.  Each source is either a directory on the filesystem or a single
 // packed asset file.
@@ -71,14 +80,6 @@ public:
     StringList digestIgnore;
   };
 
-    enum class AssetType {
-    Json,
-    Image,
-    Audio,
-    Font,
-    Bytes
-  };
-
   enum class QueuePriority {
     None,
     Working,
@@ -107,6 +108,7 @@ public:
 
     double time = 0.0;
     bool needsPostProcessing = false;
+    bool forcePersist = false;
   };
 
   struct JsonData : AssetData {


### PR DESCRIPTION
Adds a file (`/preload.config`).
After assets are loaded, goes through this file and loads every asset listed in it, forcing those assets to be persistent.
Should allow reducing lag spikes in cases involving loading assets (such as, as already done here, inventory filters)