### PR TITLE
expose moving collisions to lua

### DIFF
--- a/source/game/scripting/StarLuaEntityUserdata.cpp
+++ b/source/game/scripting/StarLuaEntityUserdata.cpp
@@ -3,6 +3,7 @@
 #include "StarActorMovementController.hpp"
 #include "StarJsonExtra.hpp"
 #include "StarWorld.hpp"
+#include "StarPhysicsEntity.hpp"
 #include "StarPlayer.hpp"
 #include "StarPlayerInventory.hpp"
 #include "StarMonster.hpp"
@@ -807,6 +808,24 @@ LuaMethods<EntityPtr> LuaUserDataMethods<EntityPtr>::make() {
         }
 
         return items;
+    });
+
+    methods.registerMethod("movingCollisionCount",
+    [&](EntityPtr const& entity) -> size_t {
+        if (auto phys = as<PhysicsEntity>(entity)) {
+            return phys->movingCollisionCount();
+        }
+
+        return 0;
+    });
+
+    methods.registerMethod("movingCollision",
+    [&](EntityPtr const& entity, size_t index) -> Maybe<PhysicsMovingCollision> {
+        if (auto phys = as<PhysicsEntity>(entity)) {
+            return phys->movingCollision(index);
+        }
+
+        return {};
     });
 
     return methods;

--- a/source/game/scripting/StarLuaGameConverters.cpp
+++ b/source/game/scripting/StarLuaGameConverters.cpp
@@ -557,6 +557,21 @@ Maybe<Collectable> LuaConverter<Collectable>::to(LuaEngine& engine, LuaValue con
   return {};
 }
 
+LuaValue LuaConverter<PhysicsMovingCollision>::from(LuaEngine& engine, PhysicsMovingCollision const& v) {
+  auto table = engine.createTable();
+  table.set("position", v.position);
+  table.set("collision", v.collision);
+  table.set("collisionKind", v.collisionKind);
+  auto categoryTable = engine.createTable();
+  table.set("categoryFilter", categoryTable);
+  // see jsonToPhysicsCategoryFilter
+  categoryTable.set(
+    v.categoryFilter.type == PhysicsCategoryFilter::Type::Whitelist ? "categoryWhitelist" : "categoryBlacklist",
+    v.categoryFilter.categories
+  );
+  return table;
+}
+
 LuaMethods<BehaviorStateWeakPtr> LuaUserDataMethods<BehaviorStateWeakPtr>::make() {
   LuaMethods<BehaviorStateWeakPtr> methods;
   methods.registerMethodWithSignature<NodeStatus, BehaviorStateWeakPtr, float>(

--- a/source/game/scripting/StarLuaGameConverters.hpp
+++ b/source/game/scripting/StarLuaGameConverters.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "StarPhysicsEntity.hpp"
 #include "StarLuaConverters.hpp"
 #include "StarInventoryTypes.hpp"
 #include "StarCollisionBlock.hpp"
@@ -168,6 +169,11 @@ template <>
 struct LuaConverter<NodeStatus> {
   static LuaValue from(LuaEngine& engine, NodeStatus const& status);
   static NodeStatus to(LuaEngine& engine, LuaValue const& v);
+};
+
+template <>
+struct LuaConverter<PhysicsMovingCollision> {
+  static LuaValue from(LuaEngine& engine, PhysicsMovingCollision const& v);
 };
 
 // Weak pointer for the same reasons as BehaviorState.


### PR DESCRIPTION
this doesn't expose collision functions to Lua, just exposes the collisions themselves

here's a laser with it set up:
<img width="178" height="207" alt="Screenshot_20251116_132333" src="https://github.com/user-attachments/assets/d3307870-7ae8-49c0-a050-a77c7c8a5351" />

as an example, here's the code this laser uses:
(lineCollision specifically)
```lua
require "/scripts/vec2.lua"
require "/scripts/poly.lua"

local function linePointBefore(p,a,b)
  -- is a before b on the line?
  -- expects both points to be on the same line and for them both to be ON THE LINE
  local i = 1
  if a[1] == p[1] then
    i = 2
  end
  if a[i] > p[i] then
    return a[i] < b[i]
  else
    return a[i] > b[i]
  end
end
local function inPhysCategory(c)
  -- for this purpose we'll use projectile category since we're checking a laser
  -- some other use of this function like a foot would use the parent entity category instead
  local cat = "projectile"
  if c.categoryWhitelist then
    for k,v in next, c.categoryWhitelist do
      return true
    end
    return false
  elseif c.categoryBlacklist then
    for k,v in next, c.categoryBlacklist do
      if v == cat then
        return false
      end
    end
    return true
  end
end

local defaultKindsWhitelist = {
  Null=true,
  Slippery=true,
  Dynamic=true,
  Block=true
}
local function lineCollision(a,b,kinds)
  -- note: this function is incorrect in cases where a is inside moving collisions
  world.debugLine(a,b,"green")
  local p = world.lineCollision(a,b,kinds)
  if not world.entity then
    return p
  end
  local kinds2 
  if kinds then
    kinds2 = {}
    for _,v in next, kinds do
      kinds2[v] = true
    end
  else
    kinds2 = defaultKindsWhitelist
  end
  local es = world.entityLineQuery(a,b,{includedTypes={"projectile","object","vehicle"},boundMode="metaboundbox"})
  for _,id in next, es do
    local e = world.entity(id)
    for i=e:movingCollisionCount()-1,0,-1 do
      local c = e:movingCollision(i)
      if c and kinds2[c.collisionKind] then
        if inPhysCategory(c.categoryFilter) then
          local cpol = poly.translate(c.collision,c.position)
          world.debugPoly(cpol,"red")
          for i=1,#cpol do
            local ca = cpol[i]
            local cb = cpol[i+1] or cpol[1]
            local inters = vec2.intersect(a,b,ca,cb)
            if inters and (not p or linePointBefore(a,inters,p)) then
              p = inters
            end
          end
        end
      end
    end
  end
  return p
end
```