### PR TITLE
Haiku port

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -82,6 +82,8 @@ if(NOT DEFINED STAR_SYSTEM)
     set(STAR_SYSTEM "freebsd")
   elseif(${CMAKE_SYSTEM_NAME} STREQUAL "NetBSD")
     set(STAR_SYSTEM "netbsd")
+  elseif(${CMAKE_SYSTEM_NAME} STREQUAL "Haiku")
+    set(STAR_SYSTEM "haiku")
   elseif(UNIX)
     set(STAR_SYSTEM "unix")
   else()
@@ -192,7 +194,7 @@ endfunction()
 
 if(STAR_LITTLE_ENDIAN)
   set_flag(STAR_LITTLE_ENDIAN)
-elseif()
+else()
   set_flag(STAR_BIG_ENDIAN)
 endif()
 
@@ -212,6 +214,8 @@ elseif(STAR_SYSTEM STREQUAL "freebsd")
   set_flag(STAR_SYSTEM_FREEBSD)
 elseif(STAR_SYSTEM STREQUAL "netbsd")
   set_flag(STAR_SYSTEM_NETBSD)
+elseif(STAR_SYSTEM STREQUAL "haiku")
+  set_flag(STAR_SYSTEM_HAIKU)
 endif()
 
 if(STAR_SYSTEM_FAMILY STREQUAL "windows")
@@ -453,6 +457,10 @@ elseif(STAR_SYSTEM_NETBSD)
   set(CMAKE_C_STANDARD_LIBRARIES "${CMAKE_C_STANDARD_LIBRARIES} -lpthread -lrt -lexecinfo")
   set(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} -lpthread -lrt -lexecinfo")
 
+elseif(STAR_SYSTEM_HAIKU)
+  set(CMAKE_C_STANDARD_LIBRARIES "${CMAKE_C_STANDARD_LIBRARIES} -lpthread -lexecinfo -lnetwork")
+  set(CMAKE_CXX_STANDARD_LIBRARIES "${CMAKE_CXX_STANDARD_LIBRARIES} -lpthread -lexecinfo -lnetwork")
+
 endif()
 
 # Find all required external libraries, based on build settings...
@@ -476,24 +484,26 @@ find_package(ZLIB REQUIRED)
 find_package(PNG REQUIRED)
 find_package(Freetype REQUIRED)
 find_package(cpr CONFIG REQUIRED)
-find_package(Opus CONFIG REQUIRED)
 find_package(OggVorbis REQUIRED)
 find_package(zstd CONFIG REQUIRED)
-find_package(re2 CONFIG REQUIRED)
 find_package(imgui CONFIG REQUIRED)
+if (NOT STAR_SYSTEM_HAIKU)
+	find_package(Opus CONFIG REQUIRED)
+	find_package(re2 CONFIG REQUIRED)
+endif()
 include_directories(SYSTEM
-        ${FREETYPE_INCLUDE_DIRS}
-        ${OGGVORBIS_INCLUDE_DIR}
+    ${FREETYPE_INCLUDE_DIRS}
+    ${OGGVORBIS_INCLUDE_DIR}
 )
 
 set(STAR_EXT_LIBS ${STAR_EXT_LIBS}
-        ZLIB::ZLIB
-        PNG::PNG
-        cpr::cpr
+    ZLIB::ZLIB
+    PNG::PNG
+    cpr::cpr
     $<IF:$<TARGET_EXISTS:Freetype::Freetype>,Freetype::Freetype,freetype>
     $<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>
-    Opus::opus
-    re2::re2
+    $<IF:$<TARGET_EXISTS:Opus::opus>,Opus::opus,opus>
+    $<IF:$<TARGET_EXISTS:re2::re2>,re2::re2,re2>
     imgui::imgui
     ${VORBISFILE_LIBRARY}
     ${VORBIS_LIBRARY}
@@ -507,7 +517,7 @@ else()
   message(STATUS "Wayland was not found")
 endif()
 
-if(STAR_SYSTEM_FAMILY STREQUAL "unix")
+if(STAR_SYSTEM_FAMILY STREQUAL "unix" AND NOT STAR_SYSTEM_HAIKU)
   set_flag(STAR_USE_CPPTRACE)
   find_package(cpptrace CONFIG REQUIRED)
   set(STAR_EXT_LIBS ${STAR_EXT_LIBS} cpptrace::cpptrace)
@@ -528,7 +538,7 @@ if(STAR_BUILD_GUI)
   include_directories(SYSTEM ${GLEW_INCLUDE_DIR})
   set(STAR_EXT_GUI_LIBS ${STAR_EXT_GUI_LIBS}
       ${OPENGL_LIBRARY}
-      GLEW::glew_s
+      $<IF:$<TARGET_EXISTS:GLEW::glew_s>,GLEW::glew_s,GLEW>
   )
 
   if(STAR_SYSTEM_MACOS)

--- a/source/core/StarFile_unix.cpp
+++ b/source/core/StarFile_unix.cpp
@@ -64,11 +64,21 @@ List<pair<String, bool>> File::dirList(const String& dirName, bool skipDots) {
     String entryString = entry->d_name;
     if (!skipDots || (entryString != "." && entryString != "..")) {
       bool isDirectory = false;
+      #ifdef STAR_SYSTEM_HAIKU
+      struct stat stbuf;
+	  stat(entry->d_name, &stbuf);
+	  if (S_ISDIR(stbuf.st_mode)) {
+        isDirectory = true; 
+	  } else if (S_ISLNK(stbuf.st_mode) || !S_ISREG(stbuf.st_mode)) {
+        isDirectory = File::isDirectory(File::relativeTo(dirName, entryString));
+      }
+      #else
       if (entry->d_type == DT_DIR) {
         isDirectory = true;
       } else if (entry->d_type == DT_LNK || entry->d_type == DT_UNKNOWN) {
         isDirectory = File::isDirectory(File::relativeTo(dirName, entryString));
       }
+      #endif
       fileList.append({entryString, isDirectory});
     }
   }


### PR DESCRIPTION
Some patches based on my experience with #495, these changes allow OpenStarbound to build and run under Haiku 64bit, provided one has the correct libraries.
The main binary still crashes as described in the issue above but I think these initial bits of the port are good enough to be looked at.

`!S_ISREG(stbuf.st_mode)` in `StarFile_unix.cpp` in the directories check is probably not right but I didn't know what to put there tbh.

I think the changes in `CMakeLists.txt` are fine but I haven't checked on other platforms.

This is not the full amount of changes I'm making to have a successful build, I am also having to patch some ImGui-related variable names in `source/client/StarClientApplication.cpp` and `source/extern/imgui_iterator.inl`.

As I'm using ImGui 1.92.7 to build this I suspect some version mismatch so I'm holding off on including those changes.

I'm using GNU Make for compilation, after invoking CMake like this:
> cmake -Bbuild -Ssource/ -DSTAR_BUILD_QT_TOOLS=ON -DCMAKE_CXX_FLAGS="-D_DEFAULT_SOURCE -D_GNU_SOURCE" -DCMAKE_BUILD_TYPE=Release