### PR TITLE
Added Sdl application info

### DIFF
--- a/source/application/StarMainApplication_sdl.cpp
+++ b/source/application/StarMainApplication_sdl.cpp
@@ -323,6 +323,7 @@ public:
 
     SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_NAME_STRING, "Starbound");
     SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_VERSION_STRING, OpenStarVersionString);
+    SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_IDENTIFIER_STRING, "org.openstarbound.starbound");
     SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_URL_STRING, "https://github.com/OpenStarbound/OpenStarbound");
     SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_TYPE_STRING, "game");
     SDL_SetHint(SDL_HINT_AUDIO_DEVICE_STREAM_NAME, "Audio");  


### PR DESCRIPTION
* Added Application name as sdl3 no longer defaults to executable name

* Added Version string because SDL documentation says it can be displayed on Mac

* Added identifier string that would also then be the name of the Flatpak container once it is made.

* Added URL to https://github.com/OpenStarbound/OpenStarbound because it might show up somewhere

* Added application type just in case some systems treat applications differently depending on it

* Made the audio stream name Audio, which basically makes it so we don't have to give an actual second name as we will never have more than one outgoing stream and one incoming stream. So, audio streams now look like this in the system tab for audio stuff.

![Screenshot](https://github.com/user-attachments/assets/4249a525-5b19-4c13-aa6b-d2adfe576944)

Instead of 

![starbound audio stuf old](https://github.com/user-attachments/assets/f5466fbb-e4e6-4b2b-89c6-5294a45186f2)

(The controller icon can be replaced once the howl icon stuff is decided upon, SDL just defaults to it as it's basically always installed)