### PR TITLE
Feat: security features for Teams and Warps

### DIFF
--- a/source/game/StarTeamManager.cpp
+++ b/source/game/StarTeamManager.cpp
@@ -4,12 +4,14 @@
 #include "StarRoot.hpp"
 #include "StarAssets.hpp"
 #include "StarText.hpp"
+#include "StarLogging.hpp"
 
 namespace Star {
 
 TeamManager::TeamManager() {
   m_pvpTeamCounter = 1;
   m_maxTeamSize = Root::singleton().configuration()->get("maxTeamSize").toUInt();
+  m_polledInvitationTimeout = Root::singleton().configuration()->getPath("teamInvitationTimeout", Json(60.0)).toDouble();
 }
 
 JsonRpcHandlers TeamManager::rpcHandlers() {
@@ -21,6 +23,24 @@ JsonRpcHandlers TeamManager::rpcHandlers() {
     {"team.acceptInvitation", bind(&TeamManager::acceptInvitation, this, _1)},
     {"team.makeLeader", bind(&TeamManager::makeLeader, this, _1)},
     {"team.removeFromTeam", [&](Json request) -> Json { return removeFromTeam(request); }}
+  };
+}
+
+JsonRpcHandlers TeamManager::authenticatedRpcHandlers(Uuid const& callerUuid) {
+  auto wrap = [&](String const& name, JsonRpcRemoteFunction fn) -> pair<String, JsonRpcRemoteFunction> {
+    return {name, [callerUuid, fn = std::move(fn)](Json const& args) -> Json {
+        return fn(args.set("_callerUuid", callerUuid.hex()));
+        }};
+  };
+
+  return JsonRpcHandlers{
+    wrap("team.fetchTeamStatus", bind(&TeamManager::fetchTeamStatus, this, _1)),
+    wrap("team.updateStatus", bind(&TeamManager::updateStatus, this, _1)),
+    wrap("team.invite", bind(&TeamManager::invite, this, _1)),
+    wrap("team.pollInvitation", bind(&TeamManager::pollInvitation, this, _1)),
+    wrap("team.acceptInvitation", bind(&TeamManager::acceptInvitation, this, _1)),
+    wrap("team.makeLeader", bind(&TeamManager::makeLeader, this, _1)),
+    wrap("team.removeFromTeam", [this](Json const& request) -> Json { return removeFromTeam(request); })
   };
 }
 
@@ -69,12 +89,23 @@ Maybe<Uuid> TeamManager::getTeam(Uuid const& playerUuid) const {
 
 void TeamManager::purgeInvitationsFor(Uuid const& playerUuid) {
   m_invitations.remove(playerUuid);
+  m_polledInvitations.remove(playerUuid);
 }
 
 void TeamManager::purgeInvitationsFrom(Uuid const& playerUuid) {
   eraseWhere(m_invitations, [playerUuid](auto const& invitation) {
-      return invitation.second.inviterUuid == playerUuid;
-    });
+    return invitation.second.inviterUuid == playerUuid;
+  });
+  eraseWhere(m_polledInvitations, [playerUuid](auto const& polled) {
+    return polled.second.inviterUuid == playerUuid;
+  });
+}
+
+void TeamManager::expirePolledInvitations() {
+  double now = Time::monotonicTime();
+  eraseWhere(m_polledInvitations, [&](auto const& entry) {
+    return (now - entry.second.polledAt) >= m_polledInvitationTimeout;
+  });
 }
 
 bool TeamManager::playerWithUuidExists(Uuid const& playerUuid) const {
@@ -172,6 +203,14 @@ bool TeamManager::removeFromTeam(Uuid const& playerUuid, Uuid const& teamUuid) {
 Json TeamManager::fetchTeamStatus(Json const& arguments) {
   RecursiveMutexLocker lock(m_mutex);
   auto playerUuid = Uuid(arguments.getString("playerUuid"));
+
+  if (auto callerHex = arguments.optString("_callerUuid")) {
+    if (Uuid(*callerHex) != playerUuid) {
+      Logger::warn("TeamManager: Rejected fetchTeamStatus from {} for {}", *callerHex, playerUuid.hex());
+      return {};
+    }
+  }
+
   JsonObject result;
   if (auto teamUuid = getTeam(playerUuid)) {
     auto& team = m_teams.get(*teamUuid);
@@ -203,6 +242,14 @@ Json TeamManager::fetchTeamStatus(Json const& arguments) {
 Json TeamManager::updateStatus(Json const& arguments) {
   RecursiveMutexLocker lock(m_mutex);
   auto playerUuid = Uuid(arguments.getString("playerUuid"));
+
+  if (auto callerHex = arguments.optString("_callerUuid")) {
+    if (Uuid(*callerHex) != playerUuid) {
+      Logger::warn("TeamManager: Rejected updateStatus from {} spoofing {}", *callerHex, playerUuid.hex());
+      return "unauthorized";
+    }
+  }
+
   if (auto teamUuid = getTeam(playerUuid)) {
     auto& team = m_teams.get(*teamUuid);
     auto& entry = team.members.get(playerUuid);
@@ -234,6 +281,13 @@ Json TeamManager::invite(Json const& arguments) {
 
   auto inviterUuid = Uuid(arguments.getString("inviterUuid"));
 
+  if (auto callerHex = arguments.optString("_callerUuid")) {
+    if (Uuid(*callerHex) != inviterUuid) {
+      Logger::warn("TeamManager: Rejected invite from {} spoofing inviter {}", *callerHex, inviterUuid.hex());
+      return "unauthorized";
+    }
+  }
+
   JsonArray invited;
   for (auto& entry : m_connectedPlayers) {
     if (!Text::stripEscapeCodes(entry.first).beginsWith(inviteeName, String::CaseInsensitive))
@@ -244,6 +298,7 @@ Json TeamManager::invite(Json const& arguments) {
       invitation.inviterUuid = inviterUuid;
       invitation.inviterName = arguments.getString("inviterName");
       m_invitations[inviteeUuid] = invitation;
+      m_polledInvitations.remove(inviteeUuid);
       invited.append(JsonArray{entry.first, inviteeUuid.hex()});
     }
   }
@@ -257,8 +312,19 @@ Json TeamManager::invite(Json const& arguments) {
 Json TeamManager::pollInvitation(Json const& arguments) {
   RecursiveMutexLocker lock(m_mutex);
   auto playerUuid = Uuid(arguments.getString("playerUuid"));
+
+  if (auto callerHex = arguments.optString("_callerUuid")) {
+    if (Uuid(*callerHex) != playerUuid) {
+      Logger::warn("TeamManager: Rejected pollInvitation from {} for {}", *callerHex, playerUuid.hex());
+      return {};
+    }
+  }
+
+  expirePolledInvitations();
+
   if (m_invitations.contains(playerUuid)) {
     auto invite = m_invitations.take(playerUuid);
+    m_polledInvitations[playerUuid] = PolledInvitation{invite.inviterUuid, Time::monotonicTime()};
     JsonObject result;
     result["inviterUuid"] = invite.inviterUuid.hex();
     result["inviterName"] = invite.inviterName;
@@ -272,8 +338,25 @@ Json TeamManager::acceptInvitation(Json const& arguments) {
   auto inviterUuid = Uuid(arguments.getString("inviterUuid"));
   auto inviteeUuid = Uuid(arguments.getString("inviteeUuid"));
 
+  if (auto callerHex = arguments.optString("_callerUuid")) {
+    if (Uuid(*callerHex) != inviteeUuid) {
+      Logger::warn("TeamManager: Rejected acceptInvitation from {} spoofing invitee {}", *callerHex, inviteeUuid.hex());
+      return "unauthorized";
+    }
+  }
+
   if (!playerWithUuidExists(inviterUuid) || !playerWithUuidExists(inviteeUuid))
     return "acceptInvitationFailed";
+
+  expirePolledInvitations();
+
+  auto polledIt = m_polledInvitations.find(inviteeUuid);
+  if (polledIt == m_polledInvitations.end() || polledIt->second.inviterUuid != inviterUuid) {
+    Logger::warn("TeamManager: Rejected acceptInvitation - no valid polled invitation from {} to {}", inviterUuid.hex(), inviteeUuid.hex());
+    return "noInvitationPending";
+  }
+
+  m_polledInvitations.remove(inviteeUuid);
 
   purgeInvitationsFrom(inviteeUuid);
 
@@ -288,8 +371,19 @@ Json TeamManager::acceptInvitation(Json const& arguments) {
 }
 
 Json TeamManager::removeFromTeam(Json const& arguments) {
+  RecursiveMutexLocker lock(m_mutex);
   auto playerUuid = Uuid(arguments.getString("playerUuid"));
   auto teamUuid = Uuid(arguments.getString("teamUuid"));
+
+  if (auto callerHex = arguments.optString("_callerUuid")) {
+    Uuid callerUuid(*callerHex);
+    if (callerUuid != playerUuid) {
+      if (!m_teams.contains(teamUuid) || m_teams.get(teamUuid).leaderUuid != callerUuid) {
+        Logger::warn("TeamManager: Rejected removeFromTeam by non-leader {} targeting {}", callerUuid.hex(), playerUuid.hex());
+        return "unauthorized";
+      }
+    }
+  }
 
   auto success = removeFromTeam(playerUuid, teamUuid);
   return success ? Json() : "removeFromTeamFailed";
@@ -304,6 +398,13 @@ Json TeamManager::makeLeader(Json const& arguments) {
     return "noSuchTeam";
 
   auto& team = m_teams.get(teamUuid);
+
+  if (auto callerHex = arguments.optString("_callerUuid")) {
+    if (Uuid(*callerHex) != team.leaderUuid) {
+      Logger::warn("TeamManager: Rejected makeLeader by non-leader {} in team {}", *callerHex, teamUuid.hex());
+      return "unauthorized";
+    }
+  }
 
   if (!team.members.contains(playerUuid))
     return "notAMemberOfTeam";

--- a/source/game/StarTeamManager.cpp
+++ b/source/game/StarTeamManager.cpp
@@ -11,7 +11,8 @@ namespace Star {
 TeamManager::TeamManager() {
   m_pvpTeamCounter = 1;
   m_maxTeamSize = Root::singleton().configuration()->get("maxTeamSize").toUInt();
-  m_polledInvitationTimeout = Root::singleton().configuration()->getPath("teamInvitationTimeout", Json(60.0)).toDouble();
+  m_polledInvitationTimeout = Root::singleton().configuration()->getPath("teamInvitationTimeout", Json(600.0)).toDouble();
+  m_secureTeams = Root::singleton().configuration()->getPath("security.secureTeams").optBool().value(true);
 }
 
 JsonRpcHandlers TeamManager::rpcHandlers() {
@@ -205,7 +206,7 @@ Json TeamManager::fetchTeamStatus(Json const& arguments) {
   auto playerUuid = Uuid(arguments.getString("playerUuid"));
 
   if (auto callerHex = arguments.optString("_callerUuid")) {
-    if (Uuid(*callerHex) != playerUuid) {
+    if (m_secureTeams && Uuid(*callerHex) != playerUuid) {
       Logger::warn("TeamManager: Rejected fetchTeamStatus from {} for {}", *callerHex, playerUuid.hex());
       return {};
     }
@@ -244,7 +245,7 @@ Json TeamManager::updateStatus(Json const& arguments) {
   auto playerUuid = Uuid(arguments.getString("playerUuid"));
 
   if (auto callerHex = arguments.optString("_callerUuid")) {
-    if (Uuid(*callerHex) != playerUuid) {
+    if (m_secureTeams && Uuid(*callerHex) != playerUuid) {
       Logger::warn("TeamManager: Rejected updateStatus from {} spoofing {}", *callerHex, playerUuid.hex());
       return "unauthorized";
     }
@@ -282,7 +283,7 @@ Json TeamManager::invite(Json const& arguments) {
   auto inviterUuid = Uuid(arguments.getString("inviterUuid"));
 
   if (auto callerHex = arguments.optString("_callerUuid")) {
-    if (Uuid(*callerHex) != inviterUuid) {
+    if (m_secureTeams && Uuid(*callerHex) != inviterUuid) {
       Logger::warn("TeamManager: Rejected invite from {} spoofing inviter {}", *callerHex, inviterUuid.hex());
       return "unauthorized";
     }
@@ -314,7 +315,7 @@ Json TeamManager::pollInvitation(Json const& arguments) {
   auto playerUuid = Uuid(arguments.getString("playerUuid"));
 
   if (auto callerHex = arguments.optString("_callerUuid")) {
-    if (Uuid(*callerHex) != playerUuid) {
+    if (m_secureTeams && Uuid(*callerHex) != playerUuid) {
       Logger::warn("TeamManager: Rejected pollInvitation from {} for {}", *callerHex, playerUuid.hex());
       return {};
     }
@@ -339,7 +340,7 @@ Json TeamManager::acceptInvitation(Json const& arguments) {
   auto inviteeUuid = Uuid(arguments.getString("inviteeUuid"));
 
   if (auto callerHex = arguments.optString("_callerUuid")) {
-    if (Uuid(*callerHex) != inviteeUuid) {
+    if (m_secureTeams && Uuid(*callerHex) != inviteeUuid) {
       Logger::warn("TeamManager: Rejected acceptInvitation from {} spoofing invitee {}", *callerHex, inviteeUuid.hex());
       return "unauthorized";
     }
@@ -377,7 +378,7 @@ Json TeamManager::removeFromTeam(Json const& arguments) {
 
   if (auto callerHex = arguments.optString("_callerUuid")) {
     Uuid callerUuid(*callerHex);
-    if (callerUuid != playerUuid) {
+    if (m_secureTeams && callerUuid != playerUuid) {
       if (!m_teams.contains(teamUuid) || m_teams.get(teamUuid).leaderUuid != callerUuid) {
         Logger::warn("TeamManager: Rejected removeFromTeam by non-leader {} targeting {}", callerUuid.hex(), playerUuid.hex());
         return "unauthorized";
@@ -400,7 +401,7 @@ Json TeamManager::makeLeader(Json const& arguments) {
   auto& team = m_teams.get(teamUuid);
 
   if (auto callerHex = arguments.optString("_callerUuid")) {
-    if (Uuid(*callerHex) != team.leaderUuid) {
+    if (m_secureTeams && Uuid(*callerHex) != team.leaderUuid) {
       Logger::warn("TeamManager: Rejected makeLeader by non-leader {} in team {}", *callerHex, teamUuid.hex());
       return "unauthorized";
     }

--- a/source/game/StarTeamManager.hpp
+++ b/source/game/StarTeamManager.hpp
@@ -74,6 +74,7 @@ private:
 
   unsigned m_maxTeamSize;
   double m_polledInvitationTimeout;
+  bool m_secureTeams;
 
   TeamNumber m_pvpTeamCounter;
 

--- a/source/game/StarTeamManager.hpp
+++ b/source/game/StarTeamManager.hpp
@@ -17,6 +17,8 @@ public:
 
   JsonRpcHandlers rpcHandlers();
 
+  JsonRpcHandlers authenticatedRpcHandlers(Uuid const& callerUuid);
+
   void setConnectedPlayers(StringMap<List<Uuid>> connectedPlayers);
   void playerDisconnected(Uuid const& playerUuid);
 
@@ -49,8 +51,14 @@ private:
     String inviterName;
   };
 
+  struct PolledInvitation {
+    Uuid inviterUuid;
+    double polledAt;
+  };
+
   void purgeInvitationsFor(Uuid const& playerUuid);
   void purgeInvitationsFrom(Uuid const& playerUuid);
+  void expirePolledInvitations();
 
   bool playerWithUuidExists(Uuid const& playerUuid) const;
 
@@ -62,8 +70,10 @@ private:
   Map<Uuid, Team> m_teams;
   StringMap<List<Uuid>> m_connectedPlayers;
   Map<Uuid, Invitation> m_invitations;
+  Map<Uuid, PolledInvitation> m_polledInvitations;
 
   unsigned m_maxTeamSize;
+  double m_polledInvitationTimeout;
 
   TeamNumber m_pvpTeamCounter;
 

--- a/source/game/StarUniverseServer.cpp
+++ b/source/game/StarUniverseServer.cpp
@@ -904,6 +904,23 @@ void UniverseServer::warpPlayers() {
     if (!clientContext)
       continue;
 
+    if (auto toPlayerUuid = warpAction.ptr<WarpToPlayer>()) {
+      bool authorized = clientContext->isAdmin();
+      if (!authorized) {
+        auto requesterTeam = m_teamManager->getTeam(clientContext->playerUuid());
+        auto targetTeam = m_teamManager->getTeam(*toPlayerUuid);
+        if (requesterTeam && targetTeam && *requesterTeam == *targetTeam)
+          authorized = true;
+      }
+      if (!authorized) {
+        Logger::warn("UniverseServer: Denied WarpToPlayer from client {} ({}) to UUID {}",
+                     clientId, clientContext->descriptiveName(), toPlayerUuid->hex());
+        m_connectionServer->sendPackets(clientId, {make_shared<PlayerWarpResultPacket>(false, warpAction, true)});
+        m_pendingPlayerWarps.remove(clientId);
+        continue;
+      }
+    }
+
     WarpToWorld warpToWorld = resolveWarpAction(warpAction, clientId, deploy);
 
     if (auto maybeToWorld = triggerWorldCreation(warpToWorld.world)) {
@@ -1621,7 +1638,70 @@ void UniverseServer::packetsReceived(UniverseConnectionServer*, ConnectionId cli
     clientsLocker.unlock();
 
     for (auto& packet : packets) {
+      auto packetType = packet->type();
+
+      switch (packetType) {
+        case PacketType::PlayerWarp:
+        case PacketType::FlyShip:
+        case PacketType::ChatSend:
+        case PacketType::ClientContextUpdate:
+        case PacketType::ClientDisconnectRequest:
+        case PacketType::CelestialRequest:
+        case PacketType::SystemObjectSpawn:
+        // World client -> server packets
+        case PacketType::ModifyTileList:
+        case PacketType::ReplaceTileList:
+        case PacketType::DamageTileGroup:
+        case PacketType::CollectLiquid:
+        case PacketType::RequestDrop:
+        case PacketType::SpawnEntity:
+        case PacketType::ConnectWire:
+        case PacketType::DisconnectAllWires:
+        case PacketType::WorldClientStateUpdate:
+        case PacketType::FindUniqueEntity:
+        case PacketType::WorldStartAcknowledge:
+        case PacketType::Ping:
+        // Bidirectional packets
+        case PacketType::EntityCreate:
+        case PacketType::EntityUpdateSet:
+        case PacketType::EntityDestroy:
+        case PacketType::EntityInteract:
+        case PacketType::EntityInteractResult:
+        case PacketType::HitRequest:
+        case PacketType::DamageRequest:
+        case PacketType::DamageNotification:
+        case PacketType::EntityMessage:
+        case PacketType::EntityMessageResponse:
+        case PacketType::UpdateWorldProperties:
+        case PacketType::StepUpdate:
+          break; // allowed
+        default:
+            Logger::warn("UniverseServer: Dropping unexpected {} packet from client {}", 
+                PacketTypeNames.getRight(packetType), clientContext->descriptiveName());
+        continue;
+      }
+
       if (auto warpAction = as<PlayerWarpPacket>(packet)) {
+        auto const& action = warpAction->action;
+        bool allowed = false;
+
+        if (action.is<WarpAlias>() || action.is<WarpToPlayer>()) {
+          allowed = true;
+        } else if (auto warpToWorld = action.ptr<WarpToWorld>()) {
+          if (warpToWorld->world.empty() || 
+              warpToWorld->world.is<ClientShipWorldId>() || 
+              warpToWorld->world.is<CelestialWorldId>() ||
+              warpToWorld->world.is<InstanceWorldId>()) {
+            allowed = true;
+          }
+        }
+
+        if (!allowed) {
+          Logger::warn("UniverseServer: Blocked invalid warp action from client {}", clientId);
+          m_connectionServer->sendPackets(clientId, {make_shared<PlayerWarpResultPacket>(false, action, true)});
+          continue;
+        }
+
         clientWarpPlayer(clientId, warpAction->action, warpAction->deploy);
 
       } else if (auto flyShip = as<FlyShipPacket>(packet)) {
@@ -1639,6 +1719,48 @@ void UniverseServer::packetsReceived(UniverseConnectionServer*, ConnectionId cli
 
       } else if (auto celestialRequest = as<CelestialRequestPacket>(packet)) {
         addCelestialRequests(clientId, std::move(celestialRequest->requests));
+
+      } else if (auto entityMessage = as<EntityMessagePacket>(packet)) {
+        entityMessage->fromConnection = clientId;
+
+        if (entityMessage->message == "warp") {
+          bool blocked = false;
+
+          if (entityMessage->args.size() < 1 || !entityMessage->args.get(0).canConvert(Json::Type::String)) {
+            Logger::warn("UniverseServer: Blocked warp entity message with invalid args from client {}", clientId);
+            blocked = true;
+          } else {
+            try {
+              parseWarpAction(entityMessage->args.get(0).toString());
+            } catch (StarException const&) {
+              Logger::warn("UniverseServer: Blocked warp entity message with unparseable warp action from client {}", clientId);
+              blocked = true;
+            }
+          }
+
+          if (!blocked) {
+            if (auto targetEntityId = entityMessage->entityId.ptr<EntityId>()) {
+              auto targetConnection = connectionForEntity(*targetEntityId);
+              if (targetConnection != clientId) {
+                clientsLocker.lock();
+                bool isAdmin = clientContext->isAdmin();
+                clientsLocker.unlock();
+                if (!isAdmin) {
+                  Logger::warn("UniverseServer: Blocked warp entity message from non-admin client {} targeting entity owned by connection {}", clientId, targetConnection);
+                  blocked = true;
+                }
+              }
+            }
+          }
+
+          if (blocked) {
+            m_connectionServer->sendPackets(clientId, {make_shared<EntityMessageResponsePacket>(makeLeft(String("Warp entity message blocked by server")), entityMessage->uuid)});
+            continue;
+          }
+        }
+
+        if (auto currentWorld = clientContext->playerWorld())
+          currentWorld->pushIncomingPackets(clientId, {std::move(packet)});
 
       } else if (is<SystemObjectSpawnPacket>(packet)) {
         if (auto currentSystem = clientContext->systemWorld())
@@ -1830,7 +1952,7 @@ void UniverseServer::acceptConnection(UniverseConnection connection, Maybe<HostA
   ConnectionId clientId = m_clients.nextId();
   auto clientContext = make_shared<ServerClientContext>(clientId, remoteAddress, netRules, clientConnect->playerUuid,
                                                         clientConnect->playerName, clientConnect->shipSpecies, administrator, clientConnect->shipChunks);
-  clientContext->registerRpcHandlers(m_teamManager->rpcHandlers());
+  clientContext->registerRpcHandlers(m_teamManager->authenticatedRpcHandlers(clientContext->playerUuid()));
 
   String clientContextFile = File::relativeTo(m_storageDirectory, strf("{}.clientcontext", clientConnect->playerUuid.hex()));
   if (File::isFile(clientContextFile)) {
@@ -1986,7 +2108,52 @@ WarpToWorld UniverseServer::resolveWarpAction(WarpAction warpAction, ConnectionI
     }
   }
 
+  if (auto shipWorldId = toWorldId.ptr<ClientShipWorldId>()) {
+    if (!canWarpToShip(clientId, *shipWorldId))
+      return {};
+  }
+
   return WarpToWorld(toWorldId, spawnTarget);
+}
+
+bool UniverseServer::canWarpToShip(ConnectionId clientId, Uuid const& targetShipUuid) const {
+  auto clientContext = m_clients.value(clientId);
+  if (!clientContext)
+    return false;
+
+  Uuid callerUuid = clientContext->playerUuid();
+
+  if (targetShipUuid == callerUuid)
+    return true;
+
+  if (clientContext->isAdmin())
+    return true;
+
+  auto callerTeam = m_teamManager->getTeam(callerUuid);
+  if (!callerTeam)
+    return false;
+
+  if (auto ownerTeam = m_teamManager->getTeam(targetShipUuid)) {
+    if (*ownerTeam == *callerTeam)
+      return true;
+  }
+
+  for (auto const& otherClient : m_clients) {
+    if (otherClient.first == clientId)
+      continue;
+    auto otherTeam = m_teamManager->getTeam(otherClient.second->playerUuid());
+    if (!otherTeam || *otherTeam != *callerTeam)
+      continue;
+    WorldId otherWorldId = otherClient.second->playerWorldId();
+    if (auto otherShipWorld = otherWorldId.ptr<ClientShipWorldId>()) {
+      if (*otherShipWorld == targetShipUuid)
+        return true;
+    }
+  }
+
+  Logger::warn("UniverseServer: Rejected ship warp from {} to ship {} - not in team and no teammate present",
+               callerUuid.hex(), targetShipUuid.hex());
+  return false;
 }
 
 void UniverseServer::doDisconnection(ConnectionId clientId, String const& reason) {

--- a/source/game/StarUniverseServer.cpp
+++ b/source/game/StarUniverseServer.cpp
@@ -92,6 +92,8 @@ UniverseServer::UniverseServer(String const& storageDir)
     networkWorkerThreads);
 
   m_pause = make_shared<atomic<bool>>(false);
+
+  m_secureWarps = Root::singleton().configuration()->getPath("security.secureWarps").optBool().value(true);
 }
 
 UniverseServer::~UniverseServer() {
@@ -905,7 +907,7 @@ void UniverseServer::warpPlayers() {
       continue;
 
     if (auto toPlayerUuid = warpAction.ptr<WarpToPlayer>()) {
-      bool authorized = clientContext->isAdmin();
+      bool authorized = clientContext->isAdmin() || !m_secureWarps;
       if (!authorized) {
         auto requesterTeam = m_teamManager->getTeam(clientContext->playerUuid());
         auto targetTeam = m_teamManager->getTeam(*toPlayerUuid);
@@ -1640,50 +1642,9 @@ void UniverseServer::packetsReceived(UniverseConnectionServer*, ConnectionId cli
     for (auto& packet : packets) {
       auto packetType = packet->type();
 
-      switch (packetType) {
-        case PacketType::PlayerWarp:
-        case PacketType::FlyShip:
-        case PacketType::ChatSend:
-        case PacketType::ClientContextUpdate:
-        case PacketType::ClientDisconnectRequest:
-        case PacketType::CelestialRequest:
-        case PacketType::SystemObjectSpawn:
-        // World client -> server packets
-        case PacketType::ModifyTileList:
-        case PacketType::ReplaceTileList:
-        case PacketType::DamageTileGroup:
-        case PacketType::CollectLiquid:
-        case PacketType::RequestDrop:
-        case PacketType::SpawnEntity:
-        case PacketType::ConnectWire:
-        case PacketType::DisconnectAllWires:
-        case PacketType::WorldClientStateUpdate:
-        case PacketType::FindUniqueEntity:
-        case PacketType::WorldStartAcknowledge:
-        case PacketType::Ping:
-        // Bidirectional packets
-        case PacketType::EntityCreate:
-        case PacketType::EntityUpdateSet:
-        case PacketType::EntityDestroy:
-        case PacketType::EntityInteract:
-        case PacketType::EntityInteractResult:
-        case PacketType::HitRequest:
-        case PacketType::DamageRequest:
-        case PacketType::DamageNotification:
-        case PacketType::EntityMessage:
-        case PacketType::EntityMessageResponse:
-        case PacketType::UpdateWorldProperties:
-        case PacketType::StepUpdate:
-          break; // allowed
-        default:
-            Logger::warn("UniverseServer: Dropping unexpected {} packet from client {}", 
-                PacketTypeNames.getRight(packetType), clientContext->descriptiveName());
-        continue;
-      }
-
       if (auto warpAction = as<PlayerWarpPacket>(packet)) {
         auto const& action = warpAction->action;
-        bool blocked = true;
+        bool blocked = m_secureWarps;
 
         if (action.is<WarpAlias>() || action.is<WarpToPlayer>()) {
           blocked = false;
@@ -1723,7 +1684,7 @@ void UniverseServer::packetsReceived(UniverseConnectionServer*, ConnectionId cli
       } else if (auto entityMessage = as<EntityMessagePacket>(packet)) {
         entityMessage->fromConnection = clientId;
 
-        if (entityMessage->message == "warp") {
+        if (m_secureWarps && entityMessage->message == "warp") {
           bool blocked = false;
 
           if (entityMessage->args.size() < 1 || !entityMessage->args.get(0).canConvert(Json::Type::String)) {
@@ -2109,7 +2070,7 @@ WarpToWorld UniverseServer::resolveWarpAction(WarpAction warpAction, ConnectionI
   }
 
   if (auto shipWorldId = toWorldId.ptr<ClientShipWorldId>()) {
-    if (!canWarpToShip(clientId, *shipWorldId))
+    if (m_secureWarps && !canWarpToShip(clientId, *shipWorldId))
       return {};
   }
 

--- a/source/game/StarUniverseServer.cpp
+++ b/source/game/StarUniverseServer.cpp
@@ -1683,20 +1683,20 @@ void UniverseServer::packetsReceived(UniverseConnectionServer*, ConnectionId cli
 
       if (auto warpAction = as<PlayerWarpPacket>(packet)) {
         auto const& action = warpAction->action;
-        bool allowed = false;
+        bool blocked = true;
 
         if (action.is<WarpAlias>() || action.is<WarpToPlayer>()) {
-          allowed = true;
+          blocked = false;
         } else if (auto warpToWorld = action.ptr<WarpToWorld>()) {
           if (warpToWorld->world.empty() || 
               warpToWorld->world.is<ClientShipWorldId>() || 
               warpToWorld->world.is<CelestialWorldId>() ||
               warpToWorld->world.is<InstanceWorldId>()) {
-            allowed = true;
+            blocked = false;
           }
         }
 
-        if (!allowed) {
+        if (blocked) {
           Logger::warn("UniverseServer: Blocked invalid warp action from client {}", clientId);
           m_connectionServer->sendPackets(clientId, {make_shared<PlayerWarpResultPacket>(false, action, true)});
           continue;
@@ -2123,10 +2123,7 @@ bool UniverseServer::canWarpToShip(ConnectionId clientId, Uuid const& targetShip
 
   Uuid callerUuid = clientContext->playerUuid();
 
-  if (targetShipUuid == callerUuid)
-    return true;
-
-  if (clientContext->isAdmin())
+  if (targetShipUuid == callerUuid || clientContext->isAdmin())
     return true;
 
   auto callerTeam = m_teamManager->getTeam(callerUuid);

--- a/source/game/StarUniverseServer.hpp
+++ b/source/game/StarUniverseServer.hpp
@@ -175,6 +175,7 @@ private:
 
   // Main lock and clients read lock must be held when calling
   WarpToWorld resolveWarpAction(WarpAction warpAction, ConnectionId clientId, bool deploy) const;
+  bool canWarpToShip(ConnectionId clientId, Uuid const& targetShipUuid) const;
 
   void doDisconnection(ConnectionId clientId, String const& reason);
 

--- a/source/game/StarUniverseServer.hpp
+++ b/source/game/StarUniverseServer.hpp
@@ -239,6 +239,7 @@ private:
   IdMap<ConnectionId, ServerClientContextPtr> m_clients;
 
   shared_ptr<atomic<bool>> m_pause;
+  bool m_secureWarps;
   Map<WorldId, Maybe<WorkerPoolPromise<WorldServerThreadPtr>>> m_worlds;
   Map<InstanceWorldId, pair<int64_t, int64_t>> m_tempWorldIndex;
   Map<Vec3I, SystemWorldServerThreadPtr> m_systemWorlds;

--- a/source/game/StarWorldServer.cpp
+++ b/source/game/StarWorldServer.cpp
@@ -432,13 +432,6 @@ void WorldServer::handleIncomingPackets(ConnectionId clientId, List<PacketPtr> c
       }
 
     } else if (auto entityInteract = as<EntityInteractPacket>(packet)) {
-      auto targetEntity = m_entityMap->entity(entityInteract->interactRequest.targetId);
-      if (targetEntity && targetEntity->entityType() == EntityType::Player) {
-        Logger::warn("WorldServer: Blocked EntityInteract packet from client {} targeting player entity {}", clientId, entityInteract->interactRequest.targetId);
-        clientInfo->outgoingPackets.append(make_shared<EntityInteractResultPacket>(InteractAction(), entityInteract->requestId, entityInteract->interactRequest.sourceId));
-        continue;
-      }
-
       auto targetEntityConnection = connectionForEntity(entityInteract->interactRequest.targetId);
       if (targetEntityConnection == ServerConnectionId) {
         auto interactResult = interact(entityInteract->interactRequest).result();
@@ -572,7 +565,8 @@ void WorldServer::handleIncomingPackets(ConnectionId clientId, List<PacketPtr> c
       // setTemplate re-adds all clients currently, update clientInfo
       clientInfo = m_clientInfo.get(clientId);
     } else {
-      throw WorldServerException::format("Improper packet type {} received by client", (int)packet->type());
+      Logger::warn("UniverseServer: Dropping unexpected {} packet from client",
+          PacketTypeNames.getRight(packet->type()));
     }
   }
 }

--- a/source/game/StarWorldServer.cpp
+++ b/source/game/StarWorldServer.cpp
@@ -432,6 +432,13 @@ void WorldServer::handleIncomingPackets(ConnectionId clientId, List<PacketPtr> c
       }
 
     } else if (auto entityInteract = as<EntityInteractPacket>(packet)) {
+      auto targetEntity = m_entityMap->entity(entityInteract->interactRequest.targetId);
+      if (targetEntity && targetEntity->entityType() == EntityType::Player) {
+        Logger::warn("WorldServer: Blocked EntityInteract packet from client {} targeting player entity {}", clientId, entityInteract->interactRequest.targetId);
+        clientInfo->outgoingPackets.append(make_shared<EntityInteractResultPacket>(InteractAction(), entityInteract->requestId, entityInteract->interactRequest.sourceId));
+        continue;
+      }
+
       auto targetEntityConnection = connectionForEntity(entityInteract->interactRequest.targetId);
       if (targetEntityConnection == ServerConnectionId) {
         auto interactResult = interact(entityInteract->interactRequest).result();


### PR DESCRIPTION
Added:

- Teams/validadion: check if the client is authorized to execute rpc commands instead of just letting them
- Teams/invitationexpire: Open Invitation expire after 10 minutes (default, config changeable). acceptInvitation can only be passed if an actual invite existed before anymore

- Warps/toplayer: Only allow warps to another player if Admin or in Team
- Warps/toplayership: Only allow warp to shipworld if Admin, in Team or TeamMember is on the shipworld

- Config/security: added security.secureTeams and security.secureWarps (both default true)