### PR TITLE
Add config var to skip checking for UGC updates

### DIFF
--- a/source/client/StarClientApplication.cpp
+++ b/source/client/StarClientApplication.cpp
@@ -855,16 +855,17 @@ void ClientApplication::updateMods(float dt) {
   auto ugcService = appController()->userGeneratedContentService();
   auto configuration = m_root->configuration();
   bool includeUGC = configuration->get("includeUGC", m_root->settings().includeUGC).toBool();
+  bool skipUGCUpdates = configuration->get("skipUGCUpdates", m_root->settings().skipUGCUpdates).toBool();
   if (ugcService && includeUGC) {
     // Prevent unnecessary log spam when UGC needs to be downloaded
-    if (!m_loggedUGCCheck) {
+    if (!skipUGCUpdates && !m_loggedUGCCheck) {
       Logger::info("Checking for user generated content updates...");
       m_loggedUGCCheck = true;
     }
-    if (ugcService->contentNeedsDownload()) {
+    if (!skipUGCUpdates && ugcService->contentNeedsDownload()) {
       ugcService->triggerContentDownload();
     }
-    else if (!(ugcService->contentNeedsDownload()) && ugcService->triggerContentDownload()) {
+    else if (skipUGCUpdates || (!(ugcService->contentNeedsDownload()) && ugcService->triggerContentDownload())) {
       Logger::info("Loading updated user generated content...");
       StringList modDirectories;
       for (auto& contentId : ugcService->subscribedContentIds()) {

--- a/source/game/StarRoot.hpp
+++ b/source/game/StarRoot.hpp
@@ -91,6 +91,9 @@ public:
     // If true, loads UGC from platform services if available. True by default.
     bool includeUGC;
 
+    // If true, we will not check for updates on user generated content. False by default.
+    bool skipUGCUpdates;
+
     // If given, will write changed configuration to the given file within the
     // storage directory.
     Maybe<String> runtimeConfigFile;

--- a/source/game/StarRootLoader.cpp
+++ b/source/game/StarRootLoader.cpp
@@ -193,6 +193,7 @@ Root::Settings RootLoader::rootSettingsForOptions(Options const& options) const 
     rootSettings.logFile = options.parameters.value("logfile").maybeFirst().orMaybe(m_defaults.logFile);
     rootSettings.logFileBackups = bootConfig.getUInt("logFileBackups", 10);
     rootSettings.includeUGC = bootConfig.getBool("includeUGC", true);
+    rootSettings.skipUGCUpdates = bootConfig.getBool("skipUGCUpdates", false);
 
     if (auto ll = options.parameters.value("loglevel").maybeFirst())
       rootSettings.logLevel = LogLevelNames.getLeft(*ll);


### PR DESCRIPTION
Since the recent asset loading rework, my game has begun trying to check for updates seemingly indefinitely (i.e; steam does not show any downloads in progress, and the update check never finishes) despite having a relatively small 270 mods installed (at least compared to some people I know).

I'm not really sure why that's happening; I'm compiling from source and running on a Linux host, and don't mind helping to debug this, but for now, here's a PR that adds a setting for bypassing the update check.

I figured I'd throw this in here, not just as a workaround, but also for people who might just not want to have their game update everything just yet (for example, someone playing on the go with a limited mobile data connection).

Simply add `"skipUGCUpdates" : true` to either your `starbound.config` or `sbinit.config` (of course, with a comma at the end if not the final config in the file), and the game will not check for updates to UGC content.