### PR TITLE
Activeitem extra stuff

### DIFF
--- a/source/frontend/StarActionBar.cpp
+++ b/source/frontend/StarActionBar.cpp
@@ -271,10 +271,15 @@ void ActionBar::update(float) {
 
     if (itemSafeTwoHanded(primaryItem)) {
       widgets.right->setItem(primaryItem);
+      widgets.right->showSecondaryIcon(true);
       widgets.right->showDurability(false);
       widgets.right->showCount(false);
-      widgets.rightOverlay->show();
+      if (primaryItem->hasSecondaryDrawables())
+        widgets.rightOverlay->hide();
+      else
+        widgets.rightOverlay->show();
     } else {
+      widgets.right->showSecondaryIcon(false);
       widgets.right->setItem(secondaryItem);
       if (secondaryPreview) {
         widgets.right->showDurability(false);

--- a/source/game/StarItem.cpp
+++ b/source/game/StarItem.cpp
@@ -32,7 +32,7 @@ Item::Item(Json config, String directory, Json parameters) {
     auto image = AssetPath::relativeTo(m_directory, inventoryIcon.toString());
     setIconDrawables({Drawable::makeImage(image, 1.0f, true, Vec2F())});
   }
-  auto secondaryIcon = instanceValue("secondaryIcon", Root::singleton().assets()->json("/items/defaultParameters.config:missingIcon"));
+  auto secondaryIcon = instanceValue("secondaryIcon", Json());
   if (secondaryIcon.type() == Json::Type::Array) {
     setSecondaryIconDrawables(secondaryIcon.toArray().transformed([&](Json config) -> Drawable {
       if (auto image = config.optString("image"))
@@ -43,7 +43,7 @@ Item::Item(Json config, String directory, Json parameters) {
     auto image = AssetPath::relativeTo(m_directory, secondaryIcon.toString());
     setSecondaryIconDrawables(Maybe<List<Drawable>>({Drawable::makeImage(image, 1.0f, true, Vec2F())}));
   } else {
-    setSecondaryIconDrawables({});
+    setSecondaryIconDrawables(Maybe<List<Drawable>>());
   }
 
   auto assets = Root::singleton().assets();

--- a/source/game/StarItem.hpp
+++ b/source/game/StarItem.hpp
@@ -82,6 +82,9 @@ public:
   uint64_t price() const;
 
   virtual List<Drawable> iconDrawables() const;
+  virtual Maybe<List<Drawable>> secondaryDrawables() const;
+  virtual bool hasSecondaryDrawables() const;
+
   virtual List<Drawable> dropDrawables() const;
   String largeImage() const;
 
@@ -119,10 +122,13 @@ public:
 protected:
   void setMaxStack(uint64_t maxStack);
   void setDescription(String const& description);
+  void setShortDescription(String const& description);
+
   void setRarity(Rarity rarity);
   void setPrice(uint64_t price);
   // icon drawables are pixels, not tile, based
   void setIconDrawables(List<Drawable> drawables);
+  void setSecondaryIconDrawables(Maybe<List<Drawable>> drawables);
   void setTwoHanded(bool twoHanded);
   void setTimeToLive(float timeToLive);
 
@@ -143,6 +149,7 @@ private:
   String m_description;
   Rarity m_rarity;
   List<Drawable> m_iconDrawables;
+  Maybe<List<Drawable>> m_secondaryIconDrawables;
   bool m_twoHanded;
   float m_timeToLive;
   uint64_t m_price;

--- a/source/game/items/StarActiveItem.cpp
+++ b/source/game/items/StarActiveItem.cpp
@@ -495,7 +495,7 @@ LuaCallbacks ActiveItem::makeActiveItemCallbacks() {
       auto image = AssetPath::relativeTo(directory(), secondaryIcon.toString());
       setSecondaryIconDrawables(Maybe<List<Drawable>>({Drawable::makeImage(image, 1.0f, true, Vec2F())}));
     } else {
-      setSecondaryIconDrawables({});
+      setSecondaryIconDrawables(Maybe<List<Drawable>>());
     }
   });
 

--- a/source/windowing/StarItemSlotWidget.cpp
+++ b/source/windowing/StarItemSlotWidget.cpp
@@ -13,10 +13,10 @@ namespace Star {
 static String formatShortSize(uint64_t n) {
     if (n < 10000)
       return toString(n);
-    
+
     uint64_t divisor = 1000ull;
     char suffix = 'k';
-    
+
     if (n >= 1000000000000000000ull) {
       divisor = 1000000000000000000ull;
       suffix = 'Q';
@@ -33,14 +33,14 @@ static String formatShortSize(uint64_t n) {
       divisor = 1000000ull;
       suffix = 'm';
     }
-    
+
     uint64_t whole = n / divisor;
     if (whole >= 100ull)
         return strf("{}{:c}", whole, suffix);
-    
+
     uint64_t remainder = n - (whole * divisor);
     uint64_t frac = (remainder / (divisor / 1000));
-    
+
     if (frac == 0)
       return strf("{}{:c}", whole, suffix);
     else if (whole >= 10)
@@ -88,7 +88,7 @@ ItemSlotWidget::ItemSlotWidget(ItemPtr const& item, String const& backingImage)
   m_showCount = true;
   m_showRarity = true;
   m_showLinkIndicator = false;
-
+  m_showSecondaryIcon = false;
   disableScissoring();
 }
 
@@ -177,6 +177,10 @@ void ItemSlotWidget::showLinkIndicator(bool showLinkIndicator) {
   m_showLinkIndicator = showLinkIndicator;
 }
 
+void ItemSlotWidget::showSecondaryIcon(bool show) {
+  m_showSecondaryIcon = show;
+}
+
 void ItemSlotWidget::indicateNew() {
   m_newItemIndicator.reset();
 }
@@ -196,7 +200,7 @@ void ItemSlotWidget::renderImpl() {
     if (m_drawBackingImageWhenFull && m_backingImage != "")
       context()->drawInterfaceQuad(m_backingImage, Vec2F(screenPosition()));
 
-    List<Drawable> iconDrawables = m_item->iconDrawables();
+    List<Drawable> iconDrawables = m_showSecondaryIcon ? m_item->secondaryDrawables().value(m_item->iconDrawables()) : m_item->iconDrawables();
 
     if (m_showRarity) {
       String border = rarityBorder(m_item->rarity());

--- a/source/windowing/StarItemSlotWidget.hpp
+++ b/source/windowing/StarItemSlotWidget.hpp
@@ -31,6 +31,7 @@ public:
   void showCount(bool show);
   void showRarity(bool showRarity);
   void showLinkIndicator(bool showLinkIndicator);
+  void showSecondaryIcon(bool show);
 
   void indicateNew();
 
@@ -49,6 +50,7 @@ private:
   bool m_showCount;
   bool m_showRarity;
   bool m_showLinkIndicator;
+  bool m_showSecondaryIcon;
 
   TextPositioning m_countPosition;
   FontMode m_countFontMode;


### PR DESCRIPTION
small tweaks to activeItem

changes how the parsing is handled for inventoryIcon slightly, so that they can use the full configuration parameters drawables have rather than solely images

the callback to set inventoryIcon now supports inputting arrays like one can define in the config parameters rather than just strings

callbacks to set shortdescription and description in script so those can change what they're displaying without having to toss and pick up the item

added a config parameter and callback to set a secondaryIcon that's displayed in the right hand slot without the overlay for two handed items