### PR TITLE
allow disabling tech overrides

### DIFF
--- a/source/game/StarPlayer.cpp
+++ b/source/game/StarPlayer.cpp
@@ -1474,7 +1474,9 @@ PlayerTechPtr Player::techs() const {
 }
 
 void Player::overrideTech(Maybe<StringList> const& techModules) {
-  if (techModules)
+  String const disableFlag = "disallowTechOverrides";
+  auto flag = getGenericProperty(disableFlag);
+  if (techModules && !(flag.isType(Json::Type::Bool) && flag.toBool()))
     m_techController->setOverrideTech(*techModules);
   else
     m_techController->clearOverrideTech();


### PR DESCRIPTION
allows disabling tech overrides with the `disallowTechOverrides` generic player property.

Useful for personal techs and for tech-reliant races like my own Drone and Worm races.