### PR TITLE
Networked animator improvements

### DIFF
--- a/source/base/StarAnimatedPartSet.cpp
+++ b/source/base/StarAnimatedPartSet.cpp
@@ -60,7 +60,9 @@ AnimatedPartSet::AnimatedPartSet(Json config, uint8_t animatorVersion) {
 
       for (auto const& partStatePair : partStateTypePair.second.toObject()) {
         auto const& stateName = partStatePair.first;
-        auto const& stateConfig = partStatePair.second;
+        auto stateConfig = partStatePair.second;
+        if ((version() > 0) && stateConfig.isType(Json::Type::String))
+          stateConfig = partStatePair.second.get(stateConfig.toString());
 
         PartState partState = {stateConfig.getObject("properties", {}), stateConfig.getObject("frameProperties", {})};
         newPart.partStates[stateTypeName][stateName] = std::move(partState);

--- a/source/base/StarAnimatedPartSet.hpp
+++ b/source/base/StarAnimatedPartSet.hpp
@@ -2,6 +2,7 @@
 
 #include "StarOrderedMap.hpp"
 #include "StarJson.hpp"
+#include "StarMatrix3.hpp"
 
 namespace Star {
 
@@ -46,7 +47,11 @@ public:
     String stateName;
     float timer;
     unsigned frame;
+    float frameProgress;
     JsonObject properties;
+    bool reverse;
+    unsigned nextFrame;
+    JsonObject nextProperties;
   };
 
   struct ActivePartInformation {
@@ -54,6 +59,18 @@ public:
     // If a state match is found, this will be set.
     Maybe<ActiveStateInformation> activeState;
     JsonObject properties;
+    JsonObject nextProperties;
+
+    Mat3F animationAffineTransform() const;
+    void setAnimationAffineTransform(Mat3F const& matrix);
+    void setAnimationAffineTransform(Mat3F const& mat1, Mat3F const& mat2, float progress);
+
+    float xTranslationAnimation;
+    float yTranslationAnimation;
+    float xScaleAnimation;
+    float yScaleAnimation;
+    float xShearAnimation;
+    float yShearAnimation;
   };
 
     enum AnimationMode {
@@ -97,7 +114,7 @@ public:
   };
 
   AnimatedPartSet();
-  AnimatedPartSet(Json config);
+  AnimatedPartSet(Json config, uint8_t animatiorVersion);
 
   // Returns the available state types.
   StringList stateTypes() const;
@@ -118,7 +135,7 @@ public:
   // beginning.  If alwaysStart is true, then starts the state animation off at
   // the beginning even if no state change has occurred.  Returns true if a
   // state animation reset was done.
-  bool setActiveState(String const& stateTypeName, String const& stateName, bool alwaysStart = false);
+  bool setActiveState(String const& stateTypeName, String const& stateName, bool alwaysStart = false, bool reverse = false);
 
   // Restart this given state type's timer off at the beginning.
   void restartState(String const& stateTypeName);
@@ -141,7 +158,8 @@ public:
   // state type is ordered, it is possible to simply serialize and deserialize
   // the state index for that state type.
   size_t activeStateIndex(String const& stateTypeName) const;
-  bool setActiveStateIndex(String const& stateTypeName, size_t stateIndex, bool alwaysStart = false);
+  bool activeStateReverse(String const& stateTypeName) const;
+  bool setActiveStateIndex(String const& stateTypeName, size_t stateIndex, bool alwaysStart = false, bool reverse = false);
 
   // Animate each state type forward 'dt' time, and either change state frames
   // or transition to new states, depending on the config.
@@ -149,6 +167,8 @@ public:
 
   // Pushes all the animations into their final state
   void finishAnimations();
+
+  uint8_t version() const;
 
 private:
   static AnimationMode stringToAnimationMode(String const& string);
@@ -158,6 +178,8 @@ private:
 
   OrderedHashMap<String, StateType> m_stateTypes;
   StringMap<Part> m_parts;
+
+  uint8_t m_animatorVersion;
 };
 
 }

--- a/source/core/StarDataStream.cpp
+++ b/source/core/StarDataStream.cpp
@@ -6,7 +6,7 @@
 
 namespace Star {
 
-unsigned const CurrentStreamVersion = 7; // update OpenProtocolVersion too!
+unsigned const CurrentStreamVersion = 8; // update OpenProtocolVersion too!
 
 DataStream::DataStream()
   : m_byteOrder(ByteOrder::BigEndian),

--- a/source/core/StarNetCompatibility.cpp
+++ b/source/core/StarNetCompatibility.cpp
@@ -2,6 +2,6 @@
 
 namespace Star {
 
-VersionNumber const OpenProtocolVersion = 7; // update StreamCompatibilityVersion too!
+VersionNumber const OpenProtocolVersion = 8; // update StreamCompatibilityVersion too!
 
 }

--- a/source/game/StarNetworkedAnimator.cpp
+++ b/source/game/StarNetworkedAnimator.cpp
@@ -264,6 +264,7 @@ NetworkedAnimator& NetworkedAnimator::operator=(NetworkedAnimator&& animator) {
   m_globalTags = std::move(animator.m_globalTags);
   m_partTags = std::move(animator.m_partTags);
   m_cachedPartDrawables = std::move(animator.m_cachedPartDrawables);
+  m_partDrawables = std::move(animator.m_partDrawables);
 
   setupNetStates();
 
@@ -288,6 +289,7 @@ NetworkedAnimator& NetworkedAnimator::operator=(NetworkedAnimator const& animato
   m_globalTags = animator.m_globalTags;
   m_partTags = animator.m_partTags;
   m_cachedPartDrawables = animator.m_cachedPartDrawables;
+  m_partDrawables = animator.m_partDrawables;
 
   setupNetStates();
 
@@ -979,7 +981,7 @@ void NetworkedAnimator::update(float dt, DynamicTarget* dynamicTarget) {
           if (auto transforms = activeState.properties.ptr(pair.first)) {
             auto mat = processTransforms(pair.second.animationAffineTransform(), transforms->toArray(), activeState.properties);
             if (pair.second.interpolated) {
-              if (auto nextTransforms = activeState.nextProperties.ptr("transforms")) {
+              if (auto nextTransforms = activeState.nextProperties.ptr(pair.first)) {
                 auto nextMat = processTransforms(pair.second.animationAffineTransform(), nextTransforms->toArray(), activeState.nextProperties);
                 pair.second.setAnimationAffineTransform(mat, nextMat, activeState.frameProgress);
               } else {

--- a/source/game/StarNetworkedAnimator.cpp
+++ b/source/game/StarNetworkedAnimator.cpp
@@ -349,6 +349,9 @@ StringList NetworkedAnimator::partNames() const {
 Json NetworkedAnimator::stateProperty(String const& stateType, String const& propertyName) const {
   return m_animatedParts.activeState(stateType).properties.value(propertyName);
 }
+Json NetworkedAnimator::stateNextProperty(String const& stateType, String const& propertyName) const {
+  return m_animatedParts.activeState(stateType).nextProperties.value(propertyName);
+}
 
 Json NetworkedAnimator::partProperty(String const& partName, String const& propertyName) const {
   return m_animatedParts.activePart(partName).properties.value(propertyName);

--- a/source/game/StarNetworkedAnimator.hpp
+++ b/source/game/StarNetworkedAnimator.hpp
@@ -129,6 +129,8 @@ public:
   void setPartDrawables(String const& partName, List<Drawable> drawables);
   void addPartDrawables(String const& partName, List<Drawable> drawables);
 
+  String applyPartTags(String const& partName, String apply);
+
   void setProcessingDirectives(Directives const& directives);
   void setZoom(float zoom);
   bool flipped() const;

--- a/source/game/StarNetworkedAnimator.hpp
+++ b/source/game/StarNetworkedAnimator.hpp
@@ -95,6 +95,7 @@ public:
   // AnimatedPartSet for the given state or part.  If the property does not
   // exist, returns null.
   Json stateProperty(String const& stateType, String const& propertyName) const;
+  Json stateNextProperty(String const& stateType, String const& propertyName) const;
   Json partProperty(String const& partName, String const& propertyName) const;
 
   // Returns the transformation from flipping and zooming that is applied to

--- a/source/game/scripting/StarNetworkedAnimatorLuaBindings.cpp
+++ b/source/game/scripting/StarNetworkedAnimatorLuaBindings.cpp
@@ -8,12 +8,21 @@ namespace Star {
 LuaCallbacks LuaBindings::makeNetworkedAnimatorCallbacks(NetworkedAnimator* networkedAnimator) {
   LuaCallbacks callbacks;
 
-  callbacks.registerCallbackWithSignature<bool, String, String, bool>(
-      "setAnimationState", bind(&NetworkedAnimator::setState, networkedAnimator, _1, _2, _3));
+  callbacks.registerCallbackWithSignature<bool, String, String, bool, bool>(
+      "setAnimationState", bind(&NetworkedAnimator::setState, networkedAnimator, _1, _2, _3, _4));
   callbacks.registerCallbackWithSignature<String, String>(
       "animationState", bind(&NetworkedAnimator::state, networkedAnimator, _1));
   callbacks.registerCallbackWithSignature<Json, String, String>(
       "animationStateProperty", bind(&NetworkedAnimator::stateProperty, networkedAnimator, _1, _2));
+  callbacks.registerCallbackWithSignature<int, String>(
+      "animationStateFrame", bind(&NetworkedAnimator::stateFrame, networkedAnimator, _1));
+  callbacks.registerCallbackWithSignature<float, String>(
+      "animationStateFrameProgress", bind(&NetworkedAnimator::stateFrameProgress, networkedAnimator, _1));
+  callbacks.registerCallbackWithSignature<float, String>(
+      "animationStateTimer", bind(&NetworkedAnimator::stateTimer, networkedAnimator, _1));
+  callbacks.registerCallbackWithSignature<bool, String>(
+      "animationStateReverse", bind(&NetworkedAnimator::stateReverse, networkedAnimator, _1));
+
   callbacks.registerCallbackWithSignature<void, String, String>(
       "setGlobalTag", bind(&NetworkedAnimator::setGlobalTag, networkedAnimator, _1, _2));
   callbacks.registerCallbackWithSignature<void, String, String, String>(
@@ -30,6 +39,7 @@ LuaCallbacks LuaBindings::makeNetworkedAnimatorCallbacks(NetworkedAnimator* netw
       "currentRotationAngle", bind(&NetworkedAnimator::currentRotationAngle, networkedAnimator, _1));
   callbacks.registerCallbackWithSignature<bool, String>(
       "hasTransformationGroup", bind(&NetworkedAnimator::hasTransformationGroup, networkedAnimator, _1));
+
   callbacks.registerCallbackWithSignature<void, String, Vec2F>("translateTransformationGroup",
       bind(&NetworkedAnimator::translateTransformationGroup, networkedAnimator, _1, _2));
   callbacks.registerCallback("rotateTransformationGroup",
@@ -48,6 +58,27 @@ LuaCallbacks LuaBindings::makeNetworkedAnimatorCallbacks(NetworkedAnimator* netw
       bind(&NetworkedAnimator::transformTransformationGroup, networkedAnimator, _1, _2, _3, _4, _5, _6, _7));
   callbacks.registerCallbackWithSignature<void, String>(
       "resetTransformationGroup", bind(&NetworkedAnimator::resetTransformationGroup, networkedAnimator, _1));
+
+  callbacks.registerCallbackWithSignature<void, String, Vec2F>("translateLocalTransformationGroup",
+      bind(&NetworkedAnimator::translateLocalTransformationGroup, networkedAnimator, _1, _2));
+  callbacks.registerCallback("rotateLocalTransformationGroup",
+      [networkedAnimator](String const& transformationGroup, float rotation, Maybe<Vec2F> const& rotationCenter) {
+        networkedAnimator->rotateLocalTransformationGroup(transformationGroup, rotation, rotationCenter.value());
+      });
+  callbacks.registerCallback("scaleLocalTransformationGroup",
+      [networkedAnimator](LuaEngine& engine, String const& transformationGroup, LuaValue scale, Maybe<Vec2F> const& scaleCenter) {
+        if (auto cs = engine.luaMaybeTo<Vec2F>(scale))
+          networkedAnimator->scaleLocalTransformationGroup(transformationGroup, *cs, scaleCenter.value());
+        else
+          networkedAnimator->scaleLocalTransformationGroup(transformationGroup, engine.luaTo<float>(scale), scaleCenter.value());
+      });
+  callbacks.registerCallbackWithSignature<void, String, float, float, float, float, float, float>(
+      "transformLocalTransformationGroup",
+      bind(&NetworkedAnimator::transformLocalTransformationGroup, networkedAnimator, _1, _2, _3, _4, _5, _6, _7));
+  callbacks.registerCallbackWithSignature<void, String>(
+      "resetLocalTransformationGroup", bind(&NetworkedAnimator::resetLocalTransformationGroup, networkedAnimator, _1));
+
+
   callbacks.registerCallbackWithSignature<void, String, bool>(
       "setParticleEmitterActive", bind(&NetworkedAnimator::setParticleEmitterActive, networkedAnimator, _1, _2));
   callbacks.registerCallbackWithSignature<void, String, float>("setParticleEmitterEmissionRate",
@@ -105,6 +136,10 @@ LuaCallbacks LuaBindings::makeNetworkedAnimatorCallbacks(NetworkedAnimator* netw
       return poly;
     });
 
+  callbacks.registerCallbackWithSignature<void, String, List<Drawable>>(
+      "addPartDrawables", bind(&NetworkedAnimator::addPartDrawables, networkedAnimator, _1, _2));
+  callbacks.registerCallbackWithSignature<void, String, List<Drawable>>(
+      "setPartDrawables", bind(&NetworkedAnimator::setPartDrawables, networkedAnimator, _1, _2));
 
   return callbacks;
 }

--- a/source/game/scripting/StarNetworkedAnimatorLuaBindings.cpp
+++ b/source/game/scripting/StarNetworkedAnimatorLuaBindings.cpp
@@ -10,6 +10,8 @@ LuaCallbacks LuaBindings::makeNetworkedAnimatorCallbacks(NetworkedAnimator* netw
 
   callbacks.registerCallbackWithSignature<bool, String, String, bool, bool>(
       "setAnimationState", bind(&NetworkedAnimator::setState, networkedAnimator, _1, _2, _3, _4));
+  callbacks.registerCallbackWithSignature<bool, String, String, bool, bool>(
+      "setLocalAnimationState", bind(&NetworkedAnimator::setLocalState, networkedAnimator, _1, _2, _3, _4));
   callbacks.registerCallbackWithSignature<String, String>(
       "animationState", bind(&NetworkedAnimator::state, networkedAnimator, _1));
   callbacks.registerCallbackWithSignature<Json, String, String>(

--- a/source/game/scripting/StarNetworkedAnimatorLuaBindings.cpp
+++ b/source/game/scripting/StarNetworkedAnimatorLuaBindings.cpp
@@ -14,6 +14,8 @@ LuaCallbacks LuaBindings::makeNetworkedAnimatorCallbacks(NetworkedAnimator* netw
       "animationState", bind(&NetworkedAnimator::state, networkedAnimator, _1));
   callbacks.registerCallbackWithSignature<Json, String, String>(
       "animationStateProperty", bind(&NetworkedAnimator::stateProperty, networkedAnimator, _1, _2));
+  callbacks.registerCallbackWithSignature<Json, String, String>(
+      "animationStateNextProperty", bind(&NetworkedAnimator::stateNextProperty, networkedAnimator, _1, _2));
   callbacks.registerCallbackWithSignature<int, String>(
       "animationStateFrame", bind(&NetworkedAnimator::stateFrame, networkedAnimator, _1));
   callbacks.registerCallbackWithSignature<float, String>(
@@ -140,6 +142,9 @@ LuaCallbacks LuaBindings::makeNetworkedAnimatorCallbacks(NetworkedAnimator* netw
       "addPartDrawables", bind(&NetworkedAnimator::addPartDrawables, networkedAnimator, _1, _2));
   callbacks.registerCallbackWithSignature<void, String, List<Drawable>>(
       "setPartDrawables", bind(&NetworkedAnimator::setPartDrawables, networkedAnimator, _1, _2));
+
+  callbacks.registerCallbackWithSignature<String, String, String>(
+      "applyPartTags", bind(&NetworkedAnimator::applyPartTags, networkedAnimator, _1, _2));
 
   return callbacks;
 }

--- a/source/game/scripting/StarScriptedAnimatorLuaBindings.cpp
+++ b/source/game/scripting/StarScriptedAnimatorLuaBindings.cpp
@@ -20,6 +20,8 @@ LuaCallbacks LuaBindings::makeScriptedAnimatorCallbacks(NetworkedAnimator* netwo
       return poly;
     });
 
+  callbacks.registerCallbackWithSignature<bool, String, String, bool, bool>(
+      "setLocalAnimationState", bind(&NetworkedAnimator::setLocalState, networkedAnimator, _1, _2, _3, _4));
   callbacks.registerCallbackWithSignature<Json, String, String>(
       "animationStateProperty", bind(&NetworkedAnimator::stateProperty, networkedAnimator, _1, _2));
   callbacks.registerCallbackWithSignature<Json, String, String>(

--- a/source/game/scripting/StarScriptedAnimatorLuaBindings.cpp
+++ b/source/game/scripting/StarScriptedAnimatorLuaBindings.cpp
@@ -4,22 +4,62 @@
 
 namespace Star {
 
-LuaCallbacks LuaBindings::makeScriptedAnimatorCallbacks(const NetworkedAnimator* animator, function<Json(String const&, Json const&)> getParameter) {
+LuaCallbacks LuaBindings::makeScriptedAnimatorCallbacks(NetworkedAnimator* networkedAnimator, function<Json(String const&, Json const&)> getParameter) {
   LuaCallbacks callbacks;
 
   callbacks.registerCallback("animationParameter", getParameter);
-  callbacks.registerCallback("partPoint", [animator](String const& partName, String const& propertyName) {
-    return animator->partPoint(partName, propertyName);
-  });
-  callbacks.registerCallback("partPoly", [animator](String const& partName, String const& propertyName) { return animator->partPoly(partName, propertyName); });
+  callbacks.registerCallbackWithSignature<Maybe<Vec2F>, String, String>("partPoint", bind(&NetworkedAnimator::partPoint, networkedAnimator, _1, _2));
+  callbacks.registerCallbackWithSignature<Maybe<PolyF>, String, String>("partPoly", bind(&NetworkedAnimator::partPoly, networkedAnimator, _1, _2));
+  callbacks.registerCallbackWithSignature<Json, String, String>("partProperty", bind(&NetworkedAnimator::partProperty, networkedAnimator, _1, _2));
 
-  callbacks.registerCallback("transformPoint", [animator] (Vec2F point, String const& part) -> Vec2F {
-      return animator->partTransformation(part).transformVec2(point);
+  callbacks.registerCallback("transformPoint", [networkedAnimator] (Vec2F point, String const& part) -> Vec2F {
+      return networkedAnimator->partTransformation(part).transformVec2(point);
     });
-  callbacks.registerCallback("transformPoly", [animator] (PolyF poly, String const& part) -> PolyF {
-      poly.transform(animator->partTransformation(part));
+  callbacks.registerCallback("transformPoly", [networkedAnimator] (PolyF poly, String const& part) -> PolyF {
+      poly.transform(networkedAnimator->partTransformation(part));
       return poly;
     });
+
+  callbacks.registerCallbackWithSignature<Json, String, String>(
+      "animationStateProperty", bind(&NetworkedAnimator::stateProperty, networkedAnimator, _1, _2));
+  callbacks.registerCallbackWithSignature<int, String>(
+      "animationState", bind(&NetworkedAnimator::state, networkedAnimator, _1));
+  callbacks.registerCallbackWithSignature<int, String>(
+      "animationStateFrame", bind(&NetworkedAnimator::stateFrame, networkedAnimator, _1));
+  callbacks.registerCallbackWithSignature<float, String>(
+      "animationStateFrameProgress", bind(&NetworkedAnimator::stateFrameProgress, networkedAnimator, _1));
+  callbacks.registerCallbackWithSignature<float, String>(
+      "animationStateTimer", bind(&NetworkedAnimator::stateTimer, networkedAnimator, _1));
+  callbacks.registerCallbackWithSignature<bool, String>(
+      "animationStateReverse", bind(&NetworkedAnimator::stateReverse, networkedAnimator, _1));
+
+  callbacks.registerCallbackWithSignature<bool, String>(
+      "hasTransformationGroup", bind(&NetworkedAnimator::hasTransformationGroup, networkedAnimator, _1));
+
+  callbacks.registerCallbackWithSignature<void, String, Vec2F>("translateLocalTransformationGroup",
+      bind(&NetworkedAnimator::translateLocalTransformationGroup, networkedAnimator, _1, _2));
+  callbacks.registerCallback("rotateLocalTransformationGroup",
+      [networkedAnimator](String const& transformationGroup, float rotation, Maybe<Vec2F> const& rotationCenter) {
+        networkedAnimator->rotateLocalTransformationGroup(transformationGroup, rotation, rotationCenter.value());
+      });
+  callbacks.registerCallback("scaleLocalTransformationGroup",
+      [networkedAnimator](LuaEngine& engine, String const& transformationGroup, LuaValue scale, Maybe<Vec2F> const& scaleCenter) {
+        if (auto cs = engine.luaMaybeTo<Vec2F>(scale))
+          networkedAnimator->scaleLocalTransformationGroup(transformationGroup, *cs, scaleCenter.value());
+        else
+          networkedAnimator->scaleLocalTransformationGroup(transformationGroup, engine.luaTo<float>(scale), scaleCenter.value());
+      });
+  callbacks.registerCallbackWithSignature<void, String, float, float, float, float, float, float>(
+      "transformLocalTransformationGroup",
+      bind(&NetworkedAnimator::transformLocalTransformationGroup, networkedAnimator, _1, _2, _3, _4, _5, _6, _7));
+  callbacks.registerCallbackWithSignature<void, String>(
+      "resetLocalTransformationGroup", bind(&NetworkedAnimator::resetLocalTransformationGroup, networkedAnimator, _1));
+
+  callbacks.registerCallbackWithSignature<void, String, List<Drawable>>(
+      "addPartDrawables", bind(&NetworkedAnimator::addPartDrawables, networkedAnimator, _1, _2));
+  callbacks.registerCallbackWithSignature<void, String, List<Drawable>>(
+      "setPartDrawables", bind(&NetworkedAnimator::setPartDrawables, networkedAnimator, _1, _2));
+
 
   return callbacks;
 }

--- a/source/game/scripting/StarScriptedAnimatorLuaBindings.cpp
+++ b/source/game/scripting/StarScriptedAnimatorLuaBindings.cpp
@@ -61,6 +61,8 @@ LuaCallbacks LuaBindings::makeScriptedAnimatorCallbacks(NetworkedAnimator* netwo
       "addPartDrawables", bind(&NetworkedAnimator::addPartDrawables, networkedAnimator, _1, _2));
   callbacks.registerCallbackWithSignature<void, String, List<Drawable>>(
       "setPartDrawables", bind(&NetworkedAnimator::setPartDrawables, networkedAnimator, _1, _2));
+  callbacks.registerCallbackWithSignature<String, String, String>(
+      "applyPartTags", bind(&NetworkedAnimator::applyPartTags, networkedAnimator, _1, _2));
 
 
   return callbacks;

--- a/source/game/scripting/StarScriptedAnimatorLuaBindings.cpp
+++ b/source/game/scripting/StarScriptedAnimatorLuaBindings.cpp
@@ -22,6 +22,8 @@ LuaCallbacks LuaBindings::makeScriptedAnimatorCallbacks(NetworkedAnimator* netwo
 
   callbacks.registerCallbackWithSignature<Json, String, String>(
       "animationStateProperty", bind(&NetworkedAnimator::stateProperty, networkedAnimator, _1, _2));
+  callbacks.registerCallbackWithSignature<Json, String, String>(
+      "animationStateNextProperty", bind(&NetworkedAnimator::stateNextProperty, networkedAnimator, _1, _2));
   callbacks.registerCallbackWithSignature<int, String>(
       "animationState", bind(&NetworkedAnimator::state, networkedAnimator, _1));
   callbacks.registerCallbackWithSignature<int, String>(

--- a/source/game/scripting/StarScriptedAnimatorLuaBindings.hpp
+++ b/source/game/scripting/StarScriptedAnimatorLuaBindings.hpp
@@ -6,6 +6,6 @@
 namespace Star {
 
 namespace LuaBindings {
-  LuaCallbacks makeScriptedAnimatorCallbacks(const NetworkedAnimator* animator, function<Json(String const&, Json const&)> getParameter);
+  LuaCallbacks makeScriptedAnimatorCallbacks(NetworkedAnimator* networkedAnimator, function<Json(String const&, Json const&)> getParameter);
 }
 }


### PR DESCRIPTION
An expansion of features for the networked animator for better ease of use, some of which that would effect how the config loads or behaves are enabled by a 'version' at the config root, which will be used to keep compatibility with retail while allowing expansion of features

added checking for a table of 'includes' in the root of the config, which is to contain paths to other animation configs to merge underneath this one, intended to be used for making animations modular for different things that may share animation parts and states

added a fourth argument for setAnimationState to have the animation play in reverse

callback to set an animation state locally only, intended for use with the scripted animator

callbacks to retrieve the frame, frame progress, animation timer, and whether the animation is playing in reverse

callback to know the next frame property in advance, so in script one could be prepared for the next frame and do things like interpolate values by using the frame progress

callbacks for setting/adding lists of drawables to be attached to an animation part not networked, intended to be used with the scripted animator

callback for applying part tags to an input string

callback for setting a transformation on a transformation group locally, intended for use with the scripted animator, this will be better for some uses rather than using the networked transforms which can become de-synced with the animation frames on clients over time due to ping or simply for animations that don't need to be synced at all.

ability to configure transformations for transformation groups and parts in animation frame properties, and have them interpolate between each frame if the config is set to,
this uses an array of transform actions from the frame properties that are read and applied each update on the client locally, this guarantees that an animation that uses transformations in an entirely consistent manner frame to frame and doesn't need to be scripted will never have any de-syncs and will not have any extra network overhead

stateTypes check for if there are any properties that share a name with a transform group within their properties to apply to them

parts check for a 'transforms' property on themselves to apply

frame transforms are an array of actions, each action is an array where the first entry defines what transformation it is, and then following entries are the arguments for that transformation, scaling and rotation will check for an optional 'rotationCenter' and 'scalingCenter' property if the arg for their center isn't defined in their action



I am aware that many of the callbacks added to the `animationConfig` table no longer fit that name as they can now perform some functions that can actually effect the animations, and would be better suited to have a different table name and I am open to suggestions