### PR TITLE
items can be shift-clicked into scripted panes

### DIFF
--- a/source/frontend/StarBaseScriptPane.cpp
+++ b/source/frontend/StarBaseScriptPane.cpp
@@ -7,6 +7,7 @@
 #include "StarLuaGameConverters.hpp"
 #include "StarWidgetLuaBindings.hpp"
 #include "StarCanvasWidget.hpp"
+#include "StarItemDatabase.hpp"
 #include "StarItemTooltip.hpp"
 #include "StarItemGridWidget.hpp"
 #include "StarSimpleTooltip.hpp"
@@ -127,6 +128,22 @@ Maybe<String> BaseScriptPane::cursorOverride(Vec2I const& screenPosition) {
     return *result;
   else
     return {};
+}
+
+Maybe<ItemPtr> BaseScriptPane::shiftItemFromInventory(ItemPtr const& input) {
+  auto result = m_script.invoke<Json>("shiftItemFromInventory", input->descriptor().toJson());
+  if (!result || result->isNull())
+    return {};
+
+  auto itemDatabase = Root::singleton().itemDatabase();
+
+  if (result->type() == Json::Type::Bool) {
+    if (result->toBool())
+      return itemDatabase->item({});
+    return {};
+  }
+
+  return itemDatabase->item(ItemDescriptor(result.value()));
 }
 
 GuiReaderPtr BaseScriptPane::reader() {

--- a/source/frontend/StarBaseScriptPane.hpp
+++ b/source/frontend/StarBaseScriptPane.hpp
@@ -32,6 +32,8 @@ public:
 
   PanePtr createTooltip(Vec2I const& screenPosition) override;
   Maybe<String> cursorOverride(Vec2I const& screenPosition) override;
+  Maybe<ItemPtr> shiftItemFromInventory(ItemPtr const& input) override;
+
 protected:
   virtual GuiReaderPtr reader() override;
   void construct(Json config);

--- a/source/frontend/StarInventory.cpp
+++ b/source/frontend/StarInventory.cpp
@@ -49,6 +49,14 @@ InventoryPane::InventoryPane(MainInterface* parent, PlayerPtr player, ContainerI
           m_containerInteractor->addToContainer(sourceItem);
           m_containerSource = inventorySlot;
           m_expectingSwap = true;
+        } else {
+          for (PanePtr& pane : m_parent->paneManager()->getAllPanes()) {
+            auto remainder = pane->shiftItemFromInventory(inventory->itemsAt(inventorySlot));
+            if (remainder.isValid()) {
+              inventory->setItem(inventorySlot, remainder.value());
+              break;
+            }
+          }
         }
       }
     } else {

--- a/source/windowing/StarPane.cpp
+++ b/source/windowing/StarPane.cpp
@@ -5,6 +5,7 @@
 #include "StarWidgetLuaBindings.hpp"
 #include "StarLuaConverters.hpp"
 #include "StarImageWidget.hpp"
+#include "StarItemDatabase.hpp"
 #include "StarGuiReader.hpp"
 
 namespace Star {
@@ -344,6 +345,10 @@ PanePtr Pane::createTooltip(Vec2I const&) {
 }
 
 Maybe<String> Pane::cursorOverride(Vec2I const&) {
+  return {};
+}
+
+Maybe<ItemPtr> Pane::shiftItemFromInventory(ItemPtr const& input) {
   return {};
 }
 

--- a/source/windowing/StarPane.hpp
+++ b/source/windowing/StarPane.hpp
@@ -2,6 +2,7 @@
 
 #include "StarWidget.hpp"
 #include "StarBiMap.hpp"
+#include "StarItemDatabase.hpp"
 
 namespace Star {
 
@@ -90,6 +91,7 @@ public:
   // new pane to be used as the tooltip.
   virtual PanePtr createTooltip(Vec2I const& screenPosition);
   virtual Maybe<String> cursorOverride(Vec2I const& screenPosition);
+  virtual Maybe<ItemPtr> shiftItemFromInventory(ItemPtr const& input);
 
   virtual LuaCallbacks makePaneCallbacks();
 protected:

--- a/source/windowing/StarPaneManager.cpp
+++ b/source/windowing/StarPaneManager.cpp
@@ -132,6 +132,17 @@ PanePtr PaneManager::getPaneAt(Vec2I const& position) const {
   return {};
 }
 
+List<PanePtr> PaneManager::getAllPanes() {
+  List<PanePtr> list;
+  for (auto const& layerPair : m_displayedPanes) {
+    for (auto const& panePair : layerPair.second) {
+      if (panePair.first != m_activeTooltip && panePair.first->active())
+        list.append(panePair.first);
+    }
+  }
+  return list;
+}
+
 void PaneManager::setBackgroundWidget(WidgetPtr bg) {
   m_backgroundWidget = bg;
 }

--- a/source/windowing/StarPaneManager.hpp
+++ b/source/windowing/StarPaneManager.hpp
@@ -63,6 +63,7 @@ public:
 
   PanePtr getPaneAt(Set<PaneLayer> const& paneLayers, Vec2I const& position) const;
   PanePtr getPaneAt(Vec2I const& position) const;
+  List<PanePtr> getAllPanes();
 
   void setBackgroundWidget(WidgetPtr bg);
 


### PR DESCRIPTION
https://github.com/user-attachments/assets/82a3d258-69ac-4248-95d4-7e904772c12a

script panes can take inventory items when you shift click them

it calls `shiftItemFromInventory(item)` & if it returns an itemdescriptor it'll replace the shift-clicked item with that. or just return true to consume the whole item .

:3