### PR TITLE
fix: improve biome foreground collision handling in WorldGenerator

### DIFF
--- a/source/game/StarWorldGeneration.cpp
+++ b/source/game/StarWorldGeneration.cpp
@@ -30,6 +30,26 @@ namespace Star {
 
 static int const PlantAdjustmentLimit = 2;
 
+namespace {
+
+bool isPreservedTileCollisionOverride(CollisionKind collision) {
+  return collision == CollisionKind::None
+      || collision == CollisionKind::Platform
+      || collision == CollisionKind::Block;
+}
+
+CollisionKind biomeForegroundCollision(MaterialDatabaseConstPtr const& materialDatabase, MaterialId oldForeground, MaterialId newForeground, CollisionKind currentCollision) {
+  CollisionKind oldCollision = materialDatabase->materialCollisionKind(oldForeground);
+  CollisionKind newCollision = materialDatabase->materialCollisionKind(newForeground);
+
+  if (currentCollision != oldCollision && isPreservedTileCollisionOverride(currentCollision))
+    return currentCollision;
+
+  return newCollision;
+}
+
+}
+
 LiquidWorld::LiquidWorld(WorldServer* world) {
   m_worldServer = world;
   auto& root = Root::singleton();
@@ -711,6 +731,9 @@ RpcPromise<Vec2I> WorldGenerator::enqueuePlacement(List<BiomeItemDistribution> d
 }
 
 void WorldGenerator::replaceBiomeBlocks(ServerTile* tile) {
+  auto materialDatabase = Root::singleton().materialDatabase();
+  MaterialId oldForeground = tile->foreground;
+
   if (auto blockBiome = m_worldServer->worldTemplate()->biome(tile->blockBiomeIndex)) {
     if (tile->foreground == BiomeMaterialId) {
       tile->foreground = blockBiome->mainBlock;
@@ -754,6 +777,8 @@ void WorldGenerator::replaceBiomeBlocks(ServerTile* tile) {
       tile->backgroundModHueShift = 0;
     }
   }
+
+  tile->updateCollision(biomeForegroundCollision(materialDatabase, oldForeground, tile->foreground, tile->collision));
 }
 
 void WorldGenerator::prepareTiles(WorldStorage* worldStorage, ServerTileSectorArray::Sector const& sector) {
@@ -1029,7 +1054,7 @@ void WorldGenerator::prepareSector(WorldStorage* worldStorage, ServerTileSectorA
       replaceBiomeBlocks(tile);
       placeBiomeGrass(worldStorage, tile, position);
 
-      tile->collision = maxCollision(tile->collision, materialDatabase->materialCollisionKind(tile->foreground));
+      tile->updateCollision(biomeForegroundCollision(materialDatabase, tile->foreground, tile->foreground, tile->collision));
     }
   }
 
@@ -1100,7 +1125,7 @@ void WorldGenerator::prepareSectorBiomeBlocks(WorldStorage* worldStorage, Server
       replaceBiomeBlocks(tile);
       placeBiomeGrass(worldStorage, tile, position);
 
-      tile->collision = maxCollision(tile->collision, materialDatabase->materialCollisionKind(tile->foreground));
+      tile->updateCollision(biomeForegroundCollision(materialDatabase, tile->foreground, tile->foreground, tile->collision));
     }
   }
 }
@@ -1188,6 +1213,7 @@ void WorldGenerator::reapplyBiome(WorldStorage* worldStorage, ServerTileSectorAr
       if (blockInfo.blockBiomeIndex != tile->blockBiomeIndex) {
         auto newBiome = planet->biome(blockInfo.blockBiomeIndex);
         auto oldBiome = planet->biome(tile->blockBiomeIndex);
+        MaterialId oldForeground = tile->foreground;
 
         biomeTileEntities.filter([&, position](TileEntityPtr tileEntity) {
             if (tileEntity->tilePosition() == position) {
@@ -1284,7 +1310,7 @@ void WorldGenerator::reapplyBiome(WorldStorage* worldStorage, ServerTileSectorAr
           tile->backgroundMod = NoModId;
         }
 
-        tile->collision = maxCollision(tile->collision, materialDatabase->materialCollisionKind(tile->foreground));
+        tile->updateCollision(biomeForegroundCollision(materialDatabase, oldForeground, tile->foreground, tile->collision));
       }
 
       if (tile->biomeTransition && !blockInfo.biomeTransition) {


### PR DESCRIPTION
I love the collision modification for blocks, but there is little annoying thing with the planet terraforming. It replaces the collision of such blocks with a standard one