### PR TITLE
minor shaders menu update

### DIFF
--- a/assets/opensb/interface/opensb/shaders/shaders.lua
+++ b/assets/opensb/interface/opensb/shaders/shaders.lua
@@ -271,7 +271,17 @@ local function addEnabled(groupname, i, added)
 end
 
 function toggleGroupEnabled(checkbox, cdata)
-  renderer.setPostProcessGroupEnabled(activeGroup, widget.getChecked(fmt("%s.%s",OPTIONS_WIDGET,checkbox)), true)
+  local checked = widget.getChecked(fmt("%s.%s",OPTIONS_WIDGET,checkbox))
+  renderer.setPostProcessGroupEnabled(activeGroup, checked, true)
+  
+  local ep = groups[activeGroup].enabledParameter
+  if ep then
+      -- this group might need to handle enable/disabling itself, since maybe it patches another shader that can't be disabled
+      for _,e in next, groups[activeGroup].enabledParameterEffects do
+        renderer.setEffectParameter(e,ep,checked)
+      end
+  end
+  
   shaderConfig = root.getConfiguration("postProcessGroups")
 end
 

--- a/assets/opensb/scripts/opensb/universeclient/loadconfig.lua
+++ b/assets/opensb/scripts/opensb/universeclient/loadconfig.lua
@@ -9,18 +9,26 @@ function module.init()
 	local changes = false
 	for k,v in next, shaderConfig do
 		local group = postProcessGroups[k]
-		if group and v.parameters then
-			for k2,v2 in next, group.parameters do
-				local param = v.parameters[k2]
-				if param ~= nil then
-					if v2.isPasses then
-						-- this parameter controls passes
-						for _,l in next, v2.layers do
-							renderer.setPostProcessLayerPasses(l,param)
-						end
-					else
-						for _,e in next, v2.effects do
-							renderer.setEffectParameter(e,k2,param)
+		if group then
+			if group.enabledParameter then
+				-- this group might need to handle enable/disabling itself, since maybe it patches another shader that can't be disabled
+				for _,e in next, group.enabledParameterEffects do
+					renderer.setEffectParameter(e,group.enabledParameter,not not v.enabled)
+				end
+			end
+			if v.parameters then
+				for k2,v2 in next, group.parameters do
+					local param = v.parameters[k2]
+					if param ~= nil then
+						if v2.isPasses then
+							-- this parameter controls passes
+							for _,l in next, v2.layers do
+								renderer.setPostProcessLayerPasses(l,param)
+							end
+						else
+							for _,e in next, v2.effects do
+								renderer.setEffectParameter(e,k2,param)
+							end
 						end
 					end
 				end

--- a/assets/opensb/scripts/opensb/universeclient/loadconfig.lua
+++ b/assets/opensb/scripts/opensb/universeclient/loadconfig.lua
@@ -7,28 +7,26 @@ function module.init()
 	local shaderConfig = root.getConfiguration("postProcessGroups") or {}
 	local postProcessGroups = renderer.postProcessGroups()
 	local changes = false
-	for k,v in next, shaderConfig do
-		local group = postProcessGroups[k]
-		if group then
-			if group.enabledParameter then
-				-- this group might need to handle enable/disabling itself, since maybe it patches another shader that can't be disabled
-				for _,e in next, group.enabledParameterEffects do
-					renderer.setEffectParameter(e,group.enabledParameter,not not v.enabled)
-				end
+	for gname,group in next, postProcessGroups do
+		local cfg = shaderConfig[gname] or {enabled=group.enabledDefault}
+		if group.enabledParameter then
+			-- this group might need to handle enable/disabling itself, since maybe it patches another shader that can't be disabled
+			for _,e in next, group.enabledParameterEffects do
+				renderer.setEffectParameter(e,group.enabledParameter,not not cfg.enabled)
 			end
-			if v.parameters then
-				for k2,v2 in next, group.parameters do
-					local param = v.parameters[k2]
-					if param ~= nil then
-						if v2.isPasses then
-							-- this parameter controls passes
-							for _,l in next, v2.layers do
-								renderer.setPostProcessLayerPasses(l,param)
-							end
-						else
-							for _,e in next, v2.effects do
-								renderer.setEffectParameter(e,k2,param)
-							end
+		end
+		if cfg.parameters then
+			for k2,v2 in next, group.parameters do
+				local param = cfg.parameters[k2]
+				if param ~= nil then
+					if v2.isPasses then
+						-- this parameter controls passes
+						for _,l in next, v2.layers do
+							renderer.setPostProcessLayerPasses(l,param)
+						end
+					else
+						for _,e in next, v2.effects do
+							renderer.setEffectParameter(e,k2,param)
 						end
 					end
 				end


### PR DESCRIPTION
Allows post process groups to set boolean effect parameters based on whether the group is enabled or disabled.
Useful for mods that patch other shaders (such as the world shader).