### PR TITLE
Client master stagehands

### DIFF
--- a/source/game/StarStagehand.cpp
+++ b/source/game/StarStagehand.cpp
@@ -130,6 +130,8 @@ Stagehand::Stagehand() {
 void Stagehand::readConfig(Json config) {
   m_config = config;
   m_scripted = m_config.contains("scripts");
+  
+  m_clientEntityMode = ClientEntityModeNames.getLeft(config.getString("clientEntityMode", "ClientSlaveOnly"));
 
   if (m_config.contains("position")) {
     auto pos = jsonToVec2F(m_config.get("position"));
@@ -181,6 +183,10 @@ LuaCallbacks Stagehand::makeStagehandCallbacks() {
     });
 
   return callbacks;
+}
+
+ClientEntityMode Stagehand::clientEntityMode() const {
+  return m_clientEntityMode;
 }
 
 String Stagehand::typeName() const {

--- a/source/game/StarStagehand.hpp
+++ b/source/game/StarStagehand.hpp
@@ -37,6 +37,8 @@ public:
   void update(float dt, uint64_t currentStep) override;
 
   bool shouldDestroy() const override;
+  
+  ClientEntityMode clientEntityMode() const override;
 
   Maybe<LuaValue> callScript(String const& func, LuaVariadic<LuaValue> const& args) override;
   Maybe<LuaValue> evalScript(String const& code) override;
@@ -59,6 +61,8 @@ private:
   RectF m_boundBox;
 
   bool m_dead = false;
+      
+  ClientEntityMode m_clientEntityMode;
 
   NetElementTopGroup m_netGroup;
 


### PR DESCRIPTION
I've used invisible vehicles for a few miscellaneous things, primarily keeping areas loaded with clientPresenceMaster and being at an easy to find spot for entity queries. Stagehands are probably much better for this kind of purpose.
As usual, clientEntityMode is only checked by the client, so this works with non-oSB servers.