### PR TITLE
Fix platform dependent undefined behavior in parallel tile iteration

### DIFF
--- a/source/core/StarSectorArray2D.hpp
+++ b/source/core/StarSectorArray2D.hpp
@@ -464,6 +464,7 @@ bool SectorArray2D<ElementT, SectorSize>::evalColumnsPrivPar(
           }
         }
       }
+      return true;
       }));
   }
   for (const auto& f : futures) {


### PR DESCRIPTION
The original optimization was missing a return true at the end of the lambda which was undefined behavior and exhibited crashes on certain platforms. This restores the behavior to match the original. Fixes: #501 