### PR TITLE
Show slot behind item when extra cosmetic slot is filled

### DIFF
--- a/assets/opensb/interface/windowconfig/inventory_cosmetics_patch.lua
+++ b/assets/opensb/interface/windowconfig/inventory_cosmetics_patch.lua
@@ -22,6 +22,7 @@ function patch(data)
       type = "itemslot",
       position = {origin.position[1] + offset, origin.position[2]},
       backingImage = origin.backingImage,
+      showBackingImageWhenFull = true,
       data = {tooltipText = "Cosmetic " .. i},
       zlevel = 5,
       children = {


### PR DESCRIPTION
Since the extra cosmetic slot grid has no backing image, this helps keep the items from just awkwardly floating over other UI elements (since without this, the grey slot icon disappears)