### PR TITLE
cosmetic armor stats

### DIFF
--- a/doc/json/openstarbound/armorItem.md
+++ b/doc/json/openstarbound/armorItem.md
@@ -1,0 +1,10 @@
+## `bool` statusEffectsInCosmeticSlots
+If true enables the armor to apply its status effects even when in cosmetic slots
+
+## `List<PersistentStatusEffect>` cosmeticStatusEffects
+List of status effects that apply whenever this armor is visible
+
+## `JsonObject` humanoidAnimationTags
+When a humanoid is using an animation config, the key value pairs of this table will be set as global tags in the animation.
+
+The `<slot>` tag within any keys will be replaced with the slot index of the armor slot (1-20)

--- a/source/game/StarArmorWearer.cpp
+++ b/source/game/StarArmorWearer.cpp
@@ -196,13 +196,13 @@ void ArmorWearer::diskLoad(Json const& diskStore) {
 
 List<PersistentStatusEffect> ArmorWearer::statusEffects() const {
   List<PersistentStatusEffect> statusEffects;
-  auto addStatusFromItem = [&](ItemPtr const& item) {
-    if (auto effectItem = as<StatusEffectItem>(item))
-      statusEffects.appendAll(effectItem->statusEffects());
-  };
 
-  for (size_t i = 0; i != 4; ++i)
-    addStatusFromItem(m_armors[i].item);
+  for (size_t i = 0; i != m_armors.size(); ++i) {
+    if ((i < 4) ||  m_armors[i].item->statusEffectsInCosmeticSlot())
+      statusEffects.appendAll(m_armors[i].item->statusEffects());
+    if (m_armors[i].visible)
+      statusEffects.appendAll(m_armors[i].item->cosmeticStatusEffects());
+  }
 
   return statusEffects;
 }

--- a/source/game/items/StarArmors.cpp
+++ b/source/game/items/StarArmors.cpp
@@ -57,10 +57,19 @@ ArmorItem::ArmorItem(Json const& config, String const& directory, Json const& da
   }
 
   m_hideBody = config.getBool("hideBody", false);
+  m_statusEffectsInCosmeticSlot = config.getBool("statusEffectsInCosmeticSlots", false);
 }
 
 List<PersistentStatusEffect> ArmorItem::statusEffects() const {
   return m_statusEffects;
+}
+
+bool ArmorItem::statusEffectsInCosmeticSlot() {
+  return m_statusEffectsInCosmeticSlot;
+}
+
+List<PersistentStatusEffect> ArmorItem::cosmeticStatusEffects() {
+  return m_cosmeticStatusEffects;
 }
 
 StringSet ArmorItem::effectSources() const {
@@ -132,6 +141,7 @@ void ArmorItem::refreshIconDrawables() {
 
 void ArmorItem::refreshStatusEffects() {
   m_statusEffects = instanceValue("statusEffects", JsonArray()).toArray().transformed(jsonToPersistentStatusEffect);
+  m_cosmeticStatusEffects = instanceValue("cosmeticStatusEffects", JsonArray()).toArray().transformed(jsonToPersistentStatusEffect);
   if (auto leveledStatusEffects = instanceValue("leveledStatusEffects", Json())) {
     auto functionDatabase = Root::singleton().functionDatabase();
     float level = instanceValue("level", 1).toFloat();

--- a/source/game/items/StarArmors.hpp
+++ b/source/game/items/StarArmors.hpp
@@ -28,6 +28,9 @@ public:
   virtual ~ArmorItem() {}
 
   virtual List<PersistentStatusEffect> statusEffects() const override;
+  bool statusEffectsInCosmeticSlot();
+  List<PersistentStatusEffect> cosmeticStatusEffects();
+
   virtual StringSet effectSources() const override;
 
   virtual List<Drawable> drawables() const override;
@@ -62,6 +65,8 @@ private:
   bool m_hideBody;
   bool m_bypassNude;
   bool m_hideInVanillaSlots;
+  bool m_statusEffectsInCosmeticSlot;
+  List<PersistentStatusEffect> m_cosmeticStatusEffects;
   Maybe<HashSet<ArmorType>> m_armorTypesToHide;
   Maybe<String> m_techModule;
 };


### PR DESCRIPTION
bool to allow armors to enable their status effects even when equipped in a cosmetic slot

and add a separate list for cosmetic status effects that only apply when the armor is visible

added docs on those new values, as well as the humanoidAnimationTags value used for the animator