### PR TITLE
Fix an infinite loop with missing workshop content and some other adjustments

### DIFF
--- a/source/application/StarUserGeneratedContentService_pc_steam.cpp
+++ b/source/application/StarUserGeneratedContentService_pc_steam.cpp
@@ -26,17 +26,38 @@ Maybe<String> SteamUserGeneratedContentService::contentDownloadDirectory(String 
   return {};
 }
 
-bool SteamUserGeneratedContentService::triggerContentDownload() {
+UserGeneratedContentService::UGCState SteamUserGeneratedContentService::triggerContentDownload() {
   List<PublishedFileId_t> contentIds(SteamUGC()->GetNumSubscribedItems(), {});
   SteamUGC()->GetSubscribedItems(contentIds.ptr(), contentIds.size());
+
+  if (!m_checkedUGC) {
+    bool contentNeedsUpdate = false;
+    for (uint64 contentId : contentIds) {
+      uint32 itemState = SteamUGC()->GetItemState(contentId);
+      if (!(itemState & k_EItemStateInstalled) || itemState & k_EItemStateNeedsUpdate) {
+        // Download is needed
+        contentNeedsUpdate = true;
+      }
+    }
+    m_checkedUGC = true;
+    if (!contentNeedsUpdate) {
+      // No download was needed
+      return UserGeneratedContentService::UGCState::NoDownload;
+    }
+  }
 
   for (uint64 contentId : contentIds) {
     if (!m_currentDownloadState.contains(contentId)) {
       uint32 itemState = SteamUGC()->GetItemState(contentId);
       if (!(itemState & k_EItemStateInstalled) || itemState & k_EItemStateNeedsUpdate) {
-        SteamUGC()->DownloadItem(contentId, true);
-        itemState = SteamUGC()->GetItemState(contentId);
-        m_currentDownloadState[contentId] = !(itemState & k_EItemStateDownloading);
+        // DownloadItem has a return bool if it succeeds in attempting to download.
+        if (SteamUGC()->DownloadItem(contentId, true)) {
+          itemState = SteamUGC()->GetItemState(contentId);
+          m_currentDownloadState[contentId] = !(itemState & k_EItemStateDownloading);
+        } else {
+          // DownloadItem failed for some reason. Just set this to true to skip this item and prevent an infinite loop.
+          m_currentDownloadState[contentId] = true;
+        }
       } else {
         m_currentDownloadState[contentId] = true;
       }
@@ -49,26 +70,15 @@ bool SteamUserGeneratedContentService::triggerContentDownload() {
       allDownloaded = false;
   }
 
-  return allDownloaded;
+  if (allDownloaded) {
+    return UserGeneratedContentService::UGCState::Finished;
+  } else {
+    return UserGeneratedContentService::UGCState::InProgress;
+  }
 }
 
 void SteamUserGeneratedContentService::onDownloadResult(DownloadItemResult_t* result) {
   m_currentDownloadState[result->m_nPublishedFileId] = true;
-}
-
-bool SteamUserGeneratedContentService::contentNeedsDownload() const {
-  List<PublishedFileId_t> contentIds(SteamUGC()->GetNumSubscribedItems(), {});
-  SteamUGC()->GetSubscribedItems(contentIds.ptr(), contentIds.size());
-
-  for (uint64 contentId : contentIds) {
-    uint32 itemState = SteamUGC()->GetItemState(contentId);
-    if (!(itemState & k_EItemStateInstalled) || itemState & k_EItemStateNeedsUpdate) {
-      // Download is needed
-      return true;
-    }
-  }
-  // No download was needed
-  return false;
 }
 
 }

--- a/source/application/StarUserGeneratedContentService_pc_steam.hpp
+++ b/source/application/StarUserGeneratedContentService_pc_steam.hpp
@@ -12,13 +12,14 @@ public:
 
   StringList subscribedContentIds() const override;
   Maybe<String> contentDownloadDirectory(String const& contentId) const override;
-  bool triggerContentDownload() override;
-  bool contentNeedsDownload() const override;
+  UserGeneratedContentService::UGCState triggerContentDownload() override;
 
 private:
   STEAM_CALLBACK(SteamUserGeneratedContentService, onDownloadResult, DownloadItemResult_t, m_callbackDownloadResult);
 
   HashMap<PublishedFileId_t, bool> m_currentDownloadState;
+
+  bool m_checkedUGC;
 };
 
 }

--- a/source/platform/StarUserGeneratedContentService.hpp
+++ b/source/platform/StarUserGeneratedContentService.hpp
@@ -6,6 +6,12 @@ STAR_CLASS(UserGeneratedContentService);
 
 class UserGeneratedContentService {
 public:
+  enum class UGCState {
+    NoDownload = 0,
+    InProgress = 1,
+    Finished = 2
+  };
+	
   ~UserGeneratedContentService() = default;
 
   // Returns a list of the content the user is currently subscribed to.
@@ -17,10 +23,7 @@ public:
 
   // Start downloading subscribed content in the background, returns true when
   // all content is synchronized.
-  virtual bool triggerContentDownload() = 0;
-
-  // Check if it's necessary to download steam workshop content.
-  virtual bool contentNeedsDownload() const = 0;
+  virtual UserGeneratedContentService::UGCState triggerContentDownload() = 0;
 };
 
 }


### PR DESCRIPTION
I deleted the new function I made to check for UGC updates and merged it into triggerContentDownload because I changed its return type to make things simpler with an enum as it needed more than two return values to simplify things.