### PR TITLE
revert Zink addition

### DIFF
--- a/scripts/ci/linux/run-client.sh
+++ b/scripts/ci/linux/run-client.sh
@@ -1,18 +1,5 @@
 #!/bin/sh
 
-# Check if environment variables are already set
-if [ -n "${__GLX_VENDOR_LIBRARY_NAME}" ] || [ -n "${MESA_LOADER_DRIVER_OVERRIDE}" ] || [ -n "${GALLIUM_DRIVER}" ]; then :
-else
-    # Check for Vulkan support
-    if command -v vulkaninfo &> /dev/null; then
-        # Check for Zink support
-        if __GLX_VENDOR_LIBRARY_NAME=mesa MESA_LOADER_DRIVER_OVERRIDE=zink GALLIUM_DRIVER=zink LIBGL_KOPPER_DRI2=1 glxinfo | grep -q 'renderer string: zink'; then
-            # Set environment variables for Zink
-            export __GLX_VENDOR_LIBRARY_NAME=mesa MESA_LOADER_DRIVER_OVERRIDE=zink GALLIUM_DRIVER=zink LIBGL_KOPPER_DRI2=1
-        fi
-    fi
-fi
-
 cd "`dirname \"$0\"`"
 
 LD_LIBRARY_PATH="$LD_LIBRARY_PATH:./" ./starbound "$@" & exit


### PR DESCRIPTION
Why remove zink for now?:

After testing extensively, setting LIBGLE_KOPPER_DRI2=1 resolves the issue with devices like the Steam Deck. These devices have specific drivers that break when using Zink with DRI3, causing the driver to attempt to load and fail repeatedly.

By not using DRI3, most of Zink's performance advantages are undone. 

I think the best approach would be to make Zink an additional setting, allowing users to choose whether to use it. This is because we can't predict if a user's device has a driver that breaks Zink with DRI3. 

I don't think that I'm going to be able to implement it due to my lack of experience in C/C++.