### PR TITLE
Configurable post-process shader passes

### DIFF
--- a/assets/opensb/interface/opensb/shaders/shaders.lua
+++ b/assets/opensb/interface/opensb/shaders/shaders.lua
@@ -184,6 +184,18 @@ local function addOption(data, i, added)
   end
 end
 
+local function updateParameter(parameter,oname,value)
+  if parameter.isPasses then
+    for k,v in next, parameter.layers do
+      renderer.setPostProcessLayerPasses(v, value)
+    end
+  else
+    for k,v in next, parameter.effects do
+      renderer.setEffectParameter(v, oname, value)
+    end
+  end
+end
+
 function sliderOptionModified(option, odata)
   local oname = string.sub(option, optionOffset)
   local parameter = groups[activeGroup].parameters[oname]
@@ -191,15 +203,12 @@ function sliderOptionModified(option, odata)
   
   widget.setText(fmt("%s.%s",OPTIONS_WIDGET,option.."_value"), fmt(digitRegex(parameter.delta),value))
   
-  for k,v in next, parameter.effects do
-    renderer.setEffectParameter(v, oname, value)
-  end
+  updateParameter(parameter,oname,value)
   shaderConfig[activeGroup].parameters[oname] = value
   root.setConfiguration("postProcessGroups",shaderConfig)
 end
 
 function selectOptionPressed(button,bdata)
-  sb.logInfo(sb.print(bdata))
   
   for k,v in next, bdata.buttons do
     if v.index ~= bdata.index then
@@ -212,9 +221,7 @@ function selectOptionPressed(button,bdata)
   local oname = bdata.option.name
   local parameter = groups[activeGroup].parameters[oname]
   
-  for k,v in next, parameter.effects do
-    renderer.setEffectParameter(v, oname, value)
-  end
+  updateParameter(parameter,oname,value)
   shaderConfig[activeGroup].parameters[oname] = value
   root.setConfiguration("postProcessGroups",shaderConfig)
 end

--- a/assets/opensb/scripts/opensb/universeclient/loadconfig.lua
+++ b/assets/opensb/scripts/opensb/universeclient/loadconfig.lua
@@ -11,9 +11,17 @@ function module.init()
 		local group = postProcessGroups[k]
 		if group and v.parameters then
 			for k2,v2 in next, group.parameters do
-				if v.parameters[k2] ~= nil then
-					for _,e in next, v2.effects do
-						renderer.setEffectParameter(e,k2,v.parameters[k2])
+				local param = v.parameters[k2]
+				if param ~= nil then
+					if v2.isPasses then
+						-- this parameter controls passes
+						for _,l in next, v2.layers do
+							renderer.setPostProcessLayerPasses(l,param)
+						end
+					else
+						for _,e in next, v2.effects do
+							renderer.setEffectParameter(e,k2,param)
+						end
 					end
 				end
 			end

--- a/source/client/StarClientApplication.hpp
+++ b/source/client/StarClientApplication.hpp
@@ -19,8 +19,9 @@ STAR_CLASS(Voice);
 
 class ClientApplication : public Application {
 public:
-  void setPostProcessGroupEnabled(String group, bool enabled, Maybe<bool> save);
-  bool postProcessGroupEnabled(String group);
+  void setPostProcessLayerPasses(String const& layer, unsigned const& passes);
+  void setPostProcessGroupEnabled(String const& group, bool const& enabled, Maybe<bool> const& save);
+  bool postProcessGroupEnabled(String const& group);
   Json postProcessGroups();
   
 protected:
@@ -116,6 +117,7 @@ private:
   
   StringMap<PostProcessGroup> m_postProcessGroups;
   List<PostProcessLayer> m_postProcessLayers;
+  StringMap<size_t> m_labelledPostProcessLayers;
 
   // Valid if main app state == SinglePlayer
   UniverseServerPtr m_universeServer;

--- a/source/client/StarRenderingLuaBindings.cpp
+++ b/source/client/StarRenderingLuaBindings.cpp
@@ -37,6 +37,9 @@ LuaCallbacks LuaBindings::makeRenderingCallbacks(ClientApplication* app) {
     auto renderer = app->renderer();
     return renderer->getEffectScriptableParameter(effectName, effectParameter);
   });
+  
+  // not saved; should be loaded by Lua again
+  callbacks.registerCallbackWithSignature<void, String, unsigned>("setPostProcessLayerPasses", bind(mem_fn(&ClientApplication::setPostProcessLayerPasses), app, _1, _2));
 
   return callbacks;
 }


### PR DESCRIPTION
(No, this is not an April Fools joke)
On the engine side, adds a Lua callback that allows changing the number of render passes for post-process layers based on a provided label. The means of keeping track of these labels is... not as clean as I'd hope, but pointers seemed to not work until reload for... some reason.
On the assets side, adds this functionality to loadconfig and the shaders menu. Options to change the number of passes are added as any other parameter, just set up differently. Note that a single post process group can have multiple layers with their own number of passes which may need their own sliders to configure this.

Updated bloom shader that uses this:
[bloom.pak.zip](https://github.com/user-attachments/files/19555004/bloom.pak.zip)