### PR TITLE
Use Zink for OpenGL on Linux if supported

### DIFF
--- a/scripts/ci/linux/run-client.sh
+++ b/scripts/ci/linux/run-client.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# Check for Zink support
+if MESA_LOADER_DRIVER_OVERRIDE=zink glxinfo | grep -q 'renderer string.*zink'; then
+    # Set environment variables for Zink
+    export __GLX_VENDOR_LIBRARY_NAME=mesa
+    export MESA_LOADER_DRIVER_OVERRIDE=zink
+    export GALLIUM_DRIVER=zink
+fi
+
 cd "`dirname \"$0\"`"
 
 LD_LIBRARY_PATH="$LD_LIBRARY_PATH:./" ./starbound "$@"


### PR DESCRIPTION
If your system supports the Zink driver, you can use it for OpenGL rendering by switching to the Vulkan backend. This can improve performance.