### PR TITLE
Fix modsWarningShown not being set in starbound.config

### DIFF
--- a/source/client/StarClientApplication.cpp
+++ b/source/client/StarClientApplication.cpp
@@ -821,6 +821,11 @@ void ClientApplication::updateMods(float dt) {
         Logger::info("Reloading to include all user generated content");
         Root::singleton().reloadWithMods(modDirectories);
 
+        // We've just reloaded, so make sure to grab our config again!
+        // If we don't do this, we'll be able to read modsWarningShown
+        // just fine, but we won't be able to write it back to the file.
+        configuration = m_root->configuration();
+        
         auto assets = m_root->assets();
 
         if (configuration->get("modsWarningShown").optBool().value()) {


### PR DESCRIPTION
At some point in OSB's development, `ClientApplication::updateMods()` was refactored to check for a configuration value at the beginning of the function. To do this, it was required to move the line that grabbed the current config higher up, and this created a regression over retail Starbound where the game cannot set `modsWarningShown` in the users `starbound.config` file.

This occurs because Root gets reloaded with mods, and in retail, the configuration was grabbed after that reload, but in OSB, the code is currently using the old configuration pre-reload, which prevents the value from being written.

This PR is a simple fix that just grabs the configuration again after the Root has been reloaded.