### PR TITLE
Lua core: backport Jump Table from Lua 5.4

### DIFF
--- a/source/extern/lua/ljumptab.h
+++ b/source/extern/lua/ljumptab.h
@@ -1,0 +1,91 @@
+/*
+** $Id: ljumptab.h $
+** Jump Table for the Lua interpreter
+** See Copyright Notice in lua.h
+*/
+
+
+#undef vmdispatch
+#undef vmcase
+#undef vmbreak
+
+#define vmdispatch(x)     goto *disptab[x];
+
+#define vmcase(l)     L_##l:
+
+#define vmbreak		vmfetch(); vmdispatch(GET_OPCODE(i));
+
+
+static const void *const disptab[NUM_OPCODES] = {
+
+#if 0
+** you can update the following list with this command:
+**
+**  sed -n '/^&&L_OP_/\!d; s/&&L_OP_/\&\&L_&&L_OP_/ ; s/,.*/,/ ; s/\/.*// ; p'  lopcodes.h
+**
+#endif
+
+&&L_OP_MOVE,	
+&&L_OP_LOADK,	
+&&L_OP_LOADKX,
+&&L_OP_LOADBOOL,
+&&L_OP_LOADNIL,
+&&L_OP_GETUPVAL,
+
+&&L_OP_GETTABUP,
+&&L_OP_GETTABLE,
+
+&&L_OP_SETTABUP,
+&&L_OP_SETUPVAL,
+&&L_OP_SETTABLE,
+
+&&L_OP_NEWTABLE,
+
+&&L_OP_SELF,	
+
+&&L_OP_ADD,	
+&&L_OP_SUB,	
+&&L_OP_MUL,	
+&&L_OP_MOD,	
+&&L_OP_POW,	
+&&L_OP_DIV,	
+&&L_OP_IDIV,	
+&&L_OP_BAND,	
+&&L_OP_BOR,	
+&&L_OP_BXOR,	
+&&L_OP_SHL,	
+&&L_OP_SHR,	
+&&L_OP_UNM,	
+&&L_OP_BNOT,	
+&&L_OP_NOT,	
+&&L_OP_LEN,	
+
+&&L_OP_CONCAT,
+
+&&L_OP_JMP,	
+&&L_OP_EQ,	
+&&L_OP_LT,	
+&&L_OP_LE,	
+
+&&L_OP_TEST,	
+&&L_OP_TESTSET,
+
+&&L_OP_CALL,	
+&&L_OP_TAILCALL,
+&&L_OP_RETURN,
+
+&&L_OP_FORLOOP,
+&&L_OP_FORPREP,
+
+&&L_OP_TFORCALL,
+&&L_OP_TFORLOOP,
+
+&&L_OP_SETLIST,
+
+&&L_OP_CLOSURE,
+
+&&L_OP_VARARG,
+
+&&L_OP_EXTRAARG
+
+};

--- a/source/extern/lua/lvm.c
+++ b/source/extern/lua/lvm.c
@@ -31,6 +31,20 @@
 #include "lvm.h"
 
 
+/*
+** By default, use jump tables in the main interpreter loop on gcc
+** and compatible compilers.
+*/
+#if !defined(LUA_USE_JUMPTABLE)
+#if defined(__GNUC__) || defined(__clang__)
+#define LUA_USE_JUMPTABLE	1
+#else
+#define LUA_USE_JUMPTABLE	0
+#endif
+#endif
+
+
+
 /* limit for table tag-method chains (to avoid loops) */
 #define MAXTAGLOOP	2000
 
@@ -788,6 +802,9 @@ void luaV_execute (lua_State *L) {
   LClosure *cl;
   TValue *k;
   StkId base;
+#if LUA_USE_JUMPTABLE
+#include "ljumptab.h"
+#endif
   ci->callstatus |= CIST_FRESH;  /* fresh invocation of 'luaV_execute" */
  newframe:  /* reentry point when frame changes (call/return) */
   lua_assert(ci == L->ci);


### PR DESCRIPTION
Backports the Jump Table implementation from Lua 5.4 which should provide around a 5% or so performance increase/boost to the core Lua interpreter for compatible compilers such as GCC and Clang.

**IMPORTANT NOTES:**
I don't actually have the correct setup to compile and test this myself sadly :( but I don't see why this wouldn't work.
Windows compiles won't benefit from this unless they are switched off of MSVC to Clang or something.