### PR TITLE
customizable vehicle layering

### DIFF
--- a/source/game/StarVehicle.cpp
+++ b/source/game/StarVehicle.cpp
@@ -29,6 +29,10 @@ Vehicle::Vehicle(Json baseConfig, String path, Json dynamicConfig)
   m_slaveHeartbeatTimer = GameTimer(configValue("slaveControlHeartbeat").toFloat());
   m_damageTeam.set(configValue("damageTeam").opt().apply(construct<EntityDamageTeam>()).value());
   m_interactive.set(configValue("interactive", true).toBool());
+  m_baseRenderLayer = parseRenderLayer(configValue("baseRenderLayer","Vehicle").toString());
+  if (!configValue("overrideRenderLayer").isNull()) {
+    m_overrideRenderLayer = parseRenderLayer(configValue("overrideRenderLayer").toString());
+  }
 
   if (auto animationScript = configValue("animationScript").optString())
     m_scriptedAnimator.setScript(*animationScript);
@@ -576,7 +580,7 @@ void Vehicle::setPosition(Vec2F const& position) {
 
 EntityRenderLayer Vehicle::renderLayer(VehicleLayer vehicleLayer) const {
   // Z-offset based on entity id, so vehicles don't overlap strangely.
-  return RenderLayerVehicle + ((EntityRenderLayer)(entityId() * 4 + (unsigned)vehicleLayer) & RenderLayerLowerMask);
+  return m_overrideRenderLayer ? (*m_overrideRenderLayer + (unsigned)vehicleLayer) : (m_baseRenderLayer + ((EntityRenderLayer)(entityId() * 4 + (unsigned)vehicleLayer) & RenderLayerLowerMask));
 }
 
 LuaCallbacks Vehicle::makeVehicleCallbacks() {

--- a/source/game/StarVehicle.hpp
+++ b/source/game/StarVehicle.hpp
@@ -167,6 +167,9 @@ private:
   NetElementData<EntityDamageTeam> m_damageTeam;
   OrderedHashMap<String, DamageSourceConfig> m_damageSources;
 
+  EntityRenderLayer m_baseRenderLayer;
+  Maybe<EntityRenderLayer> m_overrideRenderLayer;
+  
   GameTimer m_slaveHeartbeatTimer;
 };
 


### PR DESCRIPTION
unlike other entity types (which just use renderLayer),
due to how vehicle entity layering works (they use three different 'sublayers'  that are added onto their own layer, and also use an offset from Vehicle based on their entity id)
I added two parameters that affect render layer for vehicles

`baseRenderLayer` (defaults to `Vehicle`) determines the base render layer the vehicle adds its entity id-based offset to
`overrideRenderLayer` if present, overrides the vehicle so it uses this layer as a base for the sublayers, no matter entity id