### PR TITLE
celestial worlds refresh celestial parameters from their own storage 

### DIFF
--- a/source/game/StarUniverseServer.cpp
+++ b/source/game/StarUniverseServer.cpp
@@ -2230,6 +2230,17 @@ Maybe<WorkerPoolPromise<WorldServerThreadPtr>> UniverseServer::celestialWorldPro
       try {
         Logger::info("UniverseServer: Loading celestial world {}", celestialWorldId);
         worldServer = make_shared<WorldServer>(File::open(storageFile, IOMode::ReadWrite));
+
+        auto worldTemplate = worldServer->worldTemplate();
+        auto worldParameters = worldTemplate->celestialParameters().value();
+        CelestialParameters newParameters(
+          celestialWorldId,
+          worldParameters.seed(),
+          worldParameters.name(),
+          worldParameters.parameters()
+        );
+        worldTemplate->setCelestialParameters(newParameters);
+        celestialDatabase->updateParameters(celestialWorldId, newParameters);
       } catch (std::exception const& e) {
         Logger::error("UniverseServer: Could not load celestial world {}, removing! Cause: {}",
                       celestialWorldId, outputException(e, false));

--- a/source/game/StarWorldTemplate.cpp
+++ b/source/game/StarWorldTemplate.cpp
@@ -110,6 +110,10 @@ WorldLayoutPtr WorldTemplate::worldLayout() const {
   return m_layout;
 }
 
+void WorldTemplate::setCelestialParameters(CelestialParameters newParameters){
+  m_celestialParameters = take(newParameters);
+}
+
 void WorldTemplate::setWorldParameters(VisitableWorldParametersPtr newParameters) {
   m_worldParameters = take(newParameters);
 }
@@ -503,7 +507,7 @@ WorldTemplate::PotentialBiomeItems WorldTemplate::potentialBiomeItemsAt(int x, i
   auto lowerBlockBiome = blockBiome(x, y - 1);
   auto upperBlockBiome = blockBiome(x, y + 1);
   auto thisBlockBiome = blockBiome(x, y);
-  
+
   PotentialBiomeItems potentialBiomeItems;
   // surface floor, surface ocean
   if (lowerBlockBiome)

--- a/source/game/StarWorldTemplate.hpp
+++ b/source/game/StarWorldTemplate.hpp
@@ -82,6 +82,7 @@ public:
   SkyParameters skyParameters() const;
   WorldLayoutPtr worldLayout() const;
 
+  void setCelestialParameters(CelestialParameters newParameters);
   void setWorldParameters(VisitableWorldParametersPtr newParameters);
   void setWorldLayout(WorldLayoutPtr newLayout);
   void setSkyParameters(SkyParameters newParameters);


### PR DESCRIPTION
This will prevent incorrect information about a planet being provided by celestial callbacks when a planet has been transplanted to a new coordinate