### PR TITLE
Npc variant fixes

### DIFF
--- a/source/core/StarDataStream.cpp
+++ b/source/core/StarDataStream.cpp
@@ -6,7 +6,7 @@
 
 namespace Star {
 
-unsigned const CurrentStreamVersion = 10; // update OpenProtocolVersion too!
+unsigned const CurrentStreamVersion = 11; // update OpenProtocolVersion too!
 
 DataStream::DataStream()
   : m_byteOrder(ByteOrder::BigEndian),

--- a/source/core/StarNetCompatibility.cpp
+++ b/source/core/StarNetCompatibility.cpp
@@ -2,6 +2,6 @@
 
 namespace Star {
 
-VersionNumber const OpenProtocolVersion = 10; // update StreamCompatibilityVersion too!
+VersionNumber const OpenProtocolVersion = 11; // update StreamCompatibilityVersion too!
 
 }

--- a/source/game/StarNpcDatabase.cpp
+++ b/source/game/StarNpcDatabase.cpp
@@ -62,7 +62,8 @@ NpcVariant NpcDatabase::generateNpcVariant(
 
   auto speciesDatabase = Root::singleton().speciesDatabase();
   auto speciesDefinition = speciesDatabase->species(species);
-  HumanoidIdentity identity = speciesDatabase->generateHumanoid(species, seed).identity;
+  auto result = speciesDatabase->generateHumanoid(species, seed);
+  HumanoidIdentity identity = result.identity;
 
   variant.uniqueHumanoidConfig = config.contains("humanoidConfig");
   if (variant.uniqueHumanoidConfig)
@@ -84,7 +85,7 @@ NpcVariant NpcDatabase::generateNpcVariant(
 
   variant.humanoidIdentity = identity;
 
-  variant.humanoidParameters = config.getObject("humanoidParameters", JsonObject());
+  variant.humanoidParameters = jsonMerge(result.humanoidParameters, config.getObject("humanoidParameters", JsonObject())).toObject();
 
   variant.movementParameters = config.get("movementParameters", {});
   variant.statusControllerSettings = config.get("statusControllerSettings");

--- a/source/game/StarNpcDatabase.cpp
+++ b/source/game/StarNpcDatabase.cpp
@@ -363,8 +363,7 @@ NpcPtr NpcDatabase::netLoadNpc(ByteArray const& netStore, NetCompatibilityRules 
 }
 
 List<Drawable> NpcDatabase::npcPortrait(NpcVariant const& npcVariant, PortraitMode mode) const {
-  Humanoid humanoid(npcVariant.humanoidConfig);
-  humanoid.setIdentity(npcVariant.humanoidIdentity);
+  Humanoid humanoid(npcVariant.humanoidIdentity, npcVariant.humanoidParameters, npcVariant.uniqueHumanoidConfig ? npcVariant.humanoidConfig : Json());
 
   auto itemDatabase = Root::singleton().itemDatabase();
   auto items = StringMap<ItemDescriptor, CaseInsensitiveStringHash, CaseInsensitiveStringCompare>::from(npcVariant.items);
@@ -374,22 +373,11 @@ List<Drawable> NpcDatabase::npcPortrait(NpcVariant const& npcVariant, PortraitMo
   };
 
   ArmorWearer armor;
-  if (items.contains("head"))
-    armor.setHeadItem(as<HeadArmor>(makeItem(items["head"])));
-  if (items.contains("headCosmetic"))
-    armor.setHeadItem(as<HeadArmor>(makeItem(items["headCosmetic"])));
-  if (items.contains("chest"))
-    armor.setChestItem(as<ChestArmor>(makeItem(items["chest"])));
-  if (items.contains("chestCosmetic"))
-    armor.setChestCosmeticItem(as<ChestArmor>(makeItem(items["chestCosmetic"])));
-  if (items.contains("legs"))
-    armor.setLegsItem(as<LegsArmor>(makeItem(items["legs"])));
-  if (items.contains("legsCosmetic"))
-    armor.setLegsCosmeticItem(as<LegsArmor>(makeItem(items["legsCosmetic"])));
-  if (items.contains("back"))
-    armor.setBackItem(as<BackArmor>(makeItem(items["back"])));
-  if (items.contains("backCosmetic"))
-    armor.setBackCosmeticItem(as<BackArmor>(makeItem(items["backCosmetic"])));
+  for (auto item : npcVariant.items) {
+    if (auto equipmentSlot = EquipmentSlotNames.maybeLeft(item.first)) {
+      armor.setItem((uint8_t)*equipmentSlot, as<ArmorItem>(makeItem(ItemDescriptor(item.second))));
+    }
+  }
 
   armor.setupHumanoid(humanoid, false);
 

--- a/source/game/scripting/StarRootLuaBindings.cpp
+++ b/source/game/scripting/StarRootLuaBindings.cpp
@@ -272,6 +272,7 @@ LuaCallbacks LuaBindings::makeRootCallbacks() {
     auto result = root->speciesDatabase()->generateHumanoid(species, seed.value(Random::randu64()), gender.isValid() ? GenderNames.getLeft(*gender) : Maybe<Gender>());
     return LuaTupleReturn<Json, JsonObject, JsonObject>{result.identity.toJson(), result.humanoidParameters, result.armor};
   });
+  callbacks.copyCallback("generateHumanoidIdentity", "generateHumanoid");
   callbacks.registerCallback("createHumanoid", [root](
     String name,
     String speciesChoice,


### PR DESCRIPTION
Realized the generated humanoid parameters weren't being set for npc variants and went to fix that

Also realized there would be a weird edge case with how the npc variant usually ends up discarding the personality generated by generateHumanoid, and generating specifically the personality itself since thats the ONE customization thing thats part of the humanoid config rather than the species config, so I made npc variants only do that generating when the npc would have a unique humanoid config to generate personality from.

Also found that the database npc portrait that root.npcPortrait uses wasn't accounting for the parameters or for the new cosmetic slots, so fixed that.

Then fixed how the parameters and description were being networked and just make it consistent since, I realized smuggling it into the overrides wouldn't actually work until the npc unloads and reloads, and its just cleaner this way anyway