### PR TITLE
Make high DPI apply only to non-Mac systems, and small metadata changes

### DIFF
--- a/source/application/StarMainApplication_sdl.cpp
+++ b/source/application/StarMainApplication_sdl.cpp
@@ -387,7 +387,7 @@ public:
       throw ApplicationException::format("Application: Could not create SDL Window: {}", SDL_GetError());
     
 #ifndef STAR_SYSTEM_MACOS
-    m_displayScale = SDL_GetDisplayContentScale(SDL_GetDisplayForWindow(m_sdlWindow));
+    m_displayScale = SDL_GetWindowDisplayScale(m_sdlWindow);
 #endif
     
 #ifdef STAR_SYSTEM_LINUX
@@ -971,7 +971,7 @@ private:
       }
 #ifndef STAR_SYSTEM_MACOS
       else if (event.type == SDL_EVENT_WINDOW_DISPLAY_SCALE_CHANGED) {
-        m_displayScale = SDL_GetDisplayContentScale(SDL_GetDisplayForWindow(m_sdlWindow));
+        m_displayScale = SDL_GetWindowDisplayScale(m_sdlWindow);
       }
 #endif
       else if (event.type == SDL_EVENT_KEY_DOWN && (!io.WantCaptureKeyboard || !io.WantTextInput)) {


### PR DESCRIPTION
Addresses Mac still having the same issue (https://github.com/OpenStarbound/OpenStarbound/pull/446#issuecomment-3865494475) by makes the DPI-related features exclusive to Windows and Linux, which isn't as problematic as disabling high DPI support on all platforms. as mac seems to have a much better scaling function that the system applies to non-high dpi apps, so the Mac version doesn't benefit much from SDL_WINDOW_HIGH_PIXEL_DENSITY.

I also updated the SDL metadata name to OpenStarbound to prevent our icon from being incorrectly replaced by Starbound's.

I removed the version string from the metadata since it doesn’t work and isn’t visible to users anyway.