### PR TITLE
Make Glitter more consistent

### DIFF
--- a/source/rendering/StarEnvironmentPainter.cpp
+++ b/source/rendering/StarEnvironmentPainter.cpp
@@ -94,7 +94,7 @@ void EnvironmentPainter::renderStars(float pixelRatio, Vec2F const& screenSize, 
 }
 
 void EnvironmentPainter::renderDebrisFields(float pixelRatio, Vec2F const& screenSize, SkyRenderData const& sky) {
-  if (!sky.settings)
+  if (m_debrisGenerators.empty() || !sky.settings)
     return;
 
     Vec2F viewSize = screenSize / pixelRatio;


### PR DESCRIPTION
This just removes the if statement that caused the glitter to only render when the sky type was Orbital or Warp. And Fixes crash if debrisGenerators is empty. 

I made this change as the glitter being so weirdly inconsistent always caused me to download mods that just remove it even though it looks nice, and because this behavior is a lot more like you would expect it to behave.

I assume the if statement was originally added at the time when it was not yet used to display the glitter that is now very much part of starbounds visual identity. 

Before and after: at Koichi's Museum
<img width="2560" height="1365" alt="sky" src="https://github.com/user-attachments/assets/dccffaf7-b721-439d-84e1-1208ab9f824d" />
