### PR TITLE
Check for valid ContainerInteractor::openContainer results

### DIFF
--- a/source/frontend/StarContainerInteractor.cpp
+++ b/source/frontend/StarContainerInteractor.cpp
@@ -1,5 +1,4 @@
 #include "StarContainerInteractor.hpp"
-
 namespace Star {
 
 void ContainerInteractor::openContainer(ContainerEntityPtr containerEntity) {
@@ -30,12 +29,10 @@ EntityId ContainerInteractor::openContainerId() const {
   return NullEntityId;
 }
 
+// Make sure to check if this is valid when you use it!
 ContainerEntityPtr const& ContainerInteractor::openContainer() const {
   if (m_openContainer && !m_openContainer->inWorld())
     m_openContainer = {};
-
-  if (!m_openContainer)
-    throw StarException("ContainerInteractor has no open container");
 
   return m_openContainer;
 }
@@ -51,35 +48,67 @@ List<ContainerResult> ContainerInteractor::pullContainerResults() {
 }
 
 void ContainerInteractor::swapInContainer(size_t slot, ItemPtr const& items) {
-  m_pendingResults.append(openContainer()->swapItems(slot, items).wrap(resultFromItem));
+  auto container = openContainer();
+  if (!container)
+    return;
+
+  m_pendingResults.append(container->swapItems(slot, items).wrap(resultFromItem));
 }
 
 void ContainerInteractor::addToContainer(ItemPtr const& items) {
-  m_pendingResults.append(openContainer()->addItems(items).wrap(resultFromItem));
+  auto container = openContainer();
+  if (!container)
+    return;
+    
+  m_pendingResults.append(container->addItems(items).wrap(resultFromItem));
 }
 
 void ContainerInteractor::takeFromContainerSlot(size_t slot, size_t count) {
-  m_pendingResults.append(openContainer()->takeItems(slot, count).wrap(resultFromItem));
+  auto container = openContainer();
+  if (!container)
+    return;
+    
+  m_pendingResults.append(container->takeItems(slot, count).wrap(resultFromItem));
 }
 
 void ContainerInteractor::applyAugmentInContainer(size_t slot, ItemPtr const& augment) {
-  m_pendingResults.append(openContainer()->applyAugment(slot, augment).wrap(resultFromItem));
+  auto container = openContainer();
+  if (!container)
+    return;
+    
+  m_pendingResults.append(container->applyAugment(slot, augment).wrap(resultFromItem));
 }
 
 void ContainerInteractor::startCraftingInContainer() {
-  openContainer()->startCrafting();
+  auto container = openContainer();
+  if (!container)
+    return;
+    
+  container->startCrafting();
 }
 
 void ContainerInteractor::stopCraftingInContainer() {
-  openContainer()->stopCrafting();
+  auto container = openContainer();
+  if (!container)
+    return;
+    
+  container->stopCrafting();
 }
 
 void ContainerInteractor::burnContainer() {
-  openContainer()->burnContainerContents();
+  auto container = openContainer();
+  if (!container)
+    return;
+    
+  container->burnContainerContents();
 }
 
 void ContainerInteractor::clearContainer() {
-  m_pendingResults.append(openContainer()->clearContainer());
+  auto container = openContainer();
+  if (!container)
+    return;
+    
+  m_pendingResults.append(container->clearContainer());
 }
 
 ContainerResult ContainerInteractor::resultFromItem(ItemPtr const& item) {

--- a/source/frontend/StarContainerInteractor.cpp
+++ b/source/frontend/StarContainerInteractor.cpp
@@ -48,67 +48,43 @@ List<ContainerResult> ContainerInteractor::pullContainerResults() {
 }
 
 void ContainerInteractor::swapInContainer(size_t slot, ItemPtr const& items) {
-  auto container = openContainer();
-  if (!container)
-    return;
-
-  m_pendingResults.append(container->swapItems(slot, items).wrap(resultFromItem));
+  if (auto container = openContainer())
+    m_pendingResults.append(container->swapItems(slot, items).wrap(resultFromItem));
 }
 
 void ContainerInteractor::addToContainer(ItemPtr const& items) {
-  auto container = openContainer();
-  if (!container)
-    return;
-    
-  m_pendingResults.append(container->addItems(items).wrap(resultFromItem));
+  if (auto container = openContainer())
+    m_pendingResults.append(container->addItems(items).wrap(resultFromItem));
 }
 
 void ContainerInteractor::takeFromContainerSlot(size_t slot, size_t count) {
-  auto container = openContainer();
-  if (!container)
-    return;
-    
-  m_pendingResults.append(container->takeItems(slot, count).wrap(resultFromItem));
+  if (auto container = openContainer())
+    m_pendingResults.append(container->takeItems(slot, count).wrap(resultFromItem));
 }
 
 void ContainerInteractor::applyAugmentInContainer(size_t slot, ItemPtr const& augment) {
-  auto container = openContainer();
-  if (!container)
-    return;
-    
-  m_pendingResults.append(container->applyAugment(slot, augment).wrap(resultFromItem));
+  if (auto container = openContainer())
+    m_pendingResults.append(container->applyAugment(slot, augment).wrap(resultFromItem));
 }
 
 void ContainerInteractor::startCraftingInContainer() {
-  auto container = openContainer();
-  if (!container)
-    return;
-    
-  container->startCrafting();
+  if (auto container = openContainer())
+    container->startCrafting();
 }
 
 void ContainerInteractor::stopCraftingInContainer() {
-  auto container = openContainer();
-  if (!container)
-    return;
-    
-  container->stopCrafting();
+  if (auto container = openContainer())
+    container->stopCrafting();
 }
 
 void ContainerInteractor::burnContainer() {
-  auto container = openContainer();
-  if (!container)
-    return;
-    
-  container->burnContainerContents();
+  if (auto container = openContainer())
+    container->burnContainerContents();
 }
 
 void ContainerInteractor::clearContainer() {
-  auto container = openContainer();
-  if (!container)
-    return;
-    
-  m_pendingResults.append(container->clearContainer());
+  if (auto container = openContainer())
+    m_pendingResults.append(container->clearContainer());
 }
 
 ContainerResult ContainerInteractor::resultFromItem(ItemPtr const& item) {

--- a/source/frontend/StarContainerInteractor.hpp
+++ b/source/frontend/StarContainerInteractor.hpp
@@ -18,7 +18,7 @@ public:
   // Returns NullEntityId if no container is open
   EntityId openContainerId() const;
 
-  // Throws exception if there is no currently open container.
+  // This does not perform any checks; make sure to check if it is valid if you use it!
   ContainerEntityPtr const& openContainer() const;
 
   List<ContainerResult> pullContainerResults();

--- a/source/frontend/StarContainerInterface.cpp
+++ b/source/frontend/StarContainerInterface.cpp
@@ -28,6 +28,10 @@ ContainerPane::ContainerPane(WorldClientPtr worldClient, PlayerPtr player, Conta
   m_containerInteractor = std::move(containerInteractor);
 
   auto container = m_containerInteractor->openContainer();
+
+  if (!container)
+    throw new StarException("Tried to instantiate a ContainerPane with no opened container!");
+
   auto guiConfig = container->containerGuiConfig();
 
   if (auto scripts = guiConfig.opt("scripts").apply(jsonToStringList)) {
@@ -57,7 +61,14 @@ ContainerPane::ContainerPane(WorldClientPtr worldClient, PlayerPtr player, Conta
     if (m_expectingSwap != ExpectingSwap::None)
       return;
 
-    if (ItemPtr slotItem = m_containerInteractor->openContainer()->itemBag()->at(index)) {
+    auto callbackContainer = m_containerInteractor->openContainer();
+
+    if (!callbackContainer) {
+      Logger::warn("rightClickCallback failed in ContainerPane because we do not have an open container!");
+      return;
+    }
+
+    if (ItemPtr slotItem = callbackContainer->itemBag()->at(index)) {
       auto swapItem = m_player->inventory()->swapSlotItem();
       if (!swapItem || swapItem->empty() || swapItem->couldStack(slotItem)) {
         size_t count = swapItem ? swapItem->couldStack(slotItem) : slotItem->maxStack();
@@ -152,7 +163,7 @@ ContainerPane::ContainerPane(WorldClientPtr worldClient, PlayerPtr player, Conta
   }
 
   if (containsChild("objectImage"))
-    if (auto containerObject = as<Object>(m_containerInteractor->openContainer()))
+    if (auto containerObject = as<Object>(container))
       fetchChild<ImageWidget>("objectImage")->setDrawables(containerObject->cursorHintDrawables());
 
   m_expectingSwap = ExpectingSwap::None;
@@ -245,7 +256,13 @@ void ContainerPane::stopCrafting() {
 }
 
 void ContainerPane::toggleCrafting() {
-  if (m_containerInteractor->openContainer()->isCrafting())
+  auto container = m_containerInteractor->openContainer();
+  if (!container) {
+    Logger::warn("ContainerPane::toggleCrafting failed because we don't have an open container!");
+    return;
+  }
+  
+  if (container->isCrafting())
     stopCrafting();
   else
     startCrafting();
@@ -268,40 +285,38 @@ void ContainerPane::update(float dt) {
   m_itemBag->clearItems();
   Input& input = Input::singleton();
 
-  if (!m_containerInteractor->containerOpen()) {
-    dismiss();
+  if (!m_containerInteractor->containerOpen())
+    return dismiss();
+  
+  auto container = m_containerInteractor->openContainer();
 
-  } else {
-    auto container = m_containerInteractor->openContainer();
+  for (size_t i = 0; i < m_itemBag->size(); ++i)
+    m_itemBag->putItems(i, container->containerItems()[i]);
 
-    for (size_t i = 0; i < m_itemBag->size(); ++i)
-      m_itemBag->putItems(i, container->containerItems()[i]);
+  if (container->isInteractive()) {
+    if (auto itemGrid = fetchChild<ItemGridWidget>("itemGrid")) {
+      itemGrid->setProgress(container->craftingProgress());
+      itemGrid->updateAllItemSlots();
+    }
+    if (auto itemGrid = fetchChild<ItemGridWidget>("itemGrid2")) {
+      itemGrid->setProgress(container->craftingProgress());
+      itemGrid->updateAllItemSlots();
+    }
 
-    if (container->isInteractive()) {
-      if (auto itemGrid = fetchChild<ItemGridWidget>("itemGrid")) {
-        itemGrid->setProgress(container->craftingProgress());
-        itemGrid->updateAllItemSlots();
+    if (auto fuelGauge = fetchChild<FuelWidget>("fuelGauge")) {
+      fuelGauge->setCurrentFuelLevel(m_worldClient->getProperty("ship.fuel", 0).toUInt());
+      fuelGauge->setMaxFuelLevel(m_worldClient->getProperty("ship.maxFuel", 0).toUInt());
+      float totalFuelAmount = 0;
+      for (auto& item : container->containerItems()) {
+        if (item)
+          totalFuelAmount += item->instanceValue("fuelAmount", 0).toUInt() * item->count();
       }
-      if (auto itemGrid = fetchChild<ItemGridWidget>("itemGrid2")) {
-        itemGrid->setProgress(container->craftingProgress());
-        itemGrid->updateAllItemSlots();
-      }
-
-      if (auto fuelGauge = fetchChild<FuelWidget>("fuelGauge")) {
-        fuelGauge->setCurrentFuelLevel(m_worldClient->getProperty("ship.fuel", 0).toUInt());
-        fuelGauge->setMaxFuelLevel(m_worldClient->getProperty("ship.maxFuel", 0).toUInt());
-        float totalFuelAmount = 0;
-        for (auto& item : container->containerItems()) {
-          if (item)
-            totalFuelAmount += item->instanceValue("fuelAmount", 0).toUInt() * item->count();
-        }
-        fuelGauge->setPotentialFuelAmount(totalFuelAmount);
-        fuelGauge->setRequestedFuelAmount(0);
-      }
-   
-      if (input.bindDown("opensb", "takeAll")) {
-        m_containerInteractor->clearContainer();
-      }
+      fuelGauge->setPotentialFuelAmount(totalFuelAmount);
+      fuelGauge->setRequestedFuelAmount(0);
+    }
+  
+    if (input.bindDown("opensb", "takeAll")) {
+      m_containerInteractor->clearContainer();
     }
   }
 }

--- a/source/frontend/StarContainerInterface.cpp
+++ b/source/frontend/StarContainerInterface.cpp
@@ -256,16 +256,13 @@ void ContainerPane::stopCrafting() {
 }
 
 void ContainerPane::toggleCrafting() {
-  auto container = m_containerInteractor->openContainer();
-  if (!container) {
-    Logger::warn("ContainerPane::toggleCrafting failed because we don't have an open container!");
-    return;
-  }
-  
-  if (container->isCrafting())
-    stopCrafting();
+  if (auto container = m_containerInteractor->openContainer())
+    if (container->isCrafting())
+      stopCrafting();
+    else
+      startCrafting();
   else
-    startCrafting();
+    Logger::warn("ContainerPane::toggleCrafting failed because we don't have an open container!");
 }
 
 void ContainerPane::clear() {


### PR DESCRIPTION
This PR removes the rather useless exception from `ContainerEntityPtr const& ContainerInteractor::openContainer()` in favor of simply checking if it is valid wherever it is used, which fixes a crash when interacting with a container at the same moment that the player walks out of its range.