### PR TITLE
remove oSB lua bind from vanilla docs

### DIFF
--- a/doc/lua/player.md
+++ b/doc/lua/player.md
@@ -527,9 +527,3 @@ Returns uuid, type, and orbits for all system objects in the specified system;
 #### `List<String>` player.collectables(`String` collectionName)
 
 Returns a list of names of the collectables the player has unlocked in the specified collection.
-
----
-
-#### `void` player.say(`String` text)
-
-Displays the text in the speech bubble above the character without sending the text to the actual chat.


### PR DESCRIPTION
player.say is already documented in the oSB docs. this removes it from the vanilla docs