### PR TITLE
Lua core: compile with C99 on Windows

### DIFF
--- a/source/extern/luaconf.h
+++ b/source/extern/luaconf.h
@@ -54,7 +54,9 @@
 
 #if defined(LUA_USE_WINDOWS)
 #define LUA_DL_DLL	/* enable support for DLL */
-#define LUA_USE_C89	/* broadly, Windows is C89 */
+#if defined(_MSC_VER) && (_MSC_VER < 1700)	/* older versions of MSVC do not have C99 support */
+#define LUA_USE_C89
+#endif
 #endif
 
 


### PR DESCRIPTION
By default Lua assumes when compiling for Windows that C99 is not supported however this is a outdated assumption and also doesn't apply when not using MSVC.

uses of `math.log` where the second argument is `2` should give better results on Windows with this change.