### PR TITLE
Allow changing which UI MMUpgrade/Collections sidebar buttons open

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Note: Not every function from [StarExtensions](https://github.com/StarExtensions
 * Perfectly Generic Items will retain the data for what item they were if a mod is uninstalled, and will attempt to restore themselves if re-installed.
 * Musical instruments have their own volume slider in the options menu.
 * Players can use items while lounging
+* Mods can change which scriptPane the Matter Manipulator/Collections sidebar button opens, in [interface.config.patch](https://github.com/OpenStarbound/OpenStarbound/blob/main/assets/interface.config.patch).
 
 * Client-side tile placement prediction (rewrite from StarExtensions)
   * You can also resize the placement area of tiles on the fly.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Note: Not every function from [StarExtensions](https://github.com/StarExtensions
 * Perfectly Generic Items will retain the data for what item they were if a mod is uninstalled, and will attempt to restore themselves if re-installed.
 * Musical instruments have their own volume slider in the options menu.
 * Players can use items while lounging
-* Mods can change which scriptPane the Matter Manipulator/Collections sidebar button opens, in [interface.config.patch](https://github.com/OpenStarbound/OpenStarbound/blob/main/assets/interface.config.patch).
+* Mods can change which scriptPane the Matter Manipulator/Collections sidebar button opens, in [interface.config.patch](https://github.com/OpenStarbound/OpenStarbound/blob/main/assets/opensb/interface.config.patch).
 
 * Client-side tile placement prediction (rewrite from StarExtensions)
   * You can also resize the placement area of tiles on the fly.

--- a/assets/opensb/interface.config.patch
+++ b/assets/opensb/interface.config.patch
@@ -48,6 +48,15 @@
     "fontSize" : 24
   },
 
+  "mainBar" : {
+    "collections" : {
+      "scriptPane" : "/interface/scripted/collections/collectionsgui.config"
+    },
+    "mmUpgrade" : {
+      "scriptPane" : "/interface/scripted/mmupgrade/mmupgradegui.config"
+    }
+  },
+
   "buttonClickSound" : [ "/sfx/interface/button/click.wav" ],
   "buttonReleaseSound" : [ "/sfx/interface/button/release.wav" ],
   "buttonHoverSound" : [ "/sfx/interface/button/hover.wav" ],

--- a/assets/opensb/interface.config.patch
+++ b/assets/opensb/interface.config.patch
@@ -48,7 +48,8 @@
     "fontSize" : 24
   },
 
-  /* You can edit which panes they open. They default to their vanilla values if unset
+  // You can edit which panes they open. They default to their vanilla values if unset
+  /*
   "mainBar" : {
     "collections" : {
       "scriptPane" : "/interface/scripted/collections/collectionsgui.config"

--- a/assets/opensb/interface.config.patch
+++ b/assets/opensb/interface.config.patch
@@ -48,6 +48,7 @@
     "fontSize" : 24
   },
 
+  /* You can edit which panes they open. They default to their vanilla values if unset
   "mainBar" : {
     "collections" : {
       "scriptPane" : "/interface/scripted/collections/collectionsgui.config"
@@ -56,6 +57,7 @@
       "scriptPane" : "/interface/scripted/mmupgrade/mmupgradegui.config"
     }
   },
+  */
 
   "buttonClickSound" : [ "/sfx/interface/button/click.wav" ],
   "buttonReleaseSound" : [ "/sfx/interface/button/release.wav" ],

--- a/source/frontend/StarMainInterface.cpp
+++ b/source/frontend/StarMainInterface.cpp
@@ -140,10 +140,10 @@ MainInterface::MainInterface(UniverseClientPtr client, WorldPainterPtr painter, 
   m_questTracker = make_shared<QuestTrackerPane>();
   m_paneManager.registerPane(MainInterfacePanes::QuestTracker, PaneLayer::Hud, m_questTracker);
 
-  m_mmUpgrade = make_shared<ScriptPane>(m_client, Root::singleton().assets()->json("/interface.config:mainBar.mmUpgrade.scriptPane").toString());
+  m_mmUpgrade = make_shared<ScriptPane>(m_client, Root::singleton().assets()->json("/interface.config:mainBar.mmUpgrade").getString("scriptPane", "/interface/scripted/mmupgrade/mmupgradegui.config"));
   m_paneManager.registerPane(MainInterfacePanes::MmUpgrade, PaneLayer::Window, m_mmUpgrade);
 
-  m_collections = make_shared<ScriptPane>(m_client, Root::singleton().assets()->json("/interface.config:mainBar.collections.scriptPane").toString());
+  m_collections = make_shared<ScriptPane>(m_client, Root::singleton().assets()->json("/interface.config:mainBar.collections").getString("scriptPane", "/interface/scripted/collections/collectionsgui.config"));
   m_paneManager.registerPane(MainInterfacePanes::Collections, PaneLayer::Window, m_collections);
 
   m_chat = make_shared<Chat>(m_client, Root::singleton().assets()->json("/interface/chat/chat.config"));

--- a/source/frontend/StarMainInterface.cpp
+++ b/source/frontend/StarMainInterface.cpp
@@ -140,10 +140,10 @@ MainInterface::MainInterface(UniverseClientPtr client, WorldPainterPtr painter, 
   m_questTracker = make_shared<QuestTrackerPane>();
   m_paneManager.registerPane(MainInterfacePanes::QuestTracker, PaneLayer::Hud, m_questTracker);
 
-  m_mmUpgrade = make_shared<ScriptPane>(m_client, "/interface/scripted/mmupgrade/mmupgradegui.config");
+  m_mmUpgrade = make_shared<ScriptPane>(m_client, Root::singleton().assets()->json("/interface.config:mainBar.mmUpgrade.scriptPane").toString());
   m_paneManager.registerPane(MainInterfacePanes::MmUpgrade, PaneLayer::Window, m_mmUpgrade);
 
-  m_collections = make_shared<ScriptPane>(m_client, "/interface/scripted/collections/collectionsgui.config");
+  m_collections = make_shared<ScriptPane>(m_client, Root::singleton().assets()->json("/interface.config:mainBar.collections.scriptPane").toString());
   m_paneManager.registerPane(MainInterfacePanes::Collections, PaneLayer::Window, m_collections);
 
   m_chat = make_shared<Chat>(m_client, Root::singleton().assets()->json("/interface/chat/chat.config"));


### PR DESCRIPTION
Mods can change which scriptPane the Matter Manipulator/Collections sidebar button opens, in interface.config.patch. By default this is commented out in the assets.

The engine defaults to the vanilla ones if interface.config isn't changing it (thanks patman!!)