### PR TITLE
fix vec3/vec4 shader scriptable uniforms

### DIFF
--- a/source/application/StarRenderer.hpp
+++ b/source/application/StarRenderer.hpp
@@ -120,7 +120,7 @@ public:
   virtual void set(List<RenderPrimitive>& primitives) = 0;
 };
 
-typedef Variant<float, int, Vec2F, Vec3F, Vec4F, bool> RenderEffectParameter;
+typedef Variant<float, int, Vec4F, Vec3F, Vec2F, bool> RenderEffectParameter;
 
 class Renderer {
 public:

--- a/source/client/StarRenderingLuaBindings.cpp
+++ b/source/client/StarRenderingLuaBindings.cpp
@@ -18,8 +18,8 @@ LuaCallbacks LuaBindings::makeRenderingCallbacks(ClientApplication* app) {
   // not entirely necessary (root.assetJson can achieve the same purpose) but may as well
   callbacks.registerCallbackWithSignature<Json>("postProcessGroups", bind(mem_fn(&ClientApplication::postProcessGroups), app));
   
-  // typedef Variant<float, int, Vec2F, Vec3F, Vec4F, bool> RenderEffectParameter;
-  // feel free to change this if there's a better way to do this
+  // typedef Variant<float, int, Vec4F, Vec3F, Vec2F, bool> RenderEffectParameter;
+  // TODO: maybe we should be checking the effect's type and converting lua based on that instead of converting to a Variant and relying on the Variant's ordering
   // specifically checks if the effect parameter is an int since Lua prefers converting the values to floats
   callbacks.registerCallback("setEffectParameter", [app](String const& effectName, String const& effectParameter, RenderEffectParameter const& value) {
     auto renderer = app->renderer();


### PR DESCRIPTION
Changes the RenderEffectParameter Variant's type order so Lua prefers converting to Vec4 or Vec3 where possible instead of always converting to Vec2.