### PR TITLE
Item count display chainges

### DIFF
--- a/source/windowing/StarItemSlotWidget.cpp
+++ b/source/windowing/StarItemSlotWidget.cpp
@@ -196,8 +196,8 @@ if (m_item->count() > 1 && m_showCount) {  // we don't need to tell people that 
         formattedCount = toString(m_item->count() / 1000000000) + "b";
     } else if (m_item->count() >= 1000000) { // Million (m)
         formattedCount = toString(m_item->count() / 1000000) + "m";
-    } else if (m_item->count() >= 1000) { // Thousand (k)
-        formattedCount = toString(m_item->count() / 10000) + "k";
+    } else if (m_item->count() >= 10000) { // Thousand (k)
+        formattedCount = toString(m_item->count() / 1000) + "k";
     } else {
         formattedCount = toString(m_item->count());
     }


### PR DESCRIPTION
Improved the large stack amount display
Format:
  1 - 999
  1000 - 9999999 = 1K - 999K
  1000000 - 9999999999 = 1M - 999M
  1000000000 - 9999999999999 = 1B - 999B
  (up to Sextillion)
This allows us to display all possible stack amounts in at most 4 characters,
Making large stacks not look as bad.

Issue encountered:
Just now I saw that it only works on Linux build at least on my fork and I don't get why.

would be huge help if someone could fix the build issue if its not only in my fork as i dont know what to do to fix it.
