### PR TITLE
fix world.entity segfaulting on non-existent entities

### DIFF
--- a/source/game/scripting/StarWorldLuaBindings.cpp
+++ b/source/game/scripting/StarWorldLuaBindings.cpp
@@ -537,8 +537,12 @@ namespace LuaBindings {
             return {};
         });
 
-    callbacks.registerCallbackWithSignature<EntityPtr, EntityId>("entity", [world](EntityId entityId) -> EntityPtr {
-      return world->entity(entityId);
+    callbacks.registerCallbackWithSignature<Maybe<EntityPtr>, EntityId>("entity", [world](EntityId entityId) -> Maybe<EntityPtr> {
+      if (auto entity = world->entity(entityId)) {
+        return entity;
+      } else {
+        return {};
+      }
     });
 
     callbacks.registerCallbackWithSignature<bool, int>("entityExists", bind(WorldEntityCallbacks::entityExists, world, _1));


### PR DESCRIPTION
right now world.entity, if used on an entity that doesn't exist, it will return a userdata that is very likely to cause a crash with a segfault if used

this fixes it so world.entity just returns nil instead in those cases

```
/run local e = world.entity(0); return e and e:exists()
```