### PR TITLE
fix typo that prevents asset packer from being verbose

### DIFF
--- a/source/utility/asset_packer.cpp
+++ b/source/utility/asset_packer.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv) {
       }
     }
 
-    bool verbose = opts.parameters.contains("v");
+    bool verbose = opts.switches.contains("v");
 
     function<void(size_t, size_t, String, String, bool)> BuildProgressCallback;
     auto progressCallback = [verbose](size_t, size_t, String filePath, String assetPath) {


### PR DESCRIPTION
should make the verbose `-v` argument work when using asset_packer.exe
  its one line :3 i barely know c++ 

<br><img width="900" alt="image" src="https://github.com/user-attachments/assets/fef97fa5-9e12-490e-bc5e-ef9b641a3a85" /> 
its like above when i build with the change 

<br><img width="900" alt="aaaaaaaaaaaaaaaa" src="https://github.com/user-attachments/assets/c00eac39-b092-43c7-be19-e30ac9800764" />

and this when i build from main

i wonder if this option ever worked on retail sb