### PR TITLE
Compatibility version counts

### DIFF
--- a/source/core/StarNetElementGroup.cpp
+++ b/source/core/StarNetElementGroup.cpp
@@ -9,6 +9,14 @@ void NetElementGroup::addNetElement(NetElement* element, bool propagateInterpola
   if (m_interpolationEnabled && propagateInterpolation)
     element->enableNetInterpolation(m_extrapolationHint);
   m_elements.append(pair<NetElement*, bool>(element, propagateInterpolation));
+
+  auto version = element->compatibilityVersion();
+  if (version == AnyVersion)
+    version = 0;
+
+  for (auto i = version; i < (CurrentStreamVersion + 1); i++) {
+    m_elementCounts[i]++;
+  }
 }
 
 void NetElementGroup::clearNetElements() {
@@ -90,15 +98,24 @@ bool NetElementGroup::writeNetDelta(DataStream& ds, uint64_t fromVersion, NetCom
 void NetElementGroup::readNetDelta(DataStream& ds, float interpolationTime, NetCompatibilityRules rules) {
   if (!checkWithRules(rules))
     return;
-  if (m_elements.size() == 0) {
+
+  auto expectedSize = m_elementCounts.maybe(rules.version()).value(m_elements.size());
+
+  if (expectedSize == 0) {
     throw IOException("readNetDelta called on empty NetElementGroup");
-  } else if (m_elements.size() == 1) {
-    m_elements[0].first->readNetDelta(ds, interpolationTime, rules);
+  } else if (expectedSize == 1) {
+    for (auto& element : m_elements)
+      if (element.first->checkWithRules(rules)) {
+        element.first->readNetDelta(ds, interpolationTime, rules);
+        break;
+      }
   } else {
     uint64_t readIndex = ds.readVlqU();
     uint64_t i = 0;
     uint64_t offset = 0;
     for (auto& element : m_elements) {
+      if (i > expectedSize)
+        break;
       if (!element.first->checkWithRules(rules)) {
         offset++;
         continue;

--- a/source/core/StarNetElementGroup.hpp
+++ b/source/core/StarNetElementGroup.hpp
@@ -45,6 +45,8 @@ private:
   bool m_interpolationEnabled = false;
   float m_extrapolationHint = 0.0f;
 
+  HashMap<VersionNumber, size_t> m_elementCounts;
+
   mutable DataStreamBuffer m_buffer;
 };
 


### PR DESCRIPTION
keep a count of elements on each compatibility version and then use this count when reading to process the data stream in the expected manner for the version being received 