### PR TITLE
valid steam achievement check

### DIFF
--- a/source/application/StarStatisticsService_pc_steam.cpp
+++ b/source/application/StarStatisticsService_pc_steam.cpp
@@ -52,7 +52,7 @@ bool SteamStatisticsService::reportEvent(String const&, Json const&) {
 
 bool SteamStatisticsService::unlockAchievement(String const& name) {
     std::vector<std::string> ValidSteamAchievements = {
-    // list of all steam 51 achivements
+    // list of all 51 steam achivements
         "completequest", "protectorate", "harvestcrop", "preparefood", "findoutpost",
         "findlore", "lunarbasemission", "findinstrument", "killmotherpoptop", "craftarmor",
         "findaugment", "floranmission", "gaincrew", "killdreadwing", "killinnocent",


### PR DESCRIPTION
I added a list of all valid steam achievement to the unlock achievement function so it no longer trys to unlock an achievement that does not exist on steam like `trashpet`.