### PR TITLE
High DPI with fix for wayland mouse issue.

### DIFF
--- a/source/application/StarMainApplication_sdl.cpp
+++ b/source/application/StarMainApplication_sdl.cpp
@@ -350,6 +350,10 @@ public:
       throw ApplicationException("Application threw exception during startup", e);
     }
 
+#ifdef STAR_SYSTEM_LINUX
+    SDL_SetHint(SDL_HINT_VIDEO_WAYLAND_SCALE_TO_DISPLAY, "1");
+#endif
+    
     Logger::info("Application: Initializing SDL Video");
     if (!SDL_InitSubSystem(SDL_INIT_VIDEO))
       throw ApplicationException(strf("Couldn't initialize SDL Video: {}", SDL_GetError()));
@@ -373,7 +377,7 @@ public:
       Logger::info("Application: No platform services available");
 
     Logger::info("Application: Creating SDL window");
-    m_sdlWindow = SDL_CreateWindow(m_windowTitle.utf8Ptr(), m_windowSize[0], m_windowSize[1], SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE);
+    m_sdlWindow = SDL_CreateWindow(m_windowTitle.utf8Ptr(), m_windowSize[0], m_windowSize[1], SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE | SDL_WINDOW_HIGH_PIXEL_DENSITY);
     if (!m_sdlWindow)
       throw ApplicationException::format("Application: Could not create SDL Window: {}", SDL_GetError());
 


### PR DESCRIPTION
So this is an actual fix for (#292) that was previously addressed by simply reverting `SDL_WINDOW_HIGH_PIXEL_DENSITY`(5085517).
This sets `SDL_HINT_VIDEO_WAYLAND_SCALE_TO_DISPLAY` before we initialize the video driver. As a result, everything remains high-DPI (images don't become blurry when scaling is enabled), and we can still use physical coordinates instead of logical ones, meaning the mouse behaves as expected. The hint was added by SDL for legacy applications. I've implemented proper DPI handling in a different fork, achieving the same outcome, but I believe the clarity of simply using a hint to make Wayland behave like other systems is much better.

Just to clarify: Wayland always applies scaling to the cursor when using a hardware cursor. This doesn't look great, but there's nothing we can do about it since it's just the system cursor displaying our cursor. However, this is visually more acceptable than Everything becoming blurry because of scaling, which is the case without these changes.

Both images show OpenStarbound with 300% scaling (a ridiculous amount of scaling), the first showing with changes (as good as it can be), the second without changes under the same conditions (Everything becomes blurry, cursor looks like its not that mutch bigger because everything is bigger and blurry).
<img width="1214" height="820" alt="cursor 3" src="https://github.com/user-attachments/assets/009fd533-5037-4477-8a04-223e0d7a7c01" />

<img width="684" height="702" alt="cursor 2" src="https://github.com/user-attachments/assets/c25a5148-3f78-4847-af47-12404a119cc5" />

