### PR TITLE
remove temporary forced x11 in run-client

### DIFF
--- a/scripts/ci/linux/run-client.sh
+++ b/scripts/ci/linux/run-client.sh
@@ -2,6 +2,4 @@
 
 cd "`dirname \"$0\"`"
 
-export SDL_VIDEODRIVER=x11
-
 LD_LIBRARY_PATH="$LD_LIBRARY_PATH:./" ./starbound "$@" & exit


### PR DESCRIPTION
The breaking of Wayland could have been discovered sooner and additionally, it should be removed considering a recent issue were they encountert an X11 limitation. If we don't remove forced X11, they are likely going to be confused. (i'm referring to issue  #270)

The following are all the known issues on Linux that should be fixed. I'm adding my findings due to the reason that I'm not finding a solution like I had hoped in the past, so it might be good if someone else takes a look at it.

- x11:

  * Maximized to Borderless: The borderless window is missing the screen height of the top bar of the maximized window.

- Wayland:

  * Normal to Borderless: The borderless window remains at the position and size of the original window.

  * Maximized to Borderless: The borderless window is set to the last value set by the normal window.

  * Fullscreen to Borderless: The borderless window is also set to the last value set by the normal window.

  * aditonatly wayland wants to scail the game if the system has scailing set. witch looks bad as our image is still the same scail so it looks blurry. 