### PR TITLE
make this behave as I actually intended it

### DIFF
--- a/source/game/StarArmorWearer.cpp
+++ b/source/game/StarArmorWearer.cpp
@@ -87,6 +87,8 @@ bool ArmorWearer::setupHumanoid(Humanoid& humanoid, bool forceNude) {
           allowed = false;
         }
       }
+
+      m_armors[i].isCurrentlyVisible = allowed;
       if (allowed) {
         addHumanoidConfig(*armor.item);
         if (armor.needsSync) {
@@ -202,7 +204,7 @@ List<PersistentStatusEffect> ArmorWearer::statusEffects() const {
       continue;
     if ((i < 4) ||  m_armors[i].item->statusEffectsInCosmeticSlot())
       statusEffects.appendAll(m_armors[i].item->statusEffects());
-    if (m_armors[i].visible)
+    if (m_armors[i].isCurrentlyVisible)
       statusEffects.appendAll(m_armors[i].item->cosmeticStatusEffects());
   }
 

--- a/source/game/StarArmorWearer.hpp
+++ b/source/game/StarArmorWearer.hpp
@@ -80,6 +80,7 @@ private:
     bool needsSync = true;
     bool needsStore = true;
     bool isCosmetic = false;
+    bool isCurrentlyVisible = false;
     NetElementData<ItemDescriptor> netState;
   };
 


### PR DESCRIPTION
the cosmetic stats should only apply when the armor is *currently* visible, so do store when it gets hidden by other armors or being nude, and check that