### PR TITLE
Fix HDR crash

### DIFF
--- a/assets/opensb/rendering/effects/basic.vert
+++ b/assets/opensb/rendering/effects/basic.vert
@@ -1,4 +1,4 @@
-#version 140
+#version 150
 
 in vec2 vertexPosition;
 

--- a/assets/opensb/rendering/effects/interface.frag
+++ b/assets/opensb/rendering/effects/interface.frag
@@ -1,4 +1,4 @@
-#version 140
+#version 150
 
 uniform sampler2D texture0;
 uniform sampler2D texture1;

--- a/assets/opensb/rendering/effects/interface.vert
+++ b/assets/opensb/rendering/effects/interface.vert
@@ -1,4 +1,4 @@
-#version 140
+#version 150
 
 uniform vec2 textureSize0;
 uniform vec2 textureSize1;

--- a/assets/opensb/rendering/effects/world.frag
+++ b/assets/opensb/rendering/effects/world.frag
@@ -1,4 +1,4 @@
-#version 140
+#version 150
 
 uniform sampler2D texture0;
 uniform sampler2D texture1;

--- a/assets/opensb/rendering/effects/world.vert
+++ b/assets/opensb/rendering/effects/world.vert
@@ -1,4 +1,4 @@
-#version 140
+#version 150
 
 uniform vec2 textureSize0;
 uniform vec2 textureSize1;

--- a/source/application/StarMainApplication_sdl.cpp
+++ b/source/application/StarMainApplication_sdl.cpp
@@ -587,8 +587,8 @@ public:
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
 #else
-    // GL 3.2 Core + GLSL 140
-    const char* glsl_version = "#version 140";
+    // GL 3.2 Core + GLSL 150
+    const char* glsl_version = "#version 150";
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, 0);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);

--- a/source/application/StarRenderer_opengl.cpp
+++ b/source/application/StarRenderer_opengl.cpp
@@ -136,6 +136,7 @@ OpenGlRenderer::OpenGlRenderer() {
   m_limitTextureGroupSize = false;
   m_useMultiTexturing = true;
   m_multiSampling = false;
+  m_hdrSetting = false;
 
   logGlErrorSummary("OpenGL errors during renderer initialization");
 }

--- a/source/application/StarRenderer_opengl.cpp
+++ b/source/application/StarRenderer_opengl.cpp
@@ -8,7 +8,7 @@ namespace Star {
 size_t const MultiTextureCount = 4;
 
 char const* DefaultVertexShader = R"SHADER(
-#version 140
+#version 150
 
 uniform vec2 textureSize0;
 uniform vec2 textureSize1;
@@ -49,7 +49,7 @@ void main() {
 )SHADER";
 
 char const* DefaultFragmentShader = R"SHADER(
-#version 140
+#version 150
 
 uniform sampler2D texture0;
 uniform sampler2D texture1;
@@ -108,8 +108,8 @@ OpenGlRenderer::OpenGlRenderer() {
   if (glewResult != GLEW_OK && glewResult != GLEW_ERROR_NO_GLX_DISPLAY)
     throw RendererException::format("Could not initialize GLEW: {}", (char*)glewGetErrorString(glewResult));
 
-  if (!GLEW_VERSION_2_0)
-    throw RendererException("OpenGL 2.0 not available!");
+  if (!GLEW_VERSION_3_2)
+    throw RendererException("OpenGL 3.2 not available!");
 
   Logger::info("OpenGL version: '{}' vendor: '{}' renderer: '{}' shader: '{}'",
       (const char*)glGetString(GL_VERSION),

--- a/source/application/StarRenderer_opengl.cpp
+++ b/source/application/StarRenderer_opengl.cpp
@@ -136,7 +136,7 @@ OpenGlRenderer::OpenGlRenderer() {
   m_limitTextureGroupSize = false;
   m_useMultiTexturing = true;
   m_multiSampling = false;
-  m_hdrSetting = false;
+  m_hdrSetting = true;
 
   logGlErrorSummary("OpenGL errors during renderer initialization");
 }


### PR DESCRIPTION
Fix crash: `HDR` reads `m_hdrSetting`, which was never initialized, causing a semi-consistent crash during framebuffer creation. We now set it once at init to prevent this. 

Update GLSL: Sets all GLSL versions to `150` (forgot to do this when fixing core mode).

Update checks: Updated the OpenGL version check to match our minimum supported OpenGL version