### PR TITLE
Proper UI Scaling for Cursor relative to the UI

### DIFF
--- a/source/frontend/StarInterfaceCursor.cpp
+++ b/source/frontend/StarInterfaceCursor.cpp
@@ -56,9 +56,9 @@ Vec2I InterfaceCursor::offset() const {
 }
 
 float InterfaceCursor::scale(float interfaceScale) const {
-  // AUTO integer scaling: derive from interface scale
-  int intScale = static_cast<int>(interfaceScale);
-  return static_cast<float>(std::max(1, intScale - 1));
+  int baseScale = m_scale ? static_cast<int>(m_scale) : 1;
+  int intScale = std::max(1, static_cast<int>((interfaceScale + 1) / 2));
+  return static_cast<float>(baseScale * intScale);
 }
 
 void InterfaceCursor::update(float dt) {


### PR DESCRIPTION
The mouse cursor previously stayed at a fixed size regardless of interface scale, causing it to appear too small on high-DPI displays when the UI is scaled up. This was due to cursor configs with "scale": 1 overriding the interface scale entirely.

This PR makes the cursor scale with the interface scale setting at 50% of the rate. The intention here is for standard display scales where you'd use lower UI scaling, the cursor remains at its native size, whilst on higher scales, it grows proportionally while avoiding becoming oversized. This follows a similar philosophy to how desktop operating systems handle cursor scaling at high DPI.