### PR TITLE
GHA: Don't compress Windows installer zip

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,6 +171,7 @@ jobs:
           name: OpenStarbound-Windows-Installer
           path: installer/OpenStarbound-Windows-Installer.exe
           archive: true
+          compression-level: 0
   
   build_linux:
     name: Build OpenStarbound Linux x86_64


### PR DESCRIPTION
brings back `compression-level: 0` to disable compression for the Windows installer zip since the exe itself is already heavily compressed. This was here previously but removed under the assumption that the installer wouldn't have to be zipped anymore.