### PR TITLE
Fixes

### DIFF
--- a/source/core/StarNetElementGroup.cpp
+++ b/source/core/StarNetElementGroup.cpp
@@ -10,16 +10,15 @@ void NetElementGroup::addNetElement(NetElement* element, bool propagateInterpola
     element->enableNetInterpolation(m_extrapolationHint);
   m_elements.append(pair<NetElement*, bool>(element, propagateInterpolation));
 
-  auto version = element->compatibilityVersion();
-  if (version == AnyVersion)
-    version = 0;
 
-  for (auto i = version; i < (CurrentStreamVersion + 1); i++) {
-    m_elementCounts[i]++;
+  for (VersionNumber i = 0; i < (CurrentStreamVersion + 1); i++) {
+    if (element->checkWithRules(NetCompatibilityRules(i)))
+      m_elementCounts[i]++;
   }
 }
 
 void NetElementGroup::clearNetElements() {
+  m_elementCounts.clear();
   m_elements.clear();
 }
 

--- a/source/game/StarNpc.cpp
+++ b/source/game/StarNpc.cpp
@@ -953,7 +953,7 @@ void Npc::setupNetStates() {
   m_netGroup.addNetElement(&m_refreshedHumanoidParameters);
 
   m_netHumanoid.setCompatibilityVersion(10);
-  // m_netGroup.addNetElement(&m_netHumanoid);
+  m_netGroup.addNetElement(&m_netHumanoid);
 
   m_scriptedAnimationParameters.setCompatibilityVersion(10);
   m_netGroup.addNetElement(&m_scriptedAnimationParameters);

--- a/source/game/StarNpc.cpp
+++ b/source/game/StarNpc.cpp
@@ -306,7 +306,7 @@ void Npc::readNetState(ByteArray data, float interpolationTime, NetCompatibility
 }
 
 String Npc::description() const {
-  return m_npcVariant.description;
+  return m_npcVariant.description.value("Some funny looking person");
 }
 
 String Npc::species() const {
@@ -1316,7 +1316,6 @@ void Npc::setHumanoidParameter(String key, Maybe<Json> value) {
   else
     m_npcVariant.humanoidParameters.erase(key);
 
-  m_npcVariant.overrides.set("humanoidParameters", m_npcVariant.humanoidParameters);
   m_netHumanoid.netElements().last()->setHumanoidParameters(m_npcVariant.humanoidParameters);
 }
 
@@ -1327,7 +1326,6 @@ Maybe<Json> Npc::getHumanoidParameter(String key) {
 void Npc::setHumanoidParameters(JsonObject parameters) {
   m_npcVariant.humanoidParameters = parameters;
 
-  m_npcVariant.overrides.set("humanoidParameters", m_npcVariant.humanoidParameters);
   m_netHumanoid.netElements().last()->setHumanoidParameters(m_npcVariant.humanoidParameters);
 }
 
@@ -1421,7 +1419,6 @@ void Npc::setName(String const& name) {
 }
 
 void Npc::setDescription(String const& description) {
-  m_npcVariant.overrides = m_npcVariant.overrides.set("description", description);
   m_npcVariant.description = description;
 }
 

--- a/source/game/StarNpcDatabase.cpp
+++ b/source/game/StarNpcDatabase.cpp
@@ -254,11 +254,18 @@ NpcVariant NpcDatabase::readNpcVariant(ByteArray const& data, NetCompatibilityRu
 }
 
 Json NpcDatabase::writeNpcVariantToJson(NpcVariant const& variant) const {
+  JsonObject overrides;
+  if (variant.overrides)
+    overrides = variant.overrides.toObject();
+  overrides.set("humanoidParameters", variant.humanoidParameters);
+  if (variant.description.isValid())
+    overrides.set("description", variant.description.value());
+
   return JsonObject{{"species", variant.species},
       {"typeName", variant.typeName},
       {"level", variant.level},
       {"seed", variant.seed},
-      {"overrides", variant.overrides},
+      {"overrides", overrides},
       {"initialScriptDelta", variant.initialScriptDelta},
       {"humanoidIdentity", variant.humanoidIdentity.toJson()},
       {"items", jsonFromMapV<StringMap<ItemDescriptor>>(variant.items, mem_fn(&ItemDescriptor::diskStore))},
@@ -280,7 +287,7 @@ NpcVariant NpcDatabase::readNpcVariantFromJson(Json const& data) const {
 
   auto config = buildConfig(variant.typeName, variant.overrides);
 
-  variant.description = config.getString("description", "Some funny looking person");
+  variant.description = config.optString("description");
 
   variant.scripts = jsonToStringList(config.get("scripts"));
   variant.scriptConfig = config.get("scriptConfig");

--- a/source/game/StarNpcDatabase.hpp
+++ b/source/game/StarNpcDatabase.hpp
@@ -27,7 +27,7 @@ struct NpcVariant {
   unsigned initialScriptDelta;
   Json scriptConfig;
 
-  String description;
+  Maybe<String> description;
 
   HumanoidIdentity humanoidIdentity;
   Json humanoidConfig;

--- a/source/game/StarPlayer.cpp
+++ b/source/game/StarPlayer.cpp
@@ -187,7 +187,7 @@ Player::Player(PlayerConfigPtr config, Uuid uuid) {
   m_netGroup.addNetElement(m_techController.get());
 
   m_netHumanoid.setCompatibilityVersion(10);
-  // m_netGroup.addNetElement(&m_netHumanoid);
+  m_netGroup.addNetElement(&m_netHumanoid);
   m_refreshedHumanoidParameters.setCompatibilityVersion(10);
   m_netGroup.addNetElement(&m_refreshedHumanoidParameters);
 


### PR DESCRIPTION
let netHumanoid exist again because I'm pretty sure it is fine and the other person was just having issues from older versions

make sure that the element counts clear when net elements are cleared and make it consistent in how it counts them with the rules checked, don't know why I didn't just do that the first time

fix when it stores the humanoid parameters and npc description into overrides, as I didn't realize overrides wasn't always just a jsonObject and npcs that weren't initialized with overrides won't have it