### PR TITLE
Ups had incorrect identifier set

### DIFF
--- a/source/application/StarMainApplication_sdl.cpp
+++ b/source/application/StarMainApplication_sdl.cpp
@@ -323,7 +323,7 @@ public:
 
     SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_NAME_STRING, "Starbound");
     SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_VERSION_STRING, OpenStarVersionString);
-    SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_IDENTIFIER_STRING, "org.openstarbound.starbound");
+    SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_IDENTIFIER_STRING, "io.github.openstarbound.openstarbound");
     SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_URL_STRING, "https://github.com/OpenStarbound/OpenStarbound");
     SDL_SetAppMetadataProperty(SDL_PROP_APP_METADATA_TYPE_STRING, "game");
     SDL_SetHint(SDL_HINT_AUDIO_DEVICE_STREAM_NAME, "Audio");  


### PR DESCRIPTION
So just read through flathub documentation and noticed that i had completely misunderstood for what the identifier is. i thought it was just a string but it is basicly just a url instead. so now its fixed  if ure interested for how the string is constructed. Its basicly in oure case io.github because github is the code host url and .openstarbound.openstarbound because thats the location so basicly the identifier is just the url in a difrent format.

To the specific part of the flathub documentation.
https://docs.flathub.org/docs/for-app-authors/requirements#control-over-domain-or-repository