### PR TITLE
Fix dismounting into the floor

### DIFF
--- a/source/game/StarActorMovementController.cpp
+++ b/source/game/StarActorMovementController.cpp
@@ -1071,15 +1071,15 @@ void ActorMovementController::doSetAnchorState(Maybe<EntityAnchorState> anchorSt
     if (!entityAnchor)
       throw ActorMovementControllerException::format("Anchor position {} is disabled ActorMovementController::setAnchorState", anchorState->positionIndex);
   }
-
-  if (!entityAnchor && m_entityAnchor && m_entityAnchor->exitBottomPosition) {
-    auto boundBox = MovementController::localBoundBox();
-    Vec2F bottomMid = {boundBox.center()[0], boundBox.yMin()};
-    setPosition(*m_entityAnchor->exitBottomPosition - bottomMid);
-  }
-
+  auto prevAnchor = m_entityAnchor;
   m_anchorState.set(anchorState);
   m_entityAnchor = std::move(entityAnchor);
+
+  if (!entityAnchor && prevAnchor && prevAnchor->exitBottomPosition) {
+    auto boundBox = MovementController::localBoundBox();
+    Vec2F bottomMid = {boundBox.center()[0], boundBox.yMin()};
+    setPosition(*prevAnchor->exitBottomPosition - bottomMid);
+  }
 
   if (m_entityAnchor)
     setPosition(m_entityAnchor->position);


### PR DESCRIPTION
When I made position() and rotation() be virtual functions that the actor movement controller overrides

this meant that localBoundBox() of base mcontroller now received the rotation applied by the anchor position of the actor mcontroller, and attempted to place the player onto the floor while reading their bound box of their collision as in the rotated position

this is fixed by simply putting the previous anchor into a local variable, and then setting the new anchor before attempting to set the player position to the dismount position