### PR TITLE
fix crash in pane.addWidget, widget.addChild with specific widget types

### DIFF
--- a/source/windowing/StarPane.cpp
+++ b/source/windowing/StarPane.cpp
@@ -397,11 +397,14 @@ LuaCallbacks Pane::makePaneCallbacks() {
   callbacks.registerCallback("getSize", [this]() -> Vec2I         {  return size();  });
   callbacks.registerCallback("setSize", [this](Vec2I const& size) { setSize(size);   });
 
-  callbacks.registerCallback("addWidget", [this](Json const& newWidgetConfig, Maybe<String> const& newWidgetName) -> LuaCallbacks {
+  callbacks.registerCallback("addWidget", [this](Json const& newWidgetConfig, Maybe<String> const& newWidgetName) -> Maybe<LuaCallbacks> {
       String name = newWidgetName.value(toString(Random::randu64()));
-      WidgetPtr newWidget = reader()->makeSingle(name, newWidgetConfig);
-      this->addChild(name, newWidget);
-      return LuaBindings::makeWidgetCallbacks(newWidget.get(), reader());
+      if (auto newWidget = reader()->makeSingle(name, newWidgetConfig)) {
+        this->addChild(name, newWidget);
+        return LuaBindings::makeWidgetCallbacks(newWidget.get(), reader());
+      } else {
+        return {};
+      }
     });
 
   callbacks.registerCallback("removeWidget", [this](String const& widgetName) -> bool

--- a/source/windowing/StarWidgetLuaBindings.cpp
+++ b/source/windowing/StarWidgetLuaBindings.cpp
@@ -200,8 +200,8 @@ LuaCallbacks LuaBindings::makeWidgetCallbacks(Widget* parentWidget, GuiReaderPtr
   callbacks.registerCallback("addChild", [parentWidget, reader](String const& widgetName, Json const& newChildConfig, Maybe<String> const& newChildName) {
       if (auto widget = parentWidget->fetchChild<Widget>(widgetName)) {
         String name = newChildName.value(toString(Random::randu64()));
-        WidgetPtr newChild = reader->makeSingle(name, newChildConfig);
-        widget->addChild(name, newChild);
+        if (auto newChild = reader->makeSingle(name, newChildConfig))
+          widget->addChild(name, newChild);
       }
     });
 


### PR DESCRIPTION
`GuiReader::makeSingle` can return a null pointer if the passed widget type is either "background", "title", or "panefeature" (all of these modify the pane's properties instead of creating a widget).
trying to create a widget of one of the listed types via `pane.addWidget` or `widget.addChild` would crash in `Widget::addChild` trying to set the non-existent widget's name.