### PR TITLE
Entity scaling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,11 +41,11 @@ _deps
 
 
 .vscode/*
-!.vscode/settings.json
-!.vscode/tasks.json
-!.vscode/launch.json
-!.vscode/extensions.json
-!.vscode/*.code-snippets
+# !.vscode/settings.json
+# !.vscode/tasks.json
+# !.vscode/launch.json
+# !.vscode/extensions.json
+# !.vscode/*.code-snippets
 
 # Local History for Visual Studio Code
 .history/

--- a/assets/opensb/scripts/opensb/player/commands.lua
+++ b/assets/opensb/scripts/opensb/player/commands.lua
@@ -49,4 +49,13 @@ register("headrotation", function(arg)
   end
 end)
 
+register("setScale", function(args)
+  if not args or args == "" then
+    mcontroller.setScale(1)
+  else
+    local scale = chat.parseArguments(args)
+    mcontroller.setScale(scale)
+  end
+end)
+
 module.register = register

--- a/source/core/StarDataStream.cpp
+++ b/source/core/StarDataStream.cpp
@@ -6,7 +6,7 @@
 
 namespace Star {
 
-unsigned const CurrentStreamVersion = 7; // update OpenProtocolVersion too!
+unsigned const CurrentStreamVersion = 8; // update OpenProtocolVersion too!
 
 DataStream::DataStream()
   : m_byteOrder(ByteOrder::BigEndian),

--- a/source/core/StarNetCompatibility.cpp
+++ b/source/core/StarNetCompatibility.cpp
@@ -2,6 +2,6 @@
 
 namespace Star {
 
-VersionNumber const OpenProtocolVersion = 7; // update StreamCompatibilityVersion too!
+VersionNumber const OpenProtocolVersion = 8; // update StreamCompatibilityVersion too!
 
 }

--- a/source/game/StarActorEntity.hpp
+++ b/source/game/StarActorEntity.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "StarEntity.hpp"
+#include "StarActorMovementController.hpp"
+#include "StarStatusController.hpp"
 
 STAR_CLASS(ActorMovementController);
 STAR_CLASS(StatusController);

--- a/source/game/StarActorEntity.hpp
+++ b/source/game/StarActorEntity.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "StarEntity.hpp"
+
+STAR_CLASS(ActorMovementController);
+STAR_CLASS(StatusController);
+
+namespace Star {
+
+class ActorEntity : public virtual Entity {
+public:
+  virtual ActorMovementController* movementController() = 0;
+  virtual StatusController* statusController() = 0;
+
+};
+
+}

--- a/source/game/StarHumanoid.cpp
+++ b/source/game/StarHumanoid.cpp
@@ -929,11 +929,16 @@ List<Drawable> Humanoid::render(bool withItems, bool withRotationAndScale) {
     addDrawable(Drawable::makeImage(AssetPath::split(image), 1.0f / TilePixels, true, {}));
   }
 
+  List<Drawable> nonRotatedDrawables;
   if (withItems) {
-    if (m_primaryHand.nonRotatedDrawables.size())
-      drawables.insertAllAt(0, m_primaryHand.nonRotatedDrawables);
-    if (m_altHand.nonRotatedDrawables.size())
-      drawables.insertAllAt(0, m_altHand.nonRotatedDrawables);
+    if (m_altHand.nonRotatedDrawables.size()) {
+      nonRotatedDrawables.appendAll(m_altHand.nonRotatedDrawables);
+    }
+    if (m_primaryHand.nonRotatedDrawables.size()) {
+      nonRotatedDrawables.appendAll(m_primaryHand.nonRotatedDrawables);
+    }
+    Drawable::translateAll(nonRotatedDrawables, m_globalOffset);
+    Drawable::rebaseAll(nonRotatedDrawables);
   }
 
   for (auto& drawable : drawables) {
@@ -946,6 +951,8 @@ List<Drawable> Humanoid::render(bool withItems, bool withRotationAndScale) {
     }
     drawable.rebase();
   }
+  drawables.insertAllAt(0, nonRotatedDrawables);
+
   return drawables;
 }
 

--- a/source/game/StarItemDrop.hpp
+++ b/source/game/StarItemDrop.hpp
@@ -13,7 +13,9 @@ namespace Star {
 STAR_CLASS(Item);
 STAR_CLASS(ItemDrop);
 
-class ItemDrop : public virtual MobileEntity {
+class ItemDrop :
+  public virtual MobileEntity,
+  public virtual Entity {
 public:
   // Creates a drop at the given position and adds a hard-coded amount of
   // randomness to the drop position / velocity.

--- a/source/game/StarItemDrop.hpp
+++ b/source/game/StarItemDrop.hpp
@@ -6,13 +6,14 @@
 #include "StarGameTimers.hpp"
 #include "StarEntity.hpp"
 #include "StarDrawable.hpp"
+#include "StarMobileEntity.hpp"
 
 namespace Star {
 
 STAR_CLASS(Item);
 STAR_CLASS(ItemDrop);
 
-class ItemDrop : public virtual Entity {
+class ItemDrop : public virtual MobileEntity {
 public:
   // Creates a drop at the given position and adds a hard-coded amount of
   // randomness to the drop position / velocity.
@@ -22,8 +23,8 @@ public:
   // Create a drop and throw in the given direction with a hard-coded initial
   // throw velocity (unrelated to magnitude of direction, direction is
   // normalized first).  Initially intangible for 1 second.
-  static ItemDropPtr throwDrop(ItemPtr const& item, Vec2F const& position, Vec2F const& velocity, Vec2F const& direction, bool eternal = false);
-  static ItemDropPtr throwDrop(ItemDescriptor const& itemDescriptor, Vec2F const& position, Vec2F const& velocity, Vec2F const& direction, bool eternal = false);
+  static ItemDropPtr throwDrop(ItemPtr const& item, Vec2F const& position, Vec2F const& velocity, Vec2F const& direction, float scale, bool eternal = false);
+  static ItemDropPtr throwDrop(ItemDescriptor const& itemDescriptor, Vec2F const& position, Vec2F const& velocity, Vec2F const& direction, float scale, bool eternal = false);
 
   ItemDrop(ItemPtr item);
   ItemDrop(Json const& diskStore);
@@ -82,6 +83,8 @@ public:
 
   Vec2F velocity() const;
   void setVelocity(Vec2F const& position);
+
+  MovementController* movementController() override;
 
 private:
   enum class Mode { Intangible, Available, Taken, Dead };

--- a/source/game/StarMobileEntity.hpp
+++ b/source/game/StarMobileEntity.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "StarEntity.hpp"
+
+STAR_CLASS(MovementController);
+
+namespace Star {
+
+class MobileEntity : public virtual Entity {
+public:
+  virtual MovementController* movementController() = 0;
+
+};
+
+}

--- a/source/game/StarMobileEntity.hpp
+++ b/source/game/StarMobileEntity.hpp
@@ -1,12 +1,14 @@
 #pragma once
 
 #include "StarEntity.hpp"
+#include "StarMovementController.hpp"
 
 STAR_CLASS(MovementController);
 
 namespace Star {
 
-class MobileEntity : public virtual Entity {
+class MobileEntity :
+  public virtual Entity {
 public:
   virtual MovementController* movementController() = 0;
 

--- a/source/game/StarMonster.cpp
+++ b/source/game/StarMonster.cpp
@@ -850,12 +850,12 @@ List<ChatAction> Monster::pullPendingChatActions() {
 List<PhysicsForceRegion> Monster::forceRegions() const {
   auto forceRegions = m_physicsForces.get();
   for (auto forceRegion : forceRegions) {
-    // if (auto dfr = as<DirectionalForceRegion>(&forceRegion)) {
-    //   dfr->region.scale(m_movementController->getScale());
-    // } else if (auto rfr = as<RadialForceRegion>(&forceRegion)) {
-    //   rfr->innerRadius *= m_movementController->getScale();
-    //   rfr->outerRadius *= m_movementController->getScale();
-    // }
+    if (auto dfr = forceRegion.ptr<DirectionalForceRegion>()) {
+      dfr->region.scale(m_movementController->getScale());
+    } else if (auto rfr = forceRegion.ptr<RadialForceRegion>()) {
+      rfr->innerRadius *= m_movementController->getScale();
+      rfr->outerRadius *= m_movementController->getScale();
+    }
   }
   return forceRegions;
 }

--- a/source/game/StarMonster.cpp
+++ b/source/game/StarMonster.cpp
@@ -850,12 +850,12 @@ List<ChatAction> Monster::pullPendingChatActions() {
 List<PhysicsForceRegion> Monster::forceRegions() const {
   auto forceRegions = m_physicsForces.get();
   for (auto forceRegion : forceRegions) {
-    if (auto dfr = as<DirectionalForceRegion>(&forceRegion)) {
-      dfr->region.scale(m_movementController->getScale());
-    } else if (auto rfr = as<RadialForceRegion>(&forceRegion)) {
-      rfr->innerRadius *= m_movementController->getScale();
-      rfr->outerRadius *= m_movementController->getScale();
-    }
+    // if (auto dfr = as<DirectionalForceRegion>(&forceRegion)) {
+    //   dfr->region.scale(m_movementController->getScale());
+    // } else if (auto rfr = as<RadialForceRegion>(&forceRegion)) {
+    //   rfr->innerRadius *= m_movementController->getScale();
+    //   rfr->outerRadius *= m_movementController->getScale();
+    // }
   }
   return forceRegions;
 }
@@ -880,6 +880,14 @@ Vec2F Monster::questIndicatorPosition() const {
   Vec2F pos = position() + m_questIndicatorOffset;
   pos[1] += collisionArea().yMax();
   return pos;
+}
+
+ActorMovementController* Monster::movementController() {
+  return m_movementController.get();
+}
+
+StatusController* Monster::statusController() {
+  return m_statusController.get();
 }
 
 }

--- a/source/game/StarMonster.hpp
+++ b/source/game/StarMonster.hpp
@@ -18,6 +18,7 @@
 #include "StarLuaComponents.hpp"
 #include "StarLuaAnimationComponent.hpp"
 #include "StarLuaActorMovementComponent.hpp"
+#include "StarActorEntity.hpp"
 
 namespace Star {
 
@@ -31,7 +32,8 @@ class Monster
     public virtual PhysicsEntity,
     public virtual NametagEntity,
     public virtual ChattyEntity,
-    public virtual InteractiveEntity {
+    public virtual InteractiveEntity,
+    public virtual ActorEntity {
 public:
   struct SkillInfo {
     String label;
@@ -132,6 +134,9 @@ public:
 
   using Entity::setKeepAlive;
   using Entity::setUniqueId;
+
+  virtual ActorMovementController* movementController() override;
+  virtual StatusController* statusController() override;
 
 private:
   Vec2F getAbsolutePosition(Vec2F relativePosition) const;

--- a/source/game/StarMovementController.hpp
+++ b/source/game/StarMovementController.hpp
@@ -108,6 +108,8 @@ public:
 
   float rotation() const;
 
+  float getScale() const;
+
   // CollisionPoly rotated and translated by position
   PolyF collisionBody() const;
 
@@ -154,6 +156,8 @@ public:
   void addMomentum(Vec2F const& momentum);
 
   void setRotation(float angle);
+
+  void setScale(float scale);
 
   // Apply one timestep of rotation.
   void rotate(float rotationRate);
@@ -266,6 +270,7 @@ private:
   NetElementFloat m_xVelocity;
   NetElementFloat m_yVelocity;
   NetElementFloat m_rotation;
+  NetElementFloat m_scale;
 
   NetElementBool m_colliding;
   NetElementBool m_collisionStuck;

--- a/source/game/StarNpc.cpp
+++ b/source/game/StarNpc.cpp
@@ -232,27 +232,27 @@ RectF Npc::metaBoundBox() const {
 
 Vec2F Npc::mouthOffset(bool ignoreAdjustments) const {
   return Vec2F{m_humanoid.mouthOffset(ignoreAdjustments)[0] * numericalDirection(m_humanoid.facingDirection()),
-      m_humanoid.mouthOffset(ignoreAdjustments)[1]};
+      m_humanoid.mouthOffset(ignoreAdjustments)[1]} * m_movementController->getScale();
 }
 
 Vec2F Npc::feetOffset() const {
-  return {m_humanoid.feetOffset()[0] * numericalDirection(m_humanoid.facingDirection()), m_humanoid.feetOffset()[1]};
+  return Vec2F{m_humanoid.feetOffset()[0] * numericalDirection(m_humanoid.facingDirection()), m_humanoid.feetOffset()[1]} * m_movementController->getScale();
 }
 
 Vec2F Npc::headArmorOffset() const {
-  return {m_humanoid.headArmorOffset()[0] * numericalDirection(m_humanoid.facingDirection()), m_humanoid.headArmorOffset()[1]};
+  return Vec2F{m_humanoid.headArmorOffset()[0] * numericalDirection(m_humanoid.facingDirection()), m_humanoid.headArmorOffset()[1]} * m_movementController->getScale();
 }
 
 Vec2F Npc::chestArmorOffset() const {
-  return {m_humanoid.chestArmorOffset()[0] * numericalDirection(m_humanoid.facingDirection()), m_humanoid.chestArmorOffset()[1]};
+  return Vec2F{m_humanoid.chestArmorOffset()[0] * numericalDirection(m_humanoid.facingDirection()), m_humanoid.chestArmorOffset()[1]} * m_movementController->getScale();
 }
 
 Vec2F Npc::backArmorOffset() const {
-  return {m_humanoid.backArmorOffset()[0] * numericalDirection(m_humanoid.facingDirection()), m_humanoid.backArmorOffset()[1]};
+  return Vec2F{m_humanoid.backArmorOffset()[0] * numericalDirection(m_humanoid.facingDirection()), m_humanoid.backArmorOffset()[1]} * m_movementController->getScale();
 }
 
 Vec2F Npc::legsArmorOffset() const {
-  return {m_humanoid.legsArmorOffset()[0] * numericalDirection(m_humanoid.facingDirection()), m_humanoid.legsArmorOffset()[1]};
+  return Vec2F{m_humanoid.legsArmorOffset()[0] * numericalDirection(m_humanoid.facingDirection()), m_humanoid.legsArmorOffset()[1]} * m_movementController->getScale();
 }
 
 RectF Npc::collisionArea() const {

--- a/source/game/StarNpc.cpp
+++ b/source/game/StarNpc.cpp
@@ -382,6 +382,8 @@ void Npc::update(float dt, uint64_t) {
   m_movementController->setTimestep(dt);
 
   if (isMaster()) {
+    m_statusController->setScale(m_movementController->getScale());
+
     m_scriptComponent.update(m_scriptComponent.updateDt(dt));
 
     if (inConflictingLoungeAnchor())
@@ -492,7 +494,7 @@ void Npc::render(RenderCallback* renderCallback) {
     scale = scale.piecewiseMultiply(result.first);
     humanoidDirectives.append(result.second);
   }
-  m_humanoid.setScale(scale);
+  m_humanoid.setScale(scale * m_movementController->getScale());
 
   for (auto& drawable : m_humanoid.render()) {
     drawable.translate(position());
@@ -1140,8 +1142,10 @@ List<DamageSource> Npc::damageSources() const {
       config = config.set("poly", jsonFromPolyF(m_movementController->collisionPoly()));
     }
     DamageSource damageSource(config);
-    if (auto damagePoly = damageSource.damageArea.ptr<PolyF>())
+    if (auto damagePoly = damageSource.damageArea.ptr<PolyF>()) {
       damagePoly->rotate(m_movementController->rotation());
+      damagePoly->scale(m_movementController->getScale());
+    }
     damageSource.damage *= m_statusController->stat("powerMultiplier");
     damageSources.append(damageSource);
   }

--- a/source/game/StarPlantDrop.cpp
+++ b/source/game/StarPlantDrop.cpp
@@ -379,4 +379,9 @@ bool PlantDrop::shouldDestroy() const {
   return m_time <= 0.0f;
 }
 
+MovementController* PlantDrop::movementController() {
+  return &m_movementController;
+}
+
+
 }

--- a/source/game/StarPlantDrop.hpp
+++ b/source/game/StarPlantDrop.hpp
@@ -11,7 +11,9 @@ namespace Star {
 STAR_CLASS(RenderCallback);
 STAR_CLASS(PlantDrop);
 
-class PlantDrop : public virtual MobileEntity {
+class PlantDrop :
+  public virtual MobileEntity,
+  public virtual Entity {
 public:
   PlantDrop(List<Plant::PlantPiece> pieces, Vec2F const& position, Vec2F const& strikeVector, String const& description,
       bool upsideDown, Json stemConfig, Json foliageConfig, Json saplingConfig,

--- a/source/game/StarPlantDrop.hpp
+++ b/source/game/StarPlantDrop.hpp
@@ -4,13 +4,14 @@
 #include "StarMovementController.hpp"
 #include "StarPlant.hpp"
 #include "StarAssetPath.hpp"
+#include "StarMobileEntity.hpp"
 
 namespace Star {
 
 STAR_CLASS(RenderCallback);
 STAR_CLASS(PlantDrop);
 
-class PlantDrop : public virtual Entity {
+class PlantDrop : public virtual MobileEntity {
 public:
   PlantDrop(List<Plant::PlantPiece> pieces, Vec2F const& position, Vec2F const& strikeVector, String const& description,
       bool upsideDown, Json stemConfig, Json foliageConfig, Json saplingConfig,
@@ -46,6 +47,8 @@ public:
   void update(float dt, uint64_t currentStep) override;
 
   void render(RenderCallback* renderCallback) override;
+
+  MovementController* movementController() override;
 
 private:
   struct PlantDropPiece {

--- a/source/game/StarPlayer.cpp
+++ b/source/game/StarPlayer.cpp
@@ -627,31 +627,31 @@ Vec2F Player::velocity() const {
 
 Vec2F Player::mouthOffset(bool ignoreAdjustments) const {
   return Vec2F(
-      m_humanoid->mouthOffset(ignoreAdjustments)[0] * numericalDirection(facingDirection()), m_humanoid->mouthOffset(ignoreAdjustments)[1]);
+      m_humanoid->mouthOffset(ignoreAdjustments)[0] * numericalDirection(facingDirection()), m_humanoid->mouthOffset(ignoreAdjustments)[1]) * m_movementController->getScale();
 }
 
 Vec2F Player::feetOffset() const {
-  return Vec2F(m_humanoid->feetOffset()[0] * numericalDirection(facingDirection()), m_humanoid->feetOffset()[1]);
+  return Vec2F(m_humanoid->feetOffset()[0] * numericalDirection(facingDirection()), m_humanoid->feetOffset()[1]) * m_movementController->getScale();
 }
 
 Vec2F Player::headArmorOffset() const {
   return Vec2F(
-      m_humanoid->headArmorOffset()[0] * numericalDirection(facingDirection()), m_humanoid->headArmorOffset()[1]);
+      m_humanoid->headArmorOffset()[0] * numericalDirection(facingDirection()), m_humanoid->headArmorOffset()[1]) * m_movementController->getScale();
 }
 
 Vec2F Player::chestArmorOffset() const {
   return Vec2F(
-      m_humanoid->chestArmorOffset()[0] * numericalDirection(facingDirection()), m_humanoid->chestArmorOffset()[1]);
+      m_humanoid->chestArmorOffset()[0] * numericalDirection(facingDirection()), m_humanoid->chestArmorOffset()[1]) * m_movementController->getScale();
 }
 
 Vec2F Player::backArmorOffset() const {
   return Vec2F(
-      m_humanoid->backArmorOffset()[0] * numericalDirection(facingDirection()), m_humanoid->backArmorOffset()[1]);
+      m_humanoid->backArmorOffset()[0] * numericalDirection(facingDirection()), m_humanoid->backArmorOffset()[1]) * m_movementController->getScale();
 }
 
 Vec2F Player::legsArmorOffset() const {
   return Vec2F(
-      m_humanoid->legsArmorOffset()[0] * numericalDirection(facingDirection()), m_humanoid->legsArmorOffset()[1]);
+      m_humanoid->legsArmorOffset()[0] * numericalDirection(facingDirection()), m_humanoid->legsArmorOffset()[1]) * m_movementController->getScale();
 }
 
 Vec2F Player::mouthPosition() const {

--- a/source/game/StarPlayer.cpp
+++ b/source/game/StarPlayer.cpp
@@ -839,7 +839,6 @@ void Player::update(float dt, uint64_t) {
   if (isMaster()) {
     m_statusController->setScale(m_movementController->getScale());
     m_techController->setScale(m_movementController->getScale());
-
     if (m_emoteCooldownTimer) {
       m_emoteCooldownTimer -= dt;
       if (m_emoteCooldownTimer <= 0) {

--- a/source/game/StarPlayer.hpp
+++ b/source/game/StarPlayer.hpp
@@ -106,6 +106,8 @@ public:
 
   Vec2F mouthPosition() const override;
   Vec2F mouthPosition(bool ignoreAdjustments) const override;
+  Vec2F throwItemPosition() const;
+  Vec2F interactPosition() const;
   Vec2F mouthOffset(bool ignoreAdjustments = true) const;
   Vec2F feetOffset() const;
   Vec2F headArmorOffset() const;
@@ -493,7 +495,7 @@ public:
   //   Unfortunately values are Strings, so to work with Json we need to serialize/deserialize. Whatever.
   //   Additionally, this is compatible with vanilla networking.
   // I call this a 'secret property'.
-  
+
   // If the secret property exists as a serialized Json string, returns a view to it without deserializing.
   Maybe<StringView> getSecretPropertyView(String const& name) const;
   // Gets a secret Json property. It will be de-serialized.

--- a/source/game/StarProjectile.cpp
+++ b/source/game/StarProjectile.cpp
@@ -483,12 +483,12 @@ List<PhysicsForceRegion> Projectile::forceRegions() const {
   for (auto const& p : m_physicsForces) {
     if (p.second.enabled.get()) {
       PhysicsForceRegion forceRegion = p.second.forceRegion;
-      if (auto dfr = as<DirectionalForceRegion>(&forceRegion)) {
-        dfr->region.scale(m_movementController->getScale());
-      } else if (auto rfr = as<RadialForceRegion>(&forceRegion)) {
-        rfr->innerRadius *= m_movementController->getScale();
-        rfr->outerRadius *= m_movementController->getScale();
-      }
+      // if (auto dfr = as<DirectionalForceRegion>(&forceRegion)) {
+      //   dfr->region.scale(m_movementController->getScale());
+      // } else if (auto rfr = as<RadialForceRegion>(&forceRegion)) {
+      //   rfr->innerRadius *= m_movementController->getScale();
+      //   rfr->outerRadius *= m_movementController->getScale();
+      // }
       forceRegion.call([pos = position()](auto& fr) {
         fr.translate(pos);
       });
@@ -1036,5 +1036,10 @@ void Projectile::renderPendingRenderables(RenderCallback* renderCallback) {
   }
   m_pendingRenderables.clear();
 }
+
+MovementController* Projectile::movementController() {
+  return m_movementController.get();
+}
+
 
 }

--- a/source/game/StarProjectile.hpp
+++ b/source/game/StarProjectile.hpp
@@ -10,6 +10,7 @@
 #include "StarMovementController.hpp"
 #include "StarParticle.hpp"
 #include "StarLuaComponents.hpp"
+#include "StarMobileEntity.hpp"
 
 namespace Star {
 
@@ -19,7 +20,12 @@ STAR_STRUCT(ProjectileConfig);
 
 STAR_CLASS(Projectile);
 
-class Projectile : public virtual Entity, public virtual ScriptedEntity, public virtual PhysicsEntity, public virtual StatusEffectEntity {
+class Projectile :
+  public virtual Entity,
+  public virtual ScriptedEntity,
+  public virtual PhysicsEntity,
+  public virtual StatusEffectEntity,
+  public virtual MobileEntity {
 public:
   Projectile(ProjectileConfigPtr const& config, Json const& parameters);
   Projectile(ProjectileConfigPtr const& config, DataStreamBuffer& netState, NetCompatibilityRules rules = {});
@@ -99,6 +105,8 @@ public:
   Maybe<PhysicsMovingCollision> movingCollision(size_t positionIndex) const override;
 
   using Entity::setTeam;
+
+  MovementController* movementController() override;
 
 private:
   struct PhysicsForceConfig {

--- a/source/game/StarStatusController.cpp
+++ b/source/game/StarStatusController.cpp
@@ -853,4 +853,10 @@ LuaCallbacks StatusController::makeUniqueEffectCallbacks(UniqueEffectInstance& u
   return callbacks;
 }
 
+void StatusController::setScale(float scale) {
+  for (auto const& animator : m_effectAnimators.netElements()) {
+    animator->animator.setZoom(scale);
+  }
+}
+
 }

--- a/source/game/StarStatusController.hpp
+++ b/source/game/StarStatusController.hpp
@@ -129,6 +129,8 @@ public:
 
   Maybe<Json> receiveMessage(String const& message, bool localMessage, JsonArray const& args = {});
 
+  void setScale(float scale);
+
 private:
   typedef LuaMessageHandlingComponent<LuaActorMovementComponent<LuaUpdatableComponent<LuaWorldComponent<LuaBaseComponent>>>> StatScript;
 

--- a/source/game/StarTechController.cpp
+++ b/source/game/StarTechController.cpp
@@ -544,4 +544,10 @@ LuaCallbacks TechController::makeTechCallbacks(TechModule& techModule) {
   return callbacks;
 }
 
+void TechController::setScale(float scale) {
+  for (auto const& animator : m_techAnimators.netElements()) {
+    animator->animator.setZoom(scale);
+  }
+}
+
 }

--- a/source/game/StarTechController.hpp
+++ b/source/game/StarTechController.hpp
@@ -84,6 +84,8 @@ public:
 
   Maybe<Json> receiveMessage(String const& message, bool localMessage, JsonArray const& args = {});
 
+  void setScale(float scale);
+
 private:
   struct TechAnimator : public NetElement {
     TechAnimator(Maybe<String> animationConfig = {});

--- a/source/game/StarToolUser.cpp
+++ b/source/game/StarToolUser.cpp
@@ -331,9 +331,9 @@ void ToolUser::setupHumanoidHandItemDrawables(Humanoid& humanoid) const {
 
 Vec2F ToolUser::armPosition(Humanoid const& humanoid, ToolHand hand, Direction facingDirection, float armAngle, Vec2F offset) const {
   if (hand == ToolHand::Primary)
-    return humanoid.primaryArmPosition(facingDirection, armAngle, offset);
+    return humanoid.primaryArmPosition(facingDirection, armAngle, offset) * m_user->movementController()->getScale();
   else
-    return humanoid.altArmPosition(facingDirection, armAngle, offset);
+    return humanoid.altArmPosition(facingDirection, armAngle, offset) * m_user->movementController()->getScale();
 }
 
 Vec2F ToolUser::handOffset(Humanoid const& humanoid, ToolHand hand, Direction direction) const {
@@ -345,9 +345,9 @@ Vec2F ToolUser::handOffset(Humanoid const& humanoid, ToolHand hand, Direction di
 
 Vec2F ToolUser::handPosition(ToolHand hand, Humanoid const& humanoid, Vec2F const& handOffset) const {
   if (hand == ToolHand::Primary)
-    return humanoid.primaryHandPosition(handOffset);
+    return humanoid.primaryHandPosition(handOffset) * m_user->movementController()->getScale();
   else
-    return humanoid.altHandPosition(handOffset);
+    return humanoid.altHandPosition(handOffset) * m_user->movementController()->getScale();
 }
 
 bool ToolUser::queryShieldHit(DamageSource const& source) const {
@@ -602,7 +602,7 @@ Maybe<Json> ToolUser::receiveMessage(String const& message, bool localMessage, J
 }
 
 float ToolUser::beamGunRadius() const {
-  return m_beamGunRadius + m_user->statusController()->statusProperty("bonusBeamGunRadius", 0).toFloat();
+  return (m_beamGunRadius + m_user->statusController()->statusProperty("bonusBeamGunRadius", 0).toFloat()) * m_user->movementController()->getScale();
 }
 
 void ToolUser::NetItem::initNetVersion(NetElementVersion const* version) {

--- a/source/game/StarVehicle.cpp
+++ b/source/game/StarVehicle.cpp
@@ -270,6 +270,8 @@ void Vehicle::update(float dt, uint64_t) {
 
   if (isMaster()) {
     m_movementController.tickMaster(dt);
+    m_networkedAnimator.setZoom(m_movementController.getScale());
+
     m_scriptComponent.update(m_scriptComponent.updateDt(dt));
 
     eraseWhere(m_aliveMasterConnections, [](auto& p) {
@@ -650,5 +652,10 @@ LuaCallbacks Vehicle::makeVehicleCallbacks() {
 Json Vehicle::configValue(String const& name, Json def) const {
   return jsonMergeQueryDef(name, std::move(def), m_baseConfig, m_dynamicConfig);
 }
+
+MovementController* Vehicle::movementController() {
+  return &m_movementController;
+}
+
 
 }

--- a/source/game/StarVehicle.hpp
+++ b/source/game/StarVehicle.hpp
@@ -20,7 +20,8 @@ class Vehicle :
   public virtual InteractiveEntity,
   public virtual PhysicsEntity,
   public virtual ScriptedEntity,
-  public virtual MobileEntity {
+  public virtual MobileEntity,
+  public virtual Entity {
 public:
   Vehicle(Json baseConfig, String path, Json dynamicConfig);
 

--- a/source/game/StarVehicle.hpp
+++ b/source/game/StarVehicle.hpp
@@ -8,13 +8,19 @@
 #include "StarLoungingEntities.hpp"
 #include "StarScriptedEntity.hpp"
 #include "StarLuaAnimationComponent.hpp"
+#include "StarMobileEntity.hpp"
 
 namespace Star {
 
 STAR_EXCEPTION(VehicleException, StarException);
 STAR_CLASS(Vehicle);
 
-class Vehicle : public virtual LoungeableEntity, public virtual InteractiveEntity, public virtual PhysicsEntity, public virtual ScriptedEntity {
+class Vehicle :
+  public virtual LoungeableEntity,
+  public virtual InteractiveEntity,
+  public virtual PhysicsEntity,
+  public virtual ScriptedEntity,
+  public virtual MobileEntity {
 public:
   Vehicle(Json baseConfig, String path, Json dynamicConfig);
 
@@ -80,6 +86,8 @@ public:
   Maybe<LuaValue> evalScript(String const& code) override;
 
   void setPosition(Vec2F const& position);
+
+  MovementController* movementController() override;
 
 private:
   struct MasterControlState {
@@ -157,7 +165,7 @@ private:
   NetworkedAnimator m_networkedAnimator;
   NetworkedAnimator::DynamicTarget m_networkedAnimatorDynamicTarget;
   LuaMessageHandlingComponent<LuaStorableComponent<LuaUpdatableComponent<LuaWorldComponent<LuaBaseComponent>>>> m_scriptComponent;
-  
+
   LuaAnimationComponent<LuaUpdatableComponent<LuaWorldComponent<LuaBaseComponent>>> m_scriptedAnimator;
   NetElementHashMap<String, Json> m_scriptedAnimationParameters;
 

--- a/source/game/StarWorldClient.cpp
+++ b/source/game/StarWorldClient.cpp
@@ -343,9 +343,9 @@ TileModificationList WorldClient::validTileModifications(TileModificationList co
 TileModificationList WorldClient::applyTileModifications(TileModificationList const& modificationList, bool allowEntityOverlap) {
   if (!inWorld())
     return {};
-  
+
   // thanks to new prediction: do each one by one so that previous modifications affect placeability
-  
+
   TileModificationList success, failures, temp;
   TileModificationList const* list = &modificationList;
 
@@ -382,12 +382,12 @@ TileModificationList WorldClient::applyTileModifications(TileModificationList co
 TileModificationList WorldClient::replaceTiles(TileModificationList const& modificationList, TileDamage const& tileDamage, bool applyDamage) {
   if (!inWorld())
     return {};
-  
+
   // Tell client it can't send a replace packet
   auto netRules = m_clientState.netCompatibilityRules();
   if (netRules.isLegacy() || netRules.version() <= 3)
     return modificationList;
-  
+
   TileModificationList success, failures;
   for (auto pair : modificationList) {
     if (!isTileProtected(pair.first) && WorldImpl::validateTileReplacement(pair.second))
@@ -531,7 +531,7 @@ void WorldClient::render(WorldRenderData& renderData, unsigned bufferTiles) {
       try { entity->render(&renderCallback); }
       catch (StarException const& e) {
         if (entity->isMaster()) // this is YOUR problem!!
-          throw e; 
+          throw e;
         else { // this is THEIR problem!!
           Logger::error("WorldClient: Exception caught in {}::render ({}): {}", EntityTypeNames.getRight(entity->entityType()), entity->entityId(), e.what());
           auto toolUser = as<ToolUserEntity>(entity);
@@ -542,7 +542,7 @@ void WorldClient::render(WorldRenderData& renderData, unsigned bufferTiles) {
           renderCallback.addDrawable(std::move(drawable), RenderLayerMiddleParticle);
         }
       }
-      
+
 
       EntityDrawables ed;
       for (auto& p : renderCallback.drawables) {
@@ -576,7 +576,7 @@ void WorldClient::render(WorldRenderData& renderData, unsigned bufferTiles) {
         for (auto& p : renderCallback.particles)
           p.directives.append(directives->get(directiveIndex));
       }
-      
+
       m_particles->addParticles(std::move(renderCallback.particles));
       m_samples.appendAll(std::move(renderCallback.audios));
       m_previewTiles.appendAll(std::move(renderCallback.previewTiles));
@@ -1098,7 +1098,7 @@ void WorldClient::handleIncomingPackets(List<PacketPtr> const& packets) {
     } else if (auto pongPacket = as<PongPacket>(packet)) {
       if (pongPacket->time)
         m_latency = Time::monotonicMilliseconds() - pongPacket->time;
-      else if (m_pingTime) 
+      else if (m_pingTime)
         m_latency = Time::monotonicMilliseconds() - m_pingTime.take();
 
     } else {
@@ -1163,7 +1163,7 @@ void WorldClient::update(float dt) {
       try { entity->update(dt, m_currentStep); }
       catch (StarException const& e) {
         if (entity->isMaster()) // this is YOUR problem!!
-          throw e; 
+          throw e;
         else // this is THEIR problem!!
           Logger::error("WorldClient: Exception caught in {}::update ({}): {}", EntityTypeNames.getRight(entity->entityType()), entity->entityId(), e.what());
       }
@@ -1197,12 +1197,14 @@ void WorldClient::update(float dt) {
       m_requestedDrops.clear();
 
     Vec2F playerPos = m_mainPlayer->position();
-    auto dropList = m_entityMap->query<ItemDrop>(RectF(playerPos - Vec2F::filled(DropDist / 2), playerPos + Vec2F::filled(DropDist / 2)));
+    // being smaller should decrease your pickup range, being larger shouldn't extend it that much further
+    auto pickupArea = m_mainPlayer->movementController()->collisionBoundBox().expanded(DropDist / 2 * clamp<float>(m_mainPlayer->movementController()->getScale(), 0, 1.5));
+    auto dropList = m_entityMap->query<ItemDrop>(pickupArea);
     for (auto itemDrop : dropList) {
       auto distSquared = m_geometry.diff(itemDrop->position(), playerPos).magnitudeSquared();
 
       // If the drop is within DropDist and not owned, request it.
-      if (itemDrop->canTake() && !m_requestedDrops.contains(itemDrop->entityId()) && distSquared < square(DropDist)) {
+      if (itemDrop->canTake() && !m_requestedDrops.contains(itemDrop->entityId()) && distSquared < square(pickupArea.width())) {
         m_requestedDrops.add(itemDrop->entityId());
         if (m_mainPlayer->itemsCanHold(itemDrop->item()) != 0) {
           m_startupHiddenEntities.erase(itemDrop->entityId());
@@ -1570,9 +1572,9 @@ void WorldClient::handleDamageNotifications() {
       // default to normal hit
       HitType effectHitType = damageKind.effects.get(material).contains(damageNotification.hitType) ? damageNotification.hitType : HitType::Hit;
       m_samples.appendAll(soundsFromDefinition(damageKind.effects.get(material).get(effectHitType).sounds, damageNotification.position));
-      
+
       auto hitParticles = particlesFromDefinition(damageKind.effects.get(material).get(effectHitType).particles, damageNotification.position);
-      
+
       const List<Directives>* directives = nullptr;
       if (auto& worldTemplate = m_worldTemplate) {
         if (const auto& parameters = worldTemplate->worldParameters())
@@ -1584,7 +1586,7 @@ void WorldClient::handleDamageNotifications() {
         for (auto& p : hitParticles)
           p.directives.append(directives->get(directiveIndex));
       }
-      
+
       m_particles->addParticles(hitParticles);
     }
   }
@@ -1826,7 +1828,7 @@ void WorldClient::initWorld(WorldStartPacket const& startPacket) {
   m_lightIntensityCalculator.setParameters(assets->json("/lighting.config:intensity"));
 
   m_inWorld = true;
-  
+
   if (!m_mainPlayer->isDead()) {
     m_mainPlayer->init(this, m_entityMap->reserveEntityId(), EntityMode::Master);
     m_entityMap->addEntity(m_mainPlayer);

--- a/source/game/interfaces/StarBeamItem.cpp
+++ b/source/game/interfaces/StarBeamItem.cpp
@@ -176,7 +176,7 @@ List<Drawable> BeamItem::beamDrawables(bool canPlace) const {
           endImage = strf("{}?{}", endImage, imageOperationToString(op));
         }
 
-        Drawable ball = Drawable::makeImage(endImage, 1.0f / TilePixels, true, m_beamCurve.dest());
+        Drawable ball = Drawable::makeImage(endImage, owner()->movementController()->getScale() / TilePixels, true, m_beamCurve.dest());
         Color ballColor = Color::White;
         ballColor.setAlphaF(getAppropriateOpacity());
         ball.color = ballColor;
@@ -184,7 +184,7 @@ List<Drawable> BeamItem::beamDrawables(bool canPlace) const {
       }
 
       for (auto line = 0; line < numLines; line++) {
-        float lineThickness = rangeRand(m_beamWidthDev, m_minBeamWidth, m_maxBeamWidth);
+        float lineThickness = rangeRand(m_beamWidthDev, m_minBeamWidth, m_maxBeamWidth) * owner()->movementController()->getScale();
         float beamTransparency = rangeRand(m_beamTransDev, m_minBeamTrans, m_maxBeamTrans);
         mainColor.setAlphaF(mainColor.alphaF() * beamTransparency);
         Vec2F previousLoc = m_beamCurve.origin(); // lines meet at origin and dest.

--- a/source/game/interfaces/StarToolUserEntity.hpp
+++ b/source/game/interfaces/StarToolUserEntity.hpp
@@ -4,6 +4,7 @@
 #include "StarParticle.hpp"
 #include "StarStatusTypes.hpp"
 #include "StarInteractionTypes.hpp"
+#include "StarActorEntity.hpp"
 
 namespace Star {
 
@@ -13,7 +14,7 @@ STAR_CLASS(ActorMovementController);
 STAR_CLASS(StatusController);
 
 // FIXME: This interface is a complete mess.
-class ToolUserEntity : public virtual Entity {
+class ToolUserEntity : public virtual ActorEntity {
 public:
   // Translates the given arm position into it's final entity space position
   // based on the given facing direction, and arm angle, and an offset from the
@@ -31,8 +32,8 @@ public:
 
   virtual void requestEmote(String const& emote) = 0;
 
-  virtual ActorMovementController* movementController() = 0;
-  virtual StatusController* statusController() = 0;
+  virtual ActorMovementController* movementController() override;
+  virtual StatusController* statusController() override;
 
   // FIXME: This is effectively unusable, because since tool user items control
   // the angle and facing direction of the owner, and this uses the facing

--- a/source/game/interfaces/StarToolUserEntity.hpp
+++ b/source/game/interfaces/StarToolUserEntity.hpp
@@ -14,7 +14,9 @@ STAR_CLASS(ActorMovementController);
 STAR_CLASS(StatusController);
 
 // FIXME: This interface is a complete mess.
-class ToolUserEntity : public virtual ActorEntity {
+class ToolUserEntity :
+  public virtual Entity,
+  public virtual ActorEntity{
 public:
   // Translates the given arm position into it's final entity space position
   // based on the given facing direction, and arm angle, and an offset from the
@@ -31,9 +33,6 @@ public:
   virtual String species() const = 0;
 
   virtual void requestEmote(String const& emote) = 0;
-
-  virtual ActorMovementController* movementController() override;
-  virtual StatusController* statusController() override;
 
   // FIXME: This is effectively unusable, because since tool user items control
   // the angle and facing direction of the owner, and this uses the facing

--- a/source/game/items/StarActiveItem.cpp
+++ b/source/game/items/StarActiveItem.cpp
@@ -172,12 +172,14 @@ List<DamageSource> ActiveItem::damageSources() const {
     if (ds.damageArea.is<PolyF>()) {
       auto& poly = ds.damageArea.get<PolyF>();
       poly.rotate(m_armAngle.get());
+      poly.scale(owner()->movementController()->getScale());
       if (owner()->facingDirection() == Direction::Left)
         poly.flipHorizontal(0.0f);
       poly.translate(handPosition(Vec2F()));
     } else if (ds.damageArea.is<Line2F>()) {
       auto& line = ds.damageArea.get<Line2F>();
       line.rotate(m_armAngle.get());
+      line.scale(owner()->movementController()->getScale());
       if (owner()->facingDirection() == Direction::Left)
         line.flipHorizontal(0.0f);
       line.translate(handPosition(Vec2F()));
@@ -191,6 +193,7 @@ List<PolyF> ActiveItem::shieldPolys() const {
   List<PolyF> shieldPolys = m_shieldPolys.get();
   for (auto sp : m_itemShieldPolys.get()) {
     sp.rotate(m_armAngle.get());
+    sp.scale(owner()->movementController()->getScale());
     if (owner()->facingDirection() == Direction::Left)
       sp.flipHorizontal(0.0f);
     sp.translate(handPosition(Vec2F()));
@@ -204,11 +207,14 @@ List<PhysicsForceRegion> ActiveItem::forceRegions() const {
   for (auto fr : m_itemForceRegions.get()) {
     if (auto dfr = fr.ptr<DirectionalForceRegion>()) {
       dfr->region.rotate(m_armAngle.get());
+      dfr->region.scale(owner()->movementController()->getScale());
       if (owner()->facingDirection() == Direction::Left)
         dfr->region.flipHorizontal(0.0f);
       dfr->region.translate(owner()->position() + handPosition(Vec2F()));
     } else if (auto rfr = fr.ptr<RadialForceRegion>()) {
       rfr->center = rfr->center.rotate(m_armAngle.get());
+      rfr->innerRadius *= owner()->movementController()->getScale();
+      rfr->outerRadius *= owner()->movementController()->getScale();
       if (owner()->facingDirection() == Direction::Left)
         rfr->center[0] *= -1;
       rfr->center += owner()->position() + handPosition(Vec2F());

--- a/source/game/items/StarLiquidItem.cpp
+++ b/source/game/items/StarLiquidItem.cpp
@@ -55,7 +55,7 @@ void LiquidItem::fire(FireMode mode, bool shifting, bool edgeTriggered) {
   float radius;
 
   if (!shifting)
-    radius = m_blockRadius;
+    radius = max(m_blockRadius * owner()->movementController()->getScale(), 1.0f);
   else
     radius = m_altBlockRadius;
 
@@ -92,7 +92,7 @@ List<PreviewTile> LiquidItem::previewTiles(bool shifting) const {
 
     float radius;
     if (!shifting)
-      radius = m_blockRadius;
+      radius = max(m_blockRadius * owner()->movementController()->getScale(), 1.0f);
     else
       radius = m_altBlockRadius;
 
@@ -116,7 +116,7 @@ bool LiquidItem::canPlace(bool shifting) const {
   if (initialized()) {
     float radius;
     if (!shifting)
-      radius = m_blockRadius;
+      radius = max(m_blockRadius * owner()->movementController()->getScale(), 1.0f);
     else
       radius = m_altBlockRadius;
 

--- a/source/game/items/StarMaterialItem.cpp
+++ b/source/game/items/StarMaterialItem.cpp
@@ -214,7 +214,7 @@ void MaterialItem::fire(FireMode mode, bool shifting, bool edgeTriggered) {
 
   if (m_blockSwap && owner()->inToolRange(aimPosition))
     total += blockSwap(radius, layer);
-  
+
   for (unsigned i = 0; i != steps; ++i) {
     auto placementOrigin = aimPosition + diff * (1.0f - (static_cast<float>(i) / steps));
     if (!owner()->inToolRange(placementOrigin))
@@ -251,11 +251,11 @@ size_t MaterialItem::blockSwap(float radius, TileLayer layer) {
   Player* player = as<Player>(owner());
   if (!player)
     return 0;
-  
+
   ItemPtr beamAxePtr = player->essentialItem(EssentialItem::BeamAxe);
   if (!beamAxePtr)
     return 0;
-  
+
   Item* beamAxe = beamAxePtr.get();
 
   List<Vec2I> swapPositions;
@@ -286,7 +286,7 @@ size_t MaterialItem::blockSwap(float radius, TileLayer layer) {
     if (!world()->damageWouldDestroy(pos, layer, damage))
       willDamage.append(pos);
   }
-  
+
   size_t success;
   size_t failed = world()->replaceTiles(toSwap, damage, true).size();
 
@@ -298,7 +298,7 @@ size_t MaterialItem::blockSwap(float radius, TileLayer layer) {
 
     for (auto pair : toSwap)
       toDamage.append(pair.first);
-    
+
     world()->damageTiles(toDamage, layer, owner()->position(), damage, owner()->entityId());
   }
 
@@ -336,7 +336,7 @@ size_t MaterialItem::blockSwap(float radius, TileLayer layer) {
 
   if (FireableItem* item = as<FireableItem>(beamAxe))
     setFireTimer(item->windupTime() + item->cooldownTime());
-  
+
   return success;
 }
 
@@ -397,7 +397,7 @@ void MaterialItem::updatePropertiesFromPlayer(Player* player) {
   auto collisionOverride = player->getSecretProperty(CollisionOverridePropertyKey);
   if (collisionOverride.isType(Json::Type::String))
     m_collisionOverride = TileCollisionOverrideNames.maybeLeft(collisionOverride.toString()).value(TileCollisionOverride::None);
-  
+
   auto blockSwap = player->getSecretProperty(BlockSwapPropertyKey);
   if (blockSwap.isType(Json::Type::Bool))
     m_blockSwap = blockSwap.toBool();
@@ -407,7 +407,7 @@ float MaterialItem::calcRadius(bool shifting) const {
   if (!multiplaceEnabled())
     return 1;
   else
-    return !shifting ? m_blockRadius : m_altBlockRadius;
+    return !shifting ? (m_blockRadius * owner()->movementController()->getScale(), 1.0f) : m_altBlockRadius;
 }
 
 List<Vec2I>& MaterialItem::tileArea(float radius, Vec2F const& position) const {

--- a/source/game/items/StarTools.cpp
+++ b/source/game/items/StarTools.cpp
@@ -57,7 +57,7 @@ void MiningTool::fire(FireMode mode, bool shifting, bool edgeTriggered) {
 
   if (initialized()) {
     bool used = false;
-    int radius = !shifting ? m_blockRadius : m_altBlockRadius;
+    int radius = !shifting ? (m_blockRadius * owner()->movementController()->getScale(), 1.0f) : m_altBlockRadius;
     String blockSound;
     List<Vec2I> brushArea;
 
@@ -371,7 +371,7 @@ List<PreviewTile> BeamMiningTool::previewTiles(bool shifting) const {
       if (!ready())
         lightColor *= Color::rgbaf(0.75f, 0.75f, 0.75f, 1.0f);
       Vec3B light = lightColor.toRgb();
-      int radius = !shifting ? m_blockRadius : m_altBlockRadius;
+      int radius = !shifting ? (m_blockRadius * owner()->movementController()->getScale(), 1.0f) : m_altBlockRadius;
       for (auto pos : tileAreaBrush(radius, ownerp->aimPosition(), true)) {
         if (worldp->tileIsOccupied(pos, TileLayer::Foreground, true)) {
           result.append({pos, true, light, true});
@@ -414,7 +414,7 @@ void BeamMiningTool::fire(FireMode mode, bool shifting, bool edgeTriggered) {
   auto ownerp = owner();
   if (ownerp && worldp) {
     bool used = false;
-    int radius = !shifting ? m_blockRadius : m_altBlockRadius;
+    int radius = !shifting ? (m_blockRadius * owner()->movementController()->getScale(), 1.0f) : m_altBlockRadius;
     String blockSound;
     List<Vec2I> brushArea;
 
@@ -646,7 +646,7 @@ List<PreviewTile> PaintingBeamTool::previewTiles(bool shifting) const {
     Vec3B light = Color::White.toRgb();
 
     if (ownerp->isAdmin() || ownerp->inToolRange()) {
-      int radius = !shifting ? m_blockRadius : m_altBlockRadius;
+      int radius = !shifting ? (m_blockRadius * owner()->movementController()->getScale(), 1.0f) : m_altBlockRadius;
 
       for (auto pos : tileAreaBrush(radius, ownerp->aimPosition(), true)) {
         if (worldp->canModifyTile(pos, PlaceMaterialColor{TileLayer::Foreground, (MaterialColorVariant)m_colorIndex}, true)) {
@@ -693,7 +693,7 @@ void PaintingBeamTool::fire(FireMode mode, bool shifting, bool edgeTriggered) {
     auto ownerp = owner();
     if (ownerp && worldp) {
       bool used = false;
-      int radius = !shifting ? m_blockRadius : m_altBlockRadius;
+      int radius = !shifting ? (m_blockRadius * owner()->movementController()->getScale(), 1.0f) : m_altBlockRadius;
 
       if (ownerp->isAdmin() || ownerp->inToolRange()) {
         for (auto pos : tileAreaBrush(radius, ownerp->aimPosition(), true)) {

--- a/source/game/items/StarTools.cpp
+++ b/source/game/items/StarTools.cpp
@@ -57,7 +57,7 @@ void MiningTool::fire(FireMode mode, bool shifting, bool edgeTriggered) {
 
   if (initialized()) {
     bool used = false;
-    int radius = !shifting ? (m_blockRadius * owner()->movementController()->getScale(), 1.0f) : m_altBlockRadius;
+    int radius = !shifting ? max(m_blockRadius * owner()->movementController()->getScale(), 1.0f) : m_altBlockRadius;
     String blockSound;
     List<Vec2I> brushArea;
 
@@ -371,7 +371,7 @@ List<PreviewTile> BeamMiningTool::previewTiles(bool shifting) const {
       if (!ready())
         lightColor *= Color::rgbaf(0.75f, 0.75f, 0.75f, 1.0f);
       Vec3B light = lightColor.toRgb();
-      int radius = !shifting ? (m_blockRadius * owner()->movementController()->getScale(), 1.0f) : m_altBlockRadius;
+      int radius = !shifting ? max(m_blockRadius * owner()->movementController()->getScale(), 1.0f) : m_altBlockRadius;
       for (auto pos : tileAreaBrush(radius, ownerp->aimPosition(), true)) {
         if (worldp->tileIsOccupied(pos, TileLayer::Foreground, true)) {
           result.append({pos, true, light, true});
@@ -414,7 +414,7 @@ void BeamMiningTool::fire(FireMode mode, bool shifting, bool edgeTriggered) {
   auto ownerp = owner();
   if (ownerp && worldp) {
     bool used = false;
-    int radius = !shifting ? (m_blockRadius * owner()->movementController()->getScale(), 1.0f) : m_altBlockRadius;
+    int radius = !shifting ? max(m_blockRadius * owner()->movementController()->getScale(), 1.0f) : m_altBlockRadius;
     String blockSound;
     List<Vec2I> brushArea;
 
@@ -646,7 +646,7 @@ List<PreviewTile> PaintingBeamTool::previewTiles(bool shifting) const {
     Vec3B light = Color::White.toRgb();
 
     if (ownerp->isAdmin() || ownerp->inToolRange()) {
-      int radius = !shifting ? (m_blockRadius * owner()->movementController()->getScale(), 1.0f) : m_altBlockRadius;
+      int radius = !shifting ? max(m_blockRadius * owner()->movementController()->getScale(), 1.0f) : m_altBlockRadius;
 
       for (auto pos : tileAreaBrush(radius, ownerp->aimPosition(), true)) {
         if (worldp->canModifyTile(pos, PlaceMaterialColor{TileLayer::Foreground, (MaterialColorVariant)m_colorIndex}, true)) {
@@ -693,7 +693,7 @@ void PaintingBeamTool::fire(FireMode mode, bool shifting, bool edgeTriggered) {
     auto ownerp = owner();
     if (ownerp && worldp) {
       bool used = false;
-      int radius = !shifting ? (m_blockRadius * owner()->movementController()->getScale(), 1.0f) : m_altBlockRadius;
+      int radius = !shifting ? max(m_blockRadius * owner()->movementController()->getScale(), 1.0f) : m_altBlockRadius;
 
       if (ownerp->isAdmin() || ownerp->inToolRange()) {
         for (auto pos : tileAreaBrush(radius, ownerp->aimPosition(), true)) {

--- a/source/game/scripting/StarLuaActorMovementComponent.hpp
+++ b/source/game/scripting/StarLuaActorMovementComponent.hpp
@@ -339,6 +339,13 @@ void LuaActorMovementComponent<Base>::addActorMovementCallbacks(ActorMovementCon
     callbacks.registerCallbackWithSignature<void, bool>("setAutoClearControls", bind(&LuaActorMovementComponent::setAutoClearControls, this, _1));
     callbacks.registerCallbackWithSignature<void>("clearControls", bind(&LuaActorMovementComponent::clearControls, this));
 
+    callbacks.registerCallback("setScale", [this](float scale) {
+        return m_movementController->setScale(scale);
+      });
+    callbacks.registerCallback("getScale", [this]() -> float {
+        return m_movementController->getScale();
+      });
+
     Base::addCallbacks("mcontroller", callbacks);
 
   } else {
@@ -426,7 +433,7 @@ void LuaActorMovementComponent<Base>::clearControls() {
   m_controlJump = {};
   m_controlHoldJump = {};
   m_controlFly = {};
-  
+
   m_resetPathMove = false;
   // Clear path move result one clear after controlPathMove is no longer called
   // to keep the result available for the following update

--- a/source/game/scripting/StarMovementControllerLuaBindings.cpp
+++ b/source/game/scripting/StarMovementControllerLuaBindings.cpp
@@ -77,6 +77,11 @@ LuaCallbacks LuaBindings::makeMovementControllerCallbacks(MovementController* mo
   callbacks.registerCallbackWithSignature<void, float, float>(
       "approachYVelocity", bind(&MovementController::approachYVelocity, movementController, _1, _2));
 
+  callbacks.registerCallbackWithSignature<void, float>(
+      "setScale", bind(&MovementController::setScale, movementController, _1));
+  callbacks.registerCallbackWithSignature<float>(
+      "getScale", bind(&MovementController::getScale, movementController));
+
   return callbacks;
 }
 


### PR DESCRIPTION
Entity scaling!

mcontroller has getScale and setScale, which will of course, scale an entity's hitbox and how big they visually are

movement speed, damage polys shield polys, and force regions should all be scaled with the entity

activeitem.handPosition will also account for the relative scale of the humanoid so most existing weapons shouldn't look too silly firing, projectiles will also inherit the scale of their owner if they're set to have an owner

the break and place and interact radius also expands with scale

item drops also inherit scale from whoever threw it

Item pickup has been, slightly modified in a way I think makes more sense, retail creates a square from the player position, I have changed it to get the player's collision bound box and then expand it by a similar amount to the original pickup range
This change I believe will behave better with not only players scaled larger, but also any potential modded species that may have large hitboxes

players also now have interactPosition() and throwPosition() which right now just are copies of postion, but are going to be used once I implement the animator on humanoids

