### PR TITLE
status effects may also suppress tools

### DIFF
--- a/source/core/StarDataStream.cpp
+++ b/source/core/StarDataStream.cpp
@@ -6,7 +6,7 @@
 
 namespace Star {
 
-unsigned const CurrentStreamVersion = 11; // update OpenProtocolVersion too!
+unsigned const CurrentStreamVersion = 12; // update OpenProtocolVersion too!
 
 DataStream::DataStream()
   : m_byteOrder(ByteOrder::BigEndian),

--- a/source/core/StarNetCompatibility.cpp
+++ b/source/core/StarNetCompatibility.cpp
@@ -2,6 +2,6 @@
 
 namespace Star {
 
-VersionNumber const OpenProtocolVersion = 11; // update StreamCompatibilityVersion too!
+VersionNumber const OpenProtocolVersion = 12; // update StreamCompatibilityVersion too!
 
 }

--- a/source/game/StarNpc.cpp
+++ b/source/game/StarNpc.cpp
@@ -1106,7 +1106,13 @@ bool Npc::setItemSlot(String const& slot, ItemDescriptor itemDescriptor) {
 }
 
 bool Npc::canUseTool() const {
-  return !shouldDestroy() && !loungingIn();
+  bool canUse = !shouldDestroy() && !m_statusController->toolUsageSuppressed();
+  if (canUse) {
+    if (auto loungeAnchor = as<LoungeAnchor>(m_movementController->entityAnchor()))
+      if (loungeAnchor->suppressTools.value(loungeAnchor->controllable))
+        return false;
+  }
+  return canUse;
 }
 
 void Npc::disableWornArmor(bool disable) {

--- a/source/game/StarPlayer.cpp
+++ b/source/game/StarPlayer.cpp
@@ -1581,7 +1581,7 @@ void Player::playEmote(HumanoidEmote emote) {
 }
 
 bool Player::canUseTool() const {
-  bool canUse = !isDead() && !isTeleporting() && !m_techController->toolUsageSuppressed();
+  bool canUse = !isDead() && !isTeleporting() && !m_techController->toolUsageSuppressed() && !m_statusController->toolUsageSuppressed();
   if (canUse) {
     if (auto loungeAnchor = as<LoungeAnchor>(m_movementController->entityAnchor()))
       if (loungeAnchor->suppressTools.value(loungeAnchor->controllable))

--- a/source/game/StarStatusController.cpp
+++ b/source/game/StarStatusController.cpp
@@ -64,6 +64,9 @@ StatusController::StatusController(Json const& config) : m_statCollection(config
   m_netGroup.addNetElement(&m_uniqueEffectMetadata);
   m_netGroup.addNetElement(&m_effectAnimators);
 
+  m_toolUsageSuppressed.setCompatibilityVersion(12);
+  m_netGroup.addNetElement(&m_toolUsageSuppressed);
+
   if (m_primaryAnimationConfig)
     m_primaryAnimatorId = m_effectAnimators.addNetElement(make_shared<EffectAnimator>(*m_primaryAnimationConfig));
   else
@@ -572,6 +575,10 @@ List<OverheadBar> StatusController::overheadBars() {
   return {};
 }
 
+bool StatusController::toolUsageSuppressed() const {
+  return m_toolUsageSuppressed.get();
+}
+
 List<AudioInstancePtr> StatusController::pullNewAudios() {
   List<AudioInstancePtr> newAudios;
   for (auto const& animator : m_effectAnimators.netElements())
@@ -729,6 +736,8 @@ bool StatusController::addUniqueEffect(
       uniqueEffect.animatorId =
           m_effectAnimators.addNetElement(make_shared<EffectAnimator>(uniqueEffect.effectConfig.animationConfig));
 
+    uniqueEffect.toolUsageSuppressed = false;
+
     if (m_parentEntity)
       initUniqueEffectScript(uniqueEffect);
 
@@ -858,6 +867,15 @@ LuaCallbacks StatusController::makeUniqueEffectCallbacks(UniqueEffectInstance& u
         throw StatusException("Cannot remove stat modifier group that was not added from this effect");
       m_statCollection.removeStatModifierGroup(groupId);
       uniqueEffect.modifierGroups.remove(groupId);
+    });
+  callbacks.registerCallback("setToolUsageSuppressed", [this, &uniqueEffect](bool suppressed) {
+      if (uniqueEffect.toolUsageSuppressed == suppressed)
+        return;
+      uniqueEffect.toolUsageSuppressed = suppressed;
+      bool anySuppressed = false;
+      for (auto& p : m_uniqueEffects)
+        anySuppressed = anySuppressed || p.second.toolUsageSuppressed;
+      m_toolUsageSuppressed.set(anySuppressed);
     });
 
   return callbacks;

--- a/source/game/StarStatusController.hpp
+++ b/source/game/StarStatusController.hpp
@@ -122,6 +122,7 @@ public:
   List<Drawable> drawables() const;
   List<LightSource> lightSources() const;
   List<OverheadBar> overheadBars();
+  bool toolUsageSuppressed() const;
 
   // new audios and particles will only be generated on the client
   List<AudioInstancePtr> pullNewAudios();
@@ -185,6 +186,7 @@ private:
     StatScript script;
     UniqueEffectMetadataGroup::ElementId metadataId;
     EffectAnimatorGroup::ElementId animatorId;
+    bool toolUsageSuppressed;
   };
 
   void updateAnimators(float dt);
@@ -206,6 +208,7 @@ private:
   StatCollection m_statCollection;
   NetElementOverride<NetElementHashMap<String, Json>> m_statusProperties;
   NetElementData<DirectivesGroup> m_parentDirectives;
+  NetElementBool m_toolUsageSuppressed;
 
   UniqueEffectMetadataGroup m_uniqueEffectMetadata;
   EffectAnimatorGroup m_effectAnimators;

--- a/source/game/StarTechController.cpp
+++ b/source/game/StarTechController.cpp
@@ -534,6 +534,8 @@ LuaCallbacks TechController::makeTechCallbacks(TechModule& techModule) {
     });
 
   callbacks.registerCallback("setToolUsageSuppressed", [this, &techModule](bool suppressed) {
+      if (techModule.toolUsageSuppressed == suppressed)
+        return;
       techModule.toolUsageSuppressed = suppressed;
       bool anySuppressed = false;
       for (auto& module : m_techModules)


### PR DESCRIPTION
adds the setToolUsageSuppressed callback to status effects so they may suppress tool usage similarly to how techs can

also makes NPC tool suppression consistent with player tool suppression in regards to lounge positions

