### PR TITLE
Fix for respawning when playerReviveTime is 0

### DIFF
--- a/source/game/StarUniverseClient.cpp
+++ b/source/game/StarUniverseClient.cpp
@@ -327,7 +327,11 @@ void UniverseClient::update(float dt) {
 
   if (m_respawning) {
     if (m_respawnTimer.ready()) {
-      if ((playerOnOwnShip() || m_worldClient->respawnInWorld()) && m_worldClient->inWorld()) {
+      if (m_worldClient->inWorld()) {
+        if (!playerOnOwnShip() && !m_worldClient->respawnInWorld()) {
+          m_pendingWarp = WarpAlias::OwnShip;
+          m_warpDelay.reset();
+        }
         m_worldClient->reviveMainPlayer();
         m_respawning = false;
       }
@@ -339,9 +343,6 @@ void UniverseClient::update(float dt) {
             {"mode", PlayerModeNames.getRight(m_mainPlayer->modeType())}
           });
         m_mainPlayer->setPendingCinematic(Json(std::move(cinematic)));
-        if (!playerOnOwnShip() && !m_worldClient->respawnInWorld())
-          m_pendingWarp = WarpAlias::OwnShip;
-        m_warpDelay.reset();
       }
     }
   } else {


### PR DESCRIPTION
So I’m going to explain the issue first:

When the respawn timer is set to 0, then we check if they are on their ship or in a world with respawnInWorld true. But the logic for warping the player to the ship is in the tick function, which never occurs as the timer is already finished.

To fix this, I made it so we check if the client is in world, and then separately check if they are not on ship or not in a world that they can respawn in. If that is the case, then we warp them.