### PR TITLE
initialize m_checkedUGC, m_interruptRadioMessage

### DIFF
--- a/source/application/StarUserGeneratedContentService_pc_steam.cpp
+++ b/source/application/StarUserGeneratedContentService_pc_steam.cpp
@@ -5,7 +5,8 @@
 namespace Star {
 
 SteamUserGeneratedContentService::SteamUserGeneratedContentService(PcPlatformServicesStatePtr)
-  : m_callbackDownloadResult(this, &SteamUserGeneratedContentService::onDownloadResult) {};
+  : m_callbackDownloadResult(this, &SteamUserGeneratedContentService::onDownloadResult),
+    m_checkedUGC(false) {};
 
 StringList SteamUserGeneratedContentService::subscribedContentIds() const {
   List<PublishedFileId_t> contentIds(SteamUGC()->GetNumSubscribedItems(), {});

--- a/source/game/StarPlayer.cpp
+++ b/source/game/StarPlayer.cpp
@@ -138,6 +138,8 @@ Player::Player(PlayerConfigPtr config, Uuid uuid) {
   m_chatMessageChanged = false;
   m_chatMessageUpdated = false;
 
+  m_interruptRadioMessage = false;
+
   m_songbook = make_shared<Songbook>(species());
 
   m_lastDamagedOtherTimer = 0;


### PR DESCRIPTION
fixes post-mod-update asset reload being run unnecessarily, and radio messages being erroneously skipped
(not all builds and systems are affected - the latter seems to not affect CI linux builds at all, with m_interruptRadioMessage always starting out as 0 despite not being initialized)