### PR TITLE
fseek: handle large files

### DIFF
--- a/source/core/StarFile_unix.cpp
+++ b/source/core/StarFile_unix.cpp
@@ -212,7 +212,7 @@ void* File::fopen(char const* filename, IOMode mode) {
 
 void File::fseek(void* f, StreamOffset offset, IOSeek seekMode) {
   auto fd = fdFromHandle(f);
-  int retCode;
+  StreamOffset retCode;
   if (seekMode == IOSeek::Relative)
     retCode = lseek(fd, offset, SEEK_CUR);
   else if (seekMode == IOSeek::Absolute)


### PR DESCRIPTION
Some mods (like https://steamcommunity.com/sharedfiles/filedetails/?id=2590273034) contain large files (over 2 Gb).

In this case, we hit an error at startup because we `lseek` to a large index in it, and store the result in an `int`, which overflows. And we interpret the overflowed value as an error :')

Here's a (s)trace of this happening:
```
openat(AT_FDCWD, [...]/Steam/steamapps/workshop/content/211820/2590273034/contents.pak", O_RDONLY) = 57
read(57, "SBAsset6", 8)                 = 8
read(57, "\0\0\0\0\2131y\0", 8)         = 8
lseek(57, 2335275264, SEEK_SET)         = 2335275264
```
leading to a garbage error
```
[Error] Application: exception thrown!
[Error] Fatal Exception caught: (IOException) Seek error: No such file or directory
```

So, this is juste a one-line change to store the return value in the correct type :)