### PR TITLE
fix character creation oversight

### DIFF
--- a/source/game/StarPlayer.cpp
+++ b/source/game/StarPlayer.cpp
@@ -2845,7 +2845,7 @@ void Player::refreshHumanoidParameters() {
   auto speciesDatabase = Root::singleton().speciesDatabase();
   auto speciesDef = speciesDatabase->species(m_identity.species);
 
-  if (isMaster()) {
+  if (isMaster() || !inWorld()) {
     m_refreshedHumanoidParameters.trigger();
     m_netHumanoid.clearNetElements();
     m_netHumanoid.addNetElement(make_shared<NetHumanoid>(m_identity, m_humanoidParameters, Json()));


### PR DESCRIPTION
Ok so I actually didn't use the character creation menu as it didn't cross my mind it wouldn't be working, everything I did test was in world using the identity set command 