### PR TITLE
rewrote zink support check and added vulkan support check

### DIFF
--- a/scripts/ci/linux/run-client.sh
+++ b/scripts/ci/linux/run-client.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Check if environment variables are already used by user
+# Check if environment variables are already set
 if [ -n "${__GLX_VENDOR_LIBRARY_NAME}" ] || [ -n "${MESA_LOADER_DRIVER_OVERRIDE}" ] || [ -n "${GALLIUM_DRIVER}" ]; then :
 else
     # Check for Vulkan support


### PR DESCRIPTION
Added Vulkan support check for zink and rewrote zink check. Environment variables are now set with 1 instead of 3 export functions. Added check to look if any of the variables are already set. If this is the case then it will not try to apply any of the Zink variables