### PR TITLE
(WIP; semi-broken) block swap changes

### DIFF
--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -257,9 +257,6 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
     return;
   
   Item* beamAxe = beamAxePtr.get();
-//BeamMiningTool* tool = as<BeamMiningTool>(beamAxe);
-//if (!tool)
-//  return;
   
   List<Vec2I> swapPositions;
   for (Vec2I& pos : tileArea(radius, owner()->aimPosition())) {
@@ -337,7 +334,7 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
       assets->json("/sfx.config:miningToolVolume").toFloat()
   );
   owner()->addSound(blockSound, assets->json("/sfx.config:miningBlockVolume").toFloat());
-//setFireTimer(tool->windupTime() + tool->cooldownTime());
+  setFireTimer(cooldownTime());
 }
 
 MaterialId MaterialItem::materialId() const {

--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -329,14 +329,14 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
     }
   }
 
-  auto strikeSounds = beamAxe->instanceValue("strikeSounds", {"/assetmissing.wav"});
+/*  auto strikeSounds = beamAxe->instanceValue("strikeSounds", {"/assetmissing.wav"});
   owner()->addSound(
       Random::randValueFrom(jsonToStringList(strikeSounds)),
       assets->json("/sfx.config:miningToolVolume").toFloat()
   );
   owner()->addSound(blockSound, assets->json("/sfx.config:miningBlockVolume").toFloat());
   setFireTimer(windupTime() + cooldownTime());
-}
+}*/
 
 MaterialId MaterialItem::materialId() const {
   return m_material;

--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -292,8 +292,8 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
 
   TileDamage damage;
   damage.type = TileDamageType::Beamish;
-  damage.amount = beamAxe->instanceValue("tileDamage", 1.0f).toFloat();
-  damage.harvestLevel = beamAxe->instanceValue("harvestLevel", 1).toUInt();
+  damage.amount = beamAxe->instanceValue("tileDamage", beamAxe->instanceValue("primaryAbility.tileDamage", 1.0f)).toFloat();
+  damage.harvestLevel = beamAxe->instanceValue("harvestLevel", beamaxe->instanceValue("primaryAbility.harvestLevel", 1)).toUInt();
 
   TileModificationList toSwap;
   List<Vec2I> toDamage;
@@ -329,10 +329,13 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
     }
   }
 
-  owner()->addSound(
-      Random::randValueFrom(jsonToStringList(beamAxe->instanceValue("strikeSounds"))),
-      assets->json("/sfx.config:miningToolVolume").toFloat()
-  );
+  auto strikeSounds = beamaxe->instanceValue("strikeSounds");
+  if (!strikeSounds.empty()) {
+    owner()->addSound(
+        Random::randValueFrom(jsonToStringList(strikeSounds)),
+        assets->json("/sfx.config:miningToolVolume").toFloat()
+    );
+  }
   owner()->addSound(blockSound, assets->json("/sfx.config:miningBlockVolume").toFloat());
   setFireTimer(windupTime() + cooldownTime());
 }

--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -292,8 +292,8 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
 
   TileDamage damage;
   damage.type = TileDamageType::Beamish;
-  damage.amount = beamAxe->instanceValue("tileDamage", instanceValue("primaryAbility.tileDamage", 1.0f)).toFloat();
-  damage.harvestLevel = beamAxe->instanceValue("harvestLevel", instanceValue("primaryAbility.harvestLevel", 1)).toUInt();
+  damage.amount = beamAxe->instanceValue("tileDamage", 1.0f).toFloat();
+  damage.harvestLevel = beamAxe->instanceValue("harvestLevel", 1).toUInt();
 
   TileModificationList toSwap;
   List<Vec2I> toDamage;
@@ -334,7 +334,7 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
       assets->json("/sfx.config:miningToolVolume").toFloat()
   );
   owner()->addSound(blockSound, assets->json("/sfx.config:miningBlockVolume").toFloat());
-  setFireTimer(cooldownTime());
+  setFireTimer(windupTime() + cooldownTime());
 }
 
 MaterialId MaterialItem::materialId() const {

--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -293,7 +293,7 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
   TileDamage damage;
   damage.type = TileDamageType::Beamish;
   damage.amount = beamAxe->instanceValue("tileDamage", beamAxe->instanceValue("primaryAbility.tileDamage", 1.0f)).toFloat();
-  damage.harvestLevel = beamAxe->instanceValue("harvestLevel", beamaxe->instanceValue("primaryAbility.harvestLevel", 1)).toUInt();
+  damage.harvestLevel = beamAxe->instanceValue("harvestLevel", beamAxe->instanceValue("primaryAbility.harvestLevel", 1)).toUInt();
 
   TileModificationList toSwap;
   List<Vec2I> toDamage;
@@ -329,7 +329,7 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
     }
   }
 
-  auto strikeSounds = beamaxe->instanceValue("strikeSounds", {});
+  auto strikeSounds = beamaxe->instanceValue("strikeSounds");
   if (!strikeSounds.empty()) {
     owner()->addSound(
         Random::randValueFrom(jsonToStringList(strikeSounds)),

--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -295,8 +295,8 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
 
   TileDamage damage;
   damage.type = TileDamageType::Beamish;
-  damage.amount = beamAxe->instanceValue("tileDamage", instanceValue("primaryAbility", {}).tileDamage, 1.0f).toFloat();
-  damage.harvestLevel = beamAxe->instanceValue("harvestLevel", instanceValue("primaryAbility", {}).harvestLevel, 1).toUInt();
+  damage.amount = beamAxe->instanceValue("tileDamage", instanceValue("primaryAbility", {}).value("tileDamage"), 1.0f).toFloat();
+  damage.harvestLevel = beamAxe->instanceValue("harvestLevel", instanceValue("primaryAbility", {}).value("harvestLevel"), 1).toUInt();
 
   TileModificationList toSwap;
   List<Vec2I> toDamage;

--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -335,8 +335,8 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
       assets->json("/sfx.config:miningToolVolume").toFloat()
   );
   owner()->addSound(blockSound, assets->json("/sfx.config:miningBlockVolume").toFloat());
-  setFireTimer(windupTime() + cooldownTime());
-}*/
+  setFireTimer(windupTime() + cooldownTime());*/
+}
 
 MaterialId MaterialItem::materialId() const {
   return m_material;

--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -295,8 +295,8 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
 
   TileDamage damage;
   damage.type = TileDamageType::Beamish;
-  damage.amount = beamAxe->instanceValue("tileDamage", instanceValue("primaryAbility", {})["tileDamage"], 1.0f).toFloat();
-  damage.harvestLevel = beamAxe->instanceValue("harvestLevel", instanceValue("primaryAbility", {})["harvestLevel"], 1).toUInt();
+  damage.amount = beamAxe->instanceValue("tileDamage", instanceValue("primaryAbility.tileDamage", 1.0f)).toFloat();
+  damage.harvestLevel = beamAxe->instanceValue("harvestLevel", instanceValue("primaryAbility.harvestLevel", 1)).toUInt();
 
   TileModificationList toSwap;
   List<Vec2I> toDamage;

--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -329,7 +329,7 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
     }
   }
 
-  auto strikeSounds = beamAxe->instanceValue("strikeSounds");
+  auto strikeSounds = beamAxe->instanceValue("strikeSounds", {});
   if (!strikeSounds.empty()) {
     owner()->addSound(
         Random::randValueFrom(jsonToStringList(strikeSounds)),

--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -329,7 +329,7 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
     }
   }
 
-  auto strikeSounds = beamaxe->instanceValue("strikeSounds");
+  auto strikeSounds = beamaxe->instanceValue("strikeSounds", {});
   if (!strikeSounds.empty()) {
     owner()->addSound(
         Random::randValueFrom(jsonToStringList(strikeSounds)),

--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -257,9 +257,9 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
     return;
   
   Item* beamAxe = beamAxePtr.get();
-//BeamMiningTool* tool = as<BeamMiningTool>(beamAxe);
-//if (!tool)
-//  return;
+  BeamMiningTool* tool = as<BeamMiningTool>(beamAxe);
+  if (!tool)
+    return;
   
   List<Vec2I> swapPositions;
   for (Vec2I& pos : tileArea(radius, owner()->aimPosition())) {

--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -329,7 +329,7 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
     }
   }
 
-  auto strikeSounds = beamaxe->instanceValue("strikeSounds");
+  auto strikeSounds = beamAxe->instanceValue("strikeSounds");
   if (!strikeSounds.empty()) {
     owner()->addSound(
         Random::randValueFrom(jsonToStringList(strikeSounds)),

--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -257,9 +257,9 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
     return;
   
   Item* beamAxe = beamAxePtr.get();
-  BeamMiningTool* tool = as<BeamMiningTool>(beamAxe);
-  if (!tool)
-    return;
+//BeamMiningTool* tool = as<BeamMiningTool>(beamAxe);
+//if (!tool)
+//  return;
   
   List<Vec2I> swapPositions;
   for (Vec2I& pos : tileArea(radius, owner()->aimPosition())) {
@@ -295,8 +295,8 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
 
   TileDamage damage;
   damage.type = TileDamageType::Beamish;
-  damage.amount = beamAxe->instanceValue("tileDamage", 1.0f).toFloat();
-  damage.harvestLevel = beamAxe->instanceValue("harvestLevel", 1).toUInt();
+  damage.amount = beamAxe->instanceValue("tileDamage", instanceValue("primaryAbility", {}).tileDamage, 1.0f).toFloat();
+  damage.harvestLevel = beamAxe->instanceValue("harvestLevel", instanceValue("primaryAbility", {}).harvestLevel, 1).toUInt();
 
   TileModificationList toSwap;
   List<Vec2I> toDamage;

--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -257,9 +257,9 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
     return;
   
   Item* beamAxe = beamAxePtr.get();
-  BeamMiningTool* tool = as<BeamMiningTool>(beamAxe);
-  if (!tool)
-    return;
+//BeamMiningTool* tool = as<BeamMiningTool>(beamAxe);
+//if (!tool)
+//  return;
   
   List<Vec2I> swapPositions;
   for (Vec2I& pos : tileArea(radius, owner()->aimPosition())) {
@@ -337,7 +337,7 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
       assets->json("/sfx.config:miningToolVolume").toFloat()
   );
   owner()->addSound(blockSound, assets->json("/sfx.config:miningBlockVolume").toFloat());
-  setFireTimer(tool->windupTime() + tool->cooldownTime());
+//setFireTimer(tool->windupTime() + tool->cooldownTime());
 }
 
 MaterialId MaterialItem::materialId() const {

--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -329,13 +329,11 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
     }
   }
 
-  auto strikeSounds = beamAxe->instanceValue("strikeSounds", {});
-  if (!strikeSounds.empty()) {
-    owner()->addSound(
-        Random::randValueFrom(jsonToStringList(strikeSounds)),
-        assets->json("/sfx.config:miningToolVolume").toFloat()
-    );
-  }
+  auto strikeSounds = beamAxe->instanceValue("strikeSounds", {"/assetmissing.wav"});
+  owner()->addSound(
+      Random::randValueFrom(jsonToStringList(strikeSounds)),
+      assets->json("/sfx.config:miningToolVolume").toFloat()
+  );
   owner()->addSound(blockSound, assets->json("/sfx.config:miningBlockVolume").toFloat());
   setFireTimer(windupTime() + cooldownTime());
 }

--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -295,8 +295,8 @@ void MaterialItem::blockSwap(float radius, TileLayer layer) {
 
   TileDamage damage;
   damage.type = TileDamageType::Beamish;
-  damage.amount = beamAxe->instanceValue("tileDamage", instanceValue("primaryAbility", {}).value("tileDamage"), 1.0f).toFloat();
-  damage.harvestLevel = beamAxe->instanceValue("harvestLevel", instanceValue("primaryAbility", {}).value("harvestLevel"), 1).toUInt();
+  damage.amount = beamAxe->instanceValue("tileDamage", instanceValue("primaryAbility", {})["tileDamage"], 1.0f).toFloat();
+  damage.harvestLevel = beamAxe->instanceValue("harvestLevel", instanceValue("primaryAbility", {})["harvestLevel"], 1).toUInt();
 
   TileModificationList toSwap;
   List<Vec2I> toDamage;


### PR DESCRIPTION
Since some mods allow the player to change their beamaxe slot item, I changed blockswap to work when a non-beamaxe item is equipped in the beamaxe slot, ie pickaxes (miningtool) and active items (vanilla energy pickaxe (this is what the primaryAbility checks are for), scripted activeitem manipulators). This check existed because of tool calls for the windup + firetime calculation between block strikes. I changed it to use the block's windup/cooldown time between strikes instead of the tool's, which is temporary until I or someone else finds a way to make it work for other item types

I also commented out the 'grab the strikeSounds of the player's tool and use it when blockswapping' because I couldn't get it to work with the energy pickaxe for now. I plan to fix these but will probably be busy for a while