### PR TITLE
make default image keys inherit correctly within object database

### DIFF
--- a/source/game/StarObject.cpp
+++ b/source/game/StarObject.cpp
@@ -35,7 +35,7 @@ Object::Object(ObjectConfigConstPtr config, Json const& parameters) {
     auto orientations = jOrientations->toArray();
     for (size_t i = 0; i != orientations.size(); ++i)
       base.set(i, jsonMergeNulling(base.get(i), orientations.get(i)));
-    m_orientations = ObjectDatabase::parseOrientations(m_config->path, base);
+    m_orientations = ObjectDatabase::parseOrientations(m_config->path, base, m_config->config);
   }
 
   m_animationTimer = 0.0f;
@@ -82,6 +82,12 @@ Object::Object(ObjectConfigConstPtr config, Json const& parameters) {
   m_turnInQuests.set(jsonToStringSet(configValue("turnInQuests", JsonArray())));
   if (!m_offeredQuests.get().empty() || !m_turnInQuests.get().empty())
     m_interactive.set(true);
+
+  auto colorName = configValue("color", "default").toString().takeUtf8();
+  m_imageKeys.set("color", colorName);
+  for (auto p : configValue("imageKeys", JsonObject()).toObject())
+    m_imageKeys.set(p.first, p.second.toString());
+
 
   setUniqueId(configValue("uniqueId").optString());
 
@@ -189,7 +195,7 @@ void Object::init(World* world, EntityId entityId, EntityMode mode) {
 
   if (isMaster()) {
     setImageKey("color", colorName);
-    for (auto p : configValue("defaultImageKeys", JsonObject()).toObject())
+    for (auto p : configValue("imageKeys", JsonObject()).toObject())
       setImageKey(p.first, p.second.toString());
 
     if (m_config->lightColors.contains(colorName))

--- a/source/game/StarObjectDatabase.hpp
+++ b/source/game/StarObjectDatabase.hpp
@@ -186,7 +186,7 @@ class ObjectDatabase {
 public:
   static List<Vec2I> scanImageSpaces(ImageConstPtr const& image, Vec2F const& position, float fillLimit, bool flip = false);
   static Json parseTouchDamage(String const& path, Json const& touchDamage);
-  static List<ObjectOrientationPtr> parseOrientations(String const& path, Json const& configList);
+  static List<ObjectOrientationPtr> parseOrientations(String const& path, Json const& configList, Json const& baseConfig);
 
   ObjectDatabase();
 


### PR DESCRIPTION
"defaultImageKeys" was added by me in an earlier PR so that they could be defined by default, changing it to just "imageKeys" makes it feel a lot less clunky

this commit also fixes the checks for applying the imageKeys within the object database's orientations not inheriting from the base config when being initially loaded, and not inheriting correctly within tooltips and placement previews