### PR TITLE
GHA-ci: optimize release compression

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,6 +57,9 @@ jobs:
         with:
           cmakeVersion: 3.29.2
 
+      - name: setup 7-Zip action
+        uses: milliewalky/setup-7-zip@v2
+
       - name: sccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
@@ -96,25 +99,37 @@ jobs:
 
       - name: Assemble Files
         working-directory: ${{ github.workspace }}
-        run: scripts\ci\windows\assemble.bat
+        run: |
+          scripts/ci/windows/assemble.bat
+          ren client.zip OpenStarbound-Windows-Client.zip
+          ren server.zip OpenStarbound-Windows-Server.zip
+
+      - name: Prepare Artifacts
+        working-directory: ${{ github.workspace }}
+        run: |
+          7z -bb3 -mtp=2 -mm=Deflate64 -mx=9 a dist.zip -r dist\
+          ren dist.zip OpenStarbound-Windows-All-DevOnly.zip
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-Windows-All-DevOnly
-          path: dist/*
+          path: OpenStarbound-Windows-All-DevOnly.zip
+          archive: false
 
       - name: Upload Client
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-Windows-Client
-          path: client_distribution/*
+          path: OpenStarbound-Windows-Client.zip
+          archive: false
 
       - name: Upload Server
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-Windows-Server
-          path: server_distribution/*
+          path: OpenStarbound-Windows-Server.zip
+          archive: false
           
       - name: Install Inno Setup
         run: |
@@ -151,11 +166,11 @@ jobs:
           & "C:\Program Files (x86)\Inno Setup 6\iscc.exe" /Oinstaller scripts\inno\setup.iss
 
       - name: Upload Installer
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-Windows-Installer
-          path: installer/*
-          compression-level: 0
+          path: installer/OpenStarbound-Windows-Installer.exe
+          archive: false
   
   build_linux:
     name: Build OpenStarbound Linux x86_64
@@ -170,7 +185,7 @@ jobs:
           libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxtst-dev \
           libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
           libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev libpipewire-0.3-dev libwayland-dev libdecor-0-dev liburing-dev \
-          autoconf autoconf-archive automake libtool patchelf
+          autoconf autoconf-archive automake libtool patchelf tarlz
 
       - name: Install CMake & Ninja
         uses: lukka/get-cmake@latest
@@ -213,13 +228,14 @@ jobs:
 
       - name: Prepare Artifacts
         working-directory: ${{ github.workspace }}
-        run: tar -cvf dist.tar dist
+        run: tarlz -c9vf OpenStarbound-Linux-GCC.tar.lz dist
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-Linux-GCC
-          path: dist.tar
+          path: OpenStarbound-Linux-GCC.tar.lz
+          archive: false
 
       - name: Run Tests
         uses: lukka/run-cmake@v10
@@ -232,19 +248,24 @@ jobs:
 
       - name: Assemble Files
         working-directory: ${{ github.workspace }}
-        run: scripts/ci/linux/assemble.sh
+        run: |
+          scripts/ci/linux/assemble.sh
+          mv -v client.tar.lz OpenStarbound-Linux-GCC-Client.tar.lz
+          mv -v server.tar.lz OpenStarbound-Linux-GCC-Server.tar.lz
 
       - name: Upload Client Files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-Linux-GCC-Client
-          path: client.tar
+          path: OpenStarbound-Linux-GCC-Client.tar.lz
+          archive: false
 
       - name: Upload Server Files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-Linux-GCC-Server
-          path: server.tar
+          path: OpenStarbound-Linux-GCC-Server.tar.lz
+          archive: false
 
   build_linux_clang:
     name: Build OpenStarbound Linux Clang x86_64
@@ -262,7 +283,7 @@ jobs:
           libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxtst-dev \
           libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
           libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev libpipewire-0.3-dev libwayland-dev libdecor-0-dev liburing-dev \
-          autoconf autoconf-archive automake libtool patchelf
+          autoconf autoconf-archive automake libtool patchelf tarlz
 
       - name: Install CMake & Ninja
         uses: lukka/get-cmake@latest
@@ -305,13 +326,14 @@ jobs:
 
       - name: Prepare Artifacts
         working-directory: ${{ github.workspace }}
-        run: tar -cvf dist.tar dist
+        run: tarlz -c9vf OpenStarbound-Linux-Clang.tar.lz dist
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-Linux-Clang
-          path: dist.tar
+          path: OpenStarbound-Linux-Clang.tar.lz
+          archive: false
 
       - name: Run Tests
         uses: lukka/run-cmake@v10
@@ -324,19 +346,24 @@ jobs:
 
       - name: Assemble Files
         working-directory: ${{ github.workspace }}
-        run: scripts/ci/linux/assemble.sh
+        run: |
+          scripts/ci/linux/assemble.sh
+          mv -v client.tar.lz OpenStarbound-Linux-Clang-Client.tar.lz
+          mv -v server.tar.lz OpenStarbound-Linux-Clang-Server.tar.lz
 
       - name: Upload Client Files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-Linux-Clang-Client
-          path: client.tar
+          path: OpenStarbound-Linux-Clang-Client.tar.lz
+          archive: false
 
       - name: Upload Server Files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-Linux-Clang-Server
-          path: server.tar
+          path: OpenStarbound-Linux-Clang-Server.tar.lz
+          archive: false
   
   build_linux_arm:
     name: Build OpenStarbound Linux arm64
@@ -351,7 +378,7 @@ jobs:
           libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxtst-dev \
           libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
           libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev libpipewire-0.3-dev libwayland-dev libdecor-0-dev liburing-dev \
-          autoconf autoconf-archive automake libtool patchelf
+          autoconf autoconf-archive automake libtool patchelf tarlz
 
       - name: Install CMake & Ninja
         uses: lukka/get-cmake@latest
@@ -394,13 +421,14 @@ jobs:
 
       - name: Prepare Artifacts
         working-directory: ${{ github.workspace }}
-        run: tar -cvf dist.tar dist
+        run: tarlz -c9vf OpenStarbound-Linux-ARM-GCC.tar.lz dist
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-Linux-ARM-GCC
-          path: dist.tar
+          path: OpenStarbound-Linux-ARM-GCC.tar.lz
+          archive: false
 
       - name: Run Tests
         uses: lukka/run-cmake@v10
@@ -413,19 +441,24 @@ jobs:
 
       - name: Assemble Files
         working-directory: ${{ github.workspace }}
-        run: scripts/ci/linux/assemble.sh
+        run: |
+          scripts/ci/linux/assemble.sh
+          mv -v client.tar.lz OpenStarbound-Linux-ARM-GCC-Client.tar.lz
+          mv -v server.tar.lz OpenStarbound-Linux-ARM-GCC-Server.tar.lz
 
       - name: Upload Client Files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-Linux-ARM-GCC-Client
-          path: client.tar
+          path: OpenStarbound-Linux-ARM-GCC-Client.tar.lz
+          archive: false
 
       - name: Upload Server Files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-Linux-ARM-GCC-Server
-          path: server.tar
+          path: OpenStarbound-Linux-ARM-GCC-Server.tar.lz
+          archive: false
 
   build_linux_arm_clang:
     name: Build OpenStarbound Linux Clang arm64
@@ -443,7 +476,7 @@ jobs:
           libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libxtst-dev \
           libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
           libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev libpipewire-0.3-dev libwayland-dev libdecor-0-dev liburing-dev \
-          autoconf autoconf-archive automake libtool patchelf
+          autoconf autoconf-archive automake libtool patchelf tarlz
 
       - name: Install CMake & Ninja
         uses: lukka/get-cmake@latest
@@ -486,13 +519,14 @@ jobs:
 
       - name: Prepare Artifacts
         working-directory: ${{ github.workspace }}
-        run: tar -cvf dist.tar dist
+        run: tarlz -c9vf OpenStarbound-Linux-ARM-Clang.tar.lz dist
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-Linux-ARM-Clang
-          path: dist.tar
+          path: OpenStarbound-Linux-ARM-Clang.tar.lz
+          archive: false
 
       - name: Run Tests
         uses: lukka/run-cmake@v10
@@ -505,19 +539,24 @@ jobs:
 
       - name: Assemble Files
         working-directory: ${{ github.workspace }}
-        run: scripts/ci/linux/assemble.sh
+        run: |
+          scripts/ci/linux/assemble.sh
+          mv -v client.tar.lz OpenStarbound-Linux-ARM-Clang-Client.tar.lz
+          mv -v server.tar.lz OpenStarbound-Linux-ARM-Clang-Server.tar.lz
 
       - name: Upload Client Files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-Linux-ARM-Clang-Client
-          path: client.tar
+          path: OpenStarbound-Linux-ARM-Clang-Client.tar.lz
+          archive: false
 
       - name: Upload Server Files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-Linux-ARM-Clang-Server
-          path: server.tar
+          path: OpenStarbound-Linux-ARM-Clang-Server.tar.lz
+          archive: false
 
   build-mac-intel:
     name: Build OpenStarbound macOS x86_64
@@ -530,7 +569,7 @@ jobs:
 
       - name: Install Packages
         run: |
-          brew install autoconf automake libtool
+          brew install autoconf automake libtool tarlz
 
       - name: Install CMake & Ninja
         uses: lukka/get-cmake@latest
@@ -576,21 +615,31 @@ jobs:
             lib/osx/libsteam_api.dylib \
             dist/
 
+      - name: Prepare Artifacts
+        working-directory: ${{ github.workspace }}
+        run: |
+          tarlz -c9vf dist.tar.lz dist
+          mv -v dist.tar.lz OpenStarbound-macOS-Intel.tar.lz
+
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-macOS-Intel
-          path: dist/*
+          path: OpenStarbound-macOS-Intel.tar.lz
+          archive: false
 
       - name: Assemble Files
         working-directory: ${{ github.workspace }}
-        run: scripts/ci/macos/assemble.sh
+        run: |
+          scripts/ci/macos/assemble.sh
+          mv -v client.tar.lz OpenStarbound-macOS-Intel-Client.tar.lz
 
       - name: Upload Client Files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-macOS-Intel-Client
-          path: client.tar
+          path: OpenStarbound-macOS-Intel-Client.tar.lz
+          archive: false
 
   build-mac-arm:
     name: Build OpenStarbound macOS arm64
@@ -603,7 +652,7 @@ jobs:
 
       - name: Install Packages
         run: |
-          brew install autoconf automake libtool
+          brew install autoconf automake libtool tarlz
 
       - name: Install CMake & Ninja
         uses: lukka/get-cmake@latest
@@ -649,18 +698,28 @@ jobs:
             lib/osx/libsteam_api.dylib \
             dist/
 
+      - name: Prepare Artifacts
+        working-directory: ${{ github.workspace }}
+        run: |
+          tarlz -c9vf dist.tar.lz dist
+          mv -v dist.tar.lz OpenStarbound-macOS-Silicon.tar.lz
+
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-macOS-Silicon
-          path: dist/*
+          path: OpenStarbound-macOS-Silicon.tar.lz
+          archive: false
 
       - name: Assemble Files
         working-directory: ${{ github.workspace }}
-        run: scripts/ci/macos/assemble.sh
+        run: |
+          scripts/ci/macos/assemble.sh
+          mv -v client.tar.lz OpenStarbound-macOS-Silicon-Client.tar.lz
 
       - name: Upload Client Files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: OpenStarbound-macOS-Silicon-Client
-          path: client.tar
+          path: OpenStarbound-macOS-Silicon-Client.tar.lz
+          archive: false

--- a/scripts/ci/linux/assemble.sh
+++ b/scripts/ci/linux/assemble.sh
@@ -56,5 +56,5 @@ cp \
   scripts/steam_appid.txt \
   server_distribution/linux/
 
-tar -cvf client.tar client_distribution
-tar -cvf server.tar server_distribution
+tarlz -c9vf client.tar.lz client_distribution
+tarlz -c9vf server.tar.lz server_distribution

--- a/scripts/ci/macos/assemble.sh
+++ b/scripts/ci/macos/assemble.sh
@@ -26,4 +26,4 @@ cp \
   scripts/steam_appid.txt \
   client_distribution/osx/
 
-tar -cvf client.tar client_distribution
+tarlz -c9vf client.tar.lz client_distribution

--- a/scripts/ci/windows/assemble.bat
+++ b/scripts/ci/windows/assemble.bat
@@ -30,3 +30,6 @@ set win=windows
 if exist %win% rmdir %win% /S /Q
 xcopy %client% %win% /E /I /Y
 xcopy %server% %win% /E /I /Y
+
+7z -bb3 -mtp=2 -mm=Deflate64 -mx=9 a client.zip -r %client%
+7z -bb3 -mtp=2 -mm=Deflate64 -mx=9 a server.zip -r %server%

--- a/scripts/inno/setup.iss
+++ b/scripts/inno/setup.iss
@@ -19,7 +19,7 @@ DisableProgramGroupPage=yes
 ; Uncomment the following line to run in non administrative install mode (install for current user only.)
 ;PrivilegesRequired=lowest
 PrivilegesRequiredOverridesAllowed=dialog
-OutputBaseFilename=OpenStarbound
+OutputBaseFilename=OpenStarbound-Windows-Installer
 SetupIconFile=scripts\inno\openstarbound.ico
 Compression=lzma2/ultra64
 SolidCompression=yes


### PR DESCRIPTION
Solves https://github.com/OpenStarbound/OpenStarbound/issues/456 by taking advantage of https://github.com/marketplace/actions/upload-a-build-artifact#upload-an-individual-file-unzipped (new feature added recently).

- ZIPs are now Deflate64 (supported natively since Windows Vista) compressed instead of Deflate.
- Windows installer is now uploaded directly instead of being inside of a ZIP.
- TARs are now Lzip (existed since 2010) compressed instead of zip (tar.lz instead of tar.zip).

The compression effort(s) for these have been set very high so if ZIP compression is considered too slow then find and replace the number in `-mx=9` with a lower value and if Lzip compression is considered too slow then find and replace the number in `-c9vf` with a lower value.