### PR TITLE
configurable colored wires per object's connection

### DIFF
--- a/source/frontend/StarWireInterface.cpp
+++ b/source/frontend/StarWireInterface.cpp
@@ -138,7 +138,7 @@ void WirePane::renderImpl() {
         if (auto sourceEntity = m_worldClient->atTile<WireEntity>(connection.entityLocation).get(0)) {
           if (connection.nodeIndex < sourceEntity->nodeCount(WireDirection::Output)) {
             outPosition += sourceEntity->nodePosition({WireDirection::Output, connection.nodeIndex});
-            wire = sourceEntity->nodeColor({WireDirection::Output, i});
+            wire = sourceEntity->nodeColor({WireDirection::Output, connection.nodeIndex});
             if (!sourceEntity->nodeState(WireNode{WireDirection::Output, connection.nodeIndex}))
               wire = wire.mix(Color::Black, 0.8f);
           } else {

--- a/source/game/StarObject.cpp
+++ b/source/game/StarObject.cpp
@@ -69,10 +69,10 @@ Object::Object(ObjectConfigConstPtr config, Json const& parameters) {
   }
 
   for (auto const& node : configValue("inputNodes", JsonArray()).iterateArray())
-    m_inputNodes.append({jsonToVec2I(node), {}, {}});
+    m_inputNodes.append(InputNode(node));
 
   for (auto const& node : configValue("outputNodes", JsonArray()).iterateArray())
-    m_outputNodes.append({jsonToVec2I(node), {}, {}});
+    m_outputNodes.append(OutputNode(node));
 
   m_offeredQuests.set(configValue("offeredQuests", JsonArray()).toArray().transformed(&QuestArcDescriptor::fromJson));
   m_turnInQuests.set(jsonToStringSet(configValue("turnInQuests", JsonArray())));
@@ -796,6 +796,19 @@ bool Object::nodeState(WireNode wireNode) const {
   else
     return m_outputNodes.at(wireNode.nodeIndex).state.get();
 }
+String Object::nodeIcon(WireNode wireNode) const {
+  if (wireNode.direction == WireDirection::Input)
+    return m_inputNodes.at(wireNode.nodeIndex).icon;
+  else
+    return m_outputNodes.at(wireNode.nodeIndex).icon;
+}
+
+Color Object::nodeColor(WireNode wireNode) const { // only output nodes determine color
+  if (wireNode.direction == WireDirection::Input)
+    return m_inputNodes.at(wireNode.nodeIndex).color;
+  else
+    return m_outputNodes.at(wireNode.nodeIndex).color;
+}
 
 void Object::addNodeConnection(WireNode wireNode, WireConnection nodeConnection) {
   if (wireNode.direction == WireDirection::Input) {
@@ -1406,4 +1419,28 @@ void Object::checkLiquidBroken() {
   }
 }
 
+Object::OutputNode::OutputNode(Json node) {
+  if (node.isType(Json::Type::Array)) {
+    position = jsonToVec2I(node);
+    color = Color::Red;
+    icon = "/interface/wires/outbound.png";
+  } else {
+    position = jsonToVec2I(node.get("position"));
+    color = jsonToColor(node.get("color"));
+    icon = node.getString("icon", "/interface/wires/outbound.png");
+  }
 }
+
+Object::InputNode::InputNode(Json node) {
+  if (node.isType(Json::Type::Array)) {
+    position = jsonToVec2I(node);
+    color = Color::Red;
+    icon = "/interface/wires/inbound.png";
+  } else {
+    position = jsonToVec2I(node.get("position"));
+    color = jsonToColor(node.get("color"));
+    icon = node.getString("icon", "/interface/wires/inbound.png");
+  }
+}
+
+}// namespace Star

--- a/source/game/StarObject.hpp
+++ b/source/game/StarObject.hpp
@@ -127,6 +127,9 @@ public:
   virtual List<WireConnection> connectionsForNode(WireNode wireNode) const override;
   virtual bool nodeState(WireNode wireNode) const override;
 
+  virtual String nodeIcon(WireNode wireNode) const override;
+  virtual Color nodeColor(WireNode wireNode) const override;
+
   virtual void addNodeConnection(WireNode wireNode, WireConnection nodeConnection) override;
   virtual void removeNodeConnection(WireNode wireNode, WireConnection nodeConnection) override;
 
@@ -178,15 +181,21 @@ protected:
 
 private:
   struct InputNode {
+    InputNode(Json node);
     Vec2I position;
     NetElementData<List<WireConnection>> connections;
     NetElementBool state;
+    Color color;
+    String icon;
   };
 
   struct OutputNode {
+    OutputNode(Json node);
     Vec2I position;
     NetElementData<List<WireConnection>> connections;
     NetElementBool state;
+    Color color;
+    String icon;
   };
 
   LuaCallbacks makeObjectCallbacks();

--- a/source/game/StarWiring.hpp
+++ b/source/game/StarWiring.hpp
@@ -19,7 +19,7 @@ WireDirection otherWireDirection(WireDirection direction);
 // Identifier for a specific WireNode in a WireEntity, node indexes for input
 // and output nodes are separate.
 struct WireNode {
-  WireDirection direction; 
+  WireDirection direction;
   size_t nodeIndex;
 };
 

--- a/source/game/interfaces/StarWireEntity.hpp
+++ b/source/game/interfaces/StarWireEntity.hpp
@@ -16,6 +16,9 @@ public:
   virtual List<WireConnection> connectionsForNode(WireNode wireNode) const = 0;
   virtual bool nodeState(WireNode wireNode) const = 0;
 
+  virtual Color nodeColor(WireNode wireNode) const = 0;
+  virtual String nodeIcon(WireNode wireNode) const = 0;
+
   virtual void addNodeConnection(WireNode wireNode, WireConnection nodeConnection) = 0;
   virtual void removeNodeConnection(WireNode wireNode, WireConnection nodeConnection) = 0;
 


### PR DESCRIPTION
Wire connection nodes can now be defined as a jsonObject rather than a vector, when defining it this way you can define a position, color, and icon used by the connection nodes, the color of an output node takes priority over the input node's color

also made the check for visited connections actually function so wires aren't drawn twice