### PR TITLE
Improve TMX layer data format support

### DIFF
--- a/source/core/StarCompression.cpp
+++ b/source/core/StarCompression.cpp
@@ -51,6 +51,49 @@ ByteArray compressData(ByteArray const& in, CompressionLevel compression) {
   return out;
 }
 
+void compressDataGzip(ByteArray const& in, ByteArray& out, CompressionLevel compression) {
+  out.clear();
+
+  if (in.empty())
+    return;
+
+  const size_t BUFSIZE = 32 * 1024;
+  auto tempBuffer = std::make_unique<unsigned char[]>(BUFSIZE);
+
+  z_stream strm{};
+  strm.zalloc = Z_NULL;
+  strm.zfree = Z_NULL;
+  strm.opaque = Z_NULL;
+  int deflate_res = deflateInit2(&strm, compression, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY);
+  if (deflate_res != Z_OK)
+    throw IOException(strf("Failed to initialise deflate ({})", deflate_res));
+
+  strm.next_in = (unsigned char*)in.ptr();
+  strm.avail_in = in.size();
+  strm.next_out = tempBuffer.get();
+  strm.avail_out = BUFSIZE;
+  while (deflate_res == Z_OK) {
+    deflate_res = deflate(&strm, Z_FINISH);
+    if (strm.avail_out == 0) {
+      out.append((char const*)tempBuffer.get(), BUFSIZE);
+      strm.next_out = tempBuffer.get();
+      strm.avail_out = BUFSIZE;
+    }
+  }
+  deflateEnd(&strm);
+
+  if (deflate_res != Z_STREAM_END)
+    throw IOException(strf("Internal error in compressDataGzip, deflate_res is {}", deflate_res));
+
+  out.append((char const*)tempBuffer.get(), BUFSIZE - strm.avail_out);
+}
+
+ByteArray compressDataGzip(ByteArray const& in, CompressionLevel compression) {
+  ByteArray out = ByteArray::withReserve(in.size());
+  compressDataGzip(in, out, compression);
+  return out;
+}
+
 void uncompressData(const char* in, size_t inLen, ByteArray& out, size_t limit) {
   out.clear();
 
@@ -108,6 +151,65 @@ void uncompressData(ByteArray const& in, ByteArray& out, size_t limit) {
 
 ByteArray uncompressData(ByteArray const& in, size_t limit) {
   return uncompressData(in.ptr(), in.size(), limit);
+}
+
+void uncompressDataGzip(const char* in, size_t inLen, ByteArray& out, size_t limit) {
+  out.clear();
+
+  if (!inLen)
+    return;
+
+  const size_t BUFSIZE = 32 * 1024;
+  auto tempBuffer = std::make_unique<unsigned char[]>(BUFSIZE);
+
+  z_stream strm{};
+  strm.zalloc = Z_NULL;
+  strm.zfree = Z_NULL;
+  strm.opaque = Z_NULL;
+  int inflate_res = inflateInit2(&strm, 31);
+  if (inflate_res != Z_OK)
+    throw IOException(strf("Failed to initialise inflate ({})", inflate_res));
+
+  strm.next_in = (unsigned char*)in;
+  strm.avail_in = inLen;
+  strm.next_out = tempBuffer.get();
+  strm.avail_out = BUFSIZE;
+
+  while (inflate_res == Z_OK || inflate_res == Z_BUF_ERROR) {
+    inflate_res = inflate(&strm, Z_FINISH);
+    if (strm.avail_out == 0) {
+      out.append((char const*)tempBuffer.get(), BUFSIZE);
+      strm.next_out = tempBuffer.get();
+      strm.avail_out = BUFSIZE;
+      if (limit && out.size() >= limit) {
+        inflateEnd(&strm);
+        throw IOException(strf("hit uncompressDataGzip limit of {} bytes", limit));
+        break;
+      }
+    } else if (inflate_res == Z_BUF_ERROR) {
+      break;
+    }
+  }
+  inflateEnd(&strm);
+
+  if (inflate_res != Z_STREAM_END)
+    throw IOException(strf("Internal error in uncompressDataGzip, inflate_res is {}", inflate_res));
+
+  out.append((char const*)tempBuffer.get(), BUFSIZE - strm.avail_out);
+}
+
+ByteArray uncompressDataGzip(const char* in, size_t inLen, size_t limit) {
+  ByteArray out = ByteArray::withReserve(inLen);
+  uncompressDataGzip(in, inLen, out, limit);
+  return out;
+}
+
+void uncompressDataGzip(ByteArray const& in, ByteArray& out, size_t limit) {
+  uncompressDataGzip(in.ptr(), in.size(), out, limit);
+}
+
+ByteArray uncompressDataGzip(ByteArray const& in, size_t limit) {
+  return uncompressDataGzip(in.ptr(), in.size(), limit);
 }
 
 CompressedFilePtr CompressedFile::open(String const& filename, IOMode mode, CompressionLevel comp) {

--- a/source/core/StarCompression.cpp
+++ b/source/core/StarCompression.cpp
@@ -51,49 +51,6 @@ ByteArray compressData(ByteArray const& in, CompressionLevel compression) {
   return out;
 }
 
-void compressDataGzip(ByteArray const& in, ByteArray& out, CompressionLevel compression) {
-  out.clear();
-
-  if (in.empty())
-    return;
-
-  const size_t BUFSIZE = 32 * 1024;
-  auto tempBuffer = std::make_unique<unsigned char[]>(BUFSIZE);
-
-  z_stream strm{};
-  strm.zalloc = Z_NULL;
-  strm.zfree = Z_NULL;
-  strm.opaque = Z_NULL;
-  int deflate_res = deflateInit2(&strm, compression, Z_DEFLATED, 31, 8, Z_DEFAULT_STRATEGY);
-  if (deflate_res != Z_OK)
-    throw IOException(strf("Failed to initialise deflate ({})", deflate_res));
-
-  strm.next_in = (unsigned char*)in.ptr();
-  strm.avail_in = in.size();
-  strm.next_out = tempBuffer.get();
-  strm.avail_out = BUFSIZE;
-  while (deflate_res == Z_OK) {
-    deflate_res = deflate(&strm, Z_FINISH);
-    if (strm.avail_out == 0) {
-      out.append((char const*)tempBuffer.get(), BUFSIZE);
-      strm.next_out = tempBuffer.get();
-      strm.avail_out = BUFSIZE;
-    }
-  }
-  deflateEnd(&strm);
-
-  if (deflate_res != Z_STREAM_END)
-    throw IOException(strf("Internal error in compressDataGzip, deflate_res is {}", deflate_res));
-
-  out.append((char const*)tempBuffer.get(), BUFSIZE - strm.avail_out);
-}
-
-ByteArray compressDataGzip(ByteArray const& in, CompressionLevel compression) {
-  ByteArray out = ByteArray::withReserve(in.size());
-  compressDataGzip(in, out, compression);
-  return out;
-}
-
 void uncompressData(const char* in, size_t inLen, ByteArray& out, size_t limit) {
   out.clear();
 

--- a/source/core/StarCompression.hpp
+++ b/source/core/StarCompression.hpp
@@ -22,9 +22,6 @@ ByteArray uncompressData(const char* in, size_t inLen, size_t limit = 0);
 void uncompressData(ByteArray const& in, ByteArray& out, size_t limit = 0);
 ByteArray uncompressData(ByteArray const& in, size_t limit = 0);
 
-void compressDataGzip(ByteArray const& in, ByteArray& out, CompressionLevel compression = MediumCompression);
-ByteArray compressDataGzip(ByteArray const& in, CompressionLevel compression = MediumCompression);
-
 void uncompressDataGzip(const char* in, size_t inLen, ByteArray& out, size_t limit = 0);
 ByteArray uncompressDataGzip(const char* in, size_t inLen, size_t limit = 0);
 void uncompressDataGzip(ByteArray const& in, ByteArray& out, size_t limit = 0);

--- a/source/core/StarCompression.hpp
+++ b/source/core/StarCompression.hpp
@@ -22,6 +22,14 @@ ByteArray uncompressData(const char* in, size_t inLen, size_t limit = 0);
 void uncompressData(ByteArray const& in, ByteArray& out, size_t limit = 0);
 ByteArray uncompressData(ByteArray const& in, size_t limit = 0);
 
+void compressDataGzip(ByteArray const& in, ByteArray& out, CompressionLevel compression = MediumCompression);
+ByteArray compressDataGzip(ByteArray const& in, CompressionLevel compression = MediumCompression);
+
+void uncompressDataGzip(const char* in, size_t inLen, ByteArray& out, size_t limit = 0);
+ByteArray uncompressDataGzip(const char* in, size_t inLen, size_t limit = 0);
+void uncompressDataGzip(ByteArray const& in, ByteArray& out, size_t limit = 0);
+ByteArray uncompressDataGzip(ByteArray const& in, size_t limit = 0);
+
 // Random access to a (potentially) compressed file.
 class CompressedFile : public IODevice {
 public:

--- a/source/core/StarZSTDCompression.cpp
+++ b/source/core/StarZSTDCompression.cpp
@@ -102,4 +102,63 @@ ByteArray DecompressionStream::decompress(ByteArray const& in) {
   return out;
 }
 
+ByteArray ZstdCompression::compress(const char* in, size_t inLen, int compressionLevel) {
+  if (inLen == 0)
+    return ByteArray();
+    
+  size_t const maxOutSize = ZSTD_compressBound(inLen);
+  ByteArray out(maxOutSize);
+  
+  size_t compressedSize = ZSTD_compress(
+    out.ptr(), maxOutSize,
+    in, inLen,
+    compressionLevel
+  );
+  
+  if (ZSTD_isError(compressedSize))
+    throw IOException(strf("ZSTD compression error {}", ZSTD_getErrorName(compressedSize)));
+  
+  out.resize(compressedSize);
+  return out;
+}
+
+void ZstdCompression::compress(const char* in, size_t inLen, ByteArray& out, int compressionLevel) {
+  out = compress(in, inLen, compressionLevel);
+}
+
+ByteArray ZstdCompression::compress(ByteArray const& in, int compressionLevel) {
+  return compress(in.ptr(), in.size(), compressionLevel);
+}
+
+void ZstdCompression::compress(ByteArray const& in, ByteArray& out, int compressionLevel) {
+  out = compress(in, compressionLevel);
+}
+
+ByteArray ZstdCompression::decompress(const char* in, size_t inLen) {
+  unsigned long long const frameContentSize = ZSTD_getFrameContentSize(in, inLen);
+  if (frameContentSize == ZSTD_CONTENTSIZE_ERROR || frameContentSize == ZSTD_CONTENTSIZE_UNKNOWN)
+    throw IOException("Cannot determine ZSTD decompressed size");
+  
+  ByteArray out(frameContentSize);
+  size_t result = ZSTD_decompress(out.ptr(), frameContentSize, in, inLen);
+  
+  if (ZSTD_isError(result))
+    throw IOException(strf("ZSTD decompression error {}", ZSTD_getErrorName(result)));
+  
+  out.resize(result);
+  return out;
+}
+
+void ZstdCompression::decompress(const char* in, size_t inLen, ByteArray& out) {
+  out = decompress(in, inLen);
+}
+
+ByteArray ZstdCompression::decompress(ByteArray const& in) {
+  return decompress(in.ptr(), in.size());
+}
+
+void ZstdCompression::decompress(ByteArray const& in, ByteArray& out) {
+  out = decompress(in);
+}
+
 }

--- a/source/core/StarZSTDCompression.cpp
+++ b/source/core/StarZSTDCompression.cpp
@@ -107,7 +107,7 @@ ByteArray ZstdCompression::compress(const char* in, size_t inLen, int compressio
     return ByteArray();
     
   size_t const maxOutSize = ZSTD_compressBound(inLen);
-  ByteArray out(maxOutSize);
+  ByteArray out(maxOutSize, 0);
   
   size_t compressedSize = ZSTD_compress(
     out.ptr(), maxOutSize,
@@ -139,7 +139,7 @@ ByteArray ZstdCompression::decompress(const char* in, size_t inLen) {
   if (frameContentSize == ZSTD_CONTENTSIZE_ERROR || frameContentSize == ZSTD_CONTENTSIZE_UNKNOWN)
     throw IOException("Cannot determine ZSTD decompressed size");
   
-  ByteArray out(frameContentSize);
+  ByteArray out(frameContentSize, 0);
   size_t result = ZSTD_decompress(out.ptr(), frameContentSize, in, inLen);
   
   if (ZSTD_isError(result))

--- a/source/core/StarZSTDCompression.hpp
+++ b/source/core/StarZSTDCompression.hpp
@@ -37,4 +37,17 @@ private:
   ZSTD_DStream* m_dStream;
 };
 
+class ZstdCompression {
+public:
+  static void compress(const char* in, size_t inLen, ByteArray& out, int compressionLevel = 0);
+  static void compress(ByteArray const& in, ByteArray& out, int compressionLevel = 0);
+  static ByteArray compress(const char* in, size_t inLen, int compressionLevel = 0);
+  static ByteArray compress(ByteArray const& in, int compressionLevel = 0);
+
+  static void decompress(const char* in, size_t inLen, ByteArray& out);
+  static void decompress(ByteArray const& in, ByteArray& out);
+  static ByteArray decompress(const char* in, size_t inLen);
+  static ByteArray decompress(ByteArray const& in);
+};
+
 }

--- a/source/game/StarDungeonTMXPart.cpp
+++ b/source/game/StarDungeonTMXPart.cpp
@@ -156,57 +156,43 @@ namespace Dungeon {
     return false;
   }
 
-  TMXTileLayer::TMXTileLayer(Json const& layer) {
-    unsigned width = layer.getInt("width"), height = layer.getInt("height");
-    int x = layer.getInt("x", 0), y = layer.getInt("y", 0);
-    m_rect = RectI({x, y}, {x + (int)width - 1, y + (int)height - 1});
+TMXTileLayer::TMXTileLayer(Json const& layer) {
+  unsigned width = layer.getInt("width"), height = layer.getInt("height");
+  int x = layer.getInt("x", 0), y = layer.getInt("y", 0);
+  m_rect = RectI({x, y}, {x + (int)width - 1, y + (int)height - 1});
+  m_name = layer.getString("name");
+  m_layer = Tiled::LayerNames.getLeft(m_name);
 
-    m_name = layer.getString("name");
-    m_layer = Tiled::LayerNames.getLeft(m_name);
-
-    if (layer.optString("compression") == String("zlib")) {
-      ByteArray compressedData = base64Decode(layer.getString("data"));
-      ByteArray bytes = uncompressData(compressedData);
-      for (size_t i = 0; i + 3 < bytes.size(); i += 4) {
-        uint32_t gid = (uint8_t)bytes[i] | ((uint8_t)bytes[i + 1] << 8) | ((uint8_t)bytes[i + 2] << 16) | ((uint8_t)bytes[i + 3] << 24);
-        m_tileData.append(gid & ~TileFlip::AllBits);
-      }
-    } else if (layer.optString("compression") == String("zstd")) {
-      ByteArray compressedData = base64Decode(layer.getString("data"));
-      ByteArray bytes = ZstdCompression::decompress(compressedData);
-      for (size_t i = 0; i + 3 < bytes.size(); i += 4) {
-        uint32_t gid = (uint8_t)bytes[i] | ((uint8_t)bytes[i + 1] << 8) | ((uint8_t)bytes[i + 2] << 16) | ((uint8_t)bytes[i + 3] << 24);
-        m_tileData.append(gid & ~TileFlip::AllBits);
-      }
-    } else if (layer.optString("compression") == String("gzip")) {
-      ByteArray compressedData = base64Decode(layer.getString("data"));
-      ByteArray bytes = uncompressDataGzip(compressedData);
-      for (size_t i = 0; i + 3 < bytes.size(); i += 4) {
-        uint32_t gid = (uint8_t)bytes[i] | ((uint8_t)bytes[i + 1] << 8) | ((uint8_t)bytes[i + 2] << 16) | ((uint8_t)bytes[i + 3] << 24);
-        m_tileData.append(gid & ~TileFlip::AllBits);
-      }
-    } else if (layer.optString("compression") == String("")) {
-      ByteArray bytes = base64Decode(layer.getString("data"));
-      for (size_t i = 0; i + 3 < bytes.size(); i += 4) {
-        uint32_t gid = (uint8_t)bytes[i] | ((uint8_t)bytes[i + 1] << 8) | ((uint8_t)bytes[i + 2] << 16) | ((uint8_t)bytes[i + 3] << 24);
-        m_tileData.append(gid & ~TileFlip::AllBits);
-      }
-    } else if (!layer.contains("compression")) {
-      for (Json const& index : layer.getArray("data")) {
-        // Ignore flipped tiles. Tiled can flip selected regions with X, but
-        // this
-        // also flips individual tiles (setting the high bits on the GID).
-        // Starbound has no support for flipped tiles, but being able to flip
-        // regions is still useful.
-        m_tileData.append(index.toUInt() & ~TileFlip::AllBits);
-      }
-    } else {
-      throw StarException::format("TMXTileLayer does not support compression mode {}", layer.getString("compression"));
+  if (!layer.contains("compression")) {
+    for (Json const& index : layer.getArray("data")) {
+      m_tileData.append(index.toUInt() & ~TileFlip::AllBits);
     }
-
-    if (m_tileData.count() != width * height)
-      throw StarException("TMXTileLayer data length was inconsistent with width/height");
+  } else {
+    String compression = layer.getString("compression");
+    ByteArray compressedData = base64Decode(layer.getString("data"));
+    ByteArray bytes;
+        
+    if (compression == "") {
+      bytes = compressedData; // uncompressed base64
+    } else if (compression == "gzip") {
+      bytes = uncompressDataGzip(compressedData);
+    } else if (compression == "zlib") {
+      bytes = uncompressData(compressedData);
+    } else if (compression == "zstd") {
+      bytes = ZstdCompression::decompress(compressedData);
+    } else {
+      throw StarException::format("TMXTileLayer does not support compression mode {}", compression);
+    }
+        
+    for (size_t i = 0; i + 3 < bytes.size(); i += 4) {
+      uint32_t gid = (uint8_t)bytes[i] | ((uint8_t)bytes[i + 1] << 8) | ((uint8_t)bytes[i + 2] << 16) | ((uint8_t)bytes[i + 3] << 24);
+      m_tileData.append(gid & ~TileFlip::AllBits);
+    }
   }
+    
+  if (m_tileData.count() != width * height)
+    throw StarException("TMXTileLayer data length was inconsistent with width/height");
+}
 
   TMXMap::TMXMap(Json const& tmx) {
     if (tmx.getUInt("tileheight") != 8 || tmx.getUInt("tilewidth") != 8)

--- a/source/game/StarDungeonTMXPart.cpp
+++ b/source/game/StarDungeonTMXPart.cpp
@@ -177,7 +177,20 @@ namespace Dungeon {
       for (size_t i = 0; i + 3 < bytes.size(); i += 4) {
         uint32_t gid = (uint8_t)bytes[i] | ((uint8_t)bytes[i + 1] << 8) | ((uint8_t)bytes[i + 2] << 16) | ((uint8_t)bytes[i + 3] << 24);
         m_tileData.append(gid & ~TileFlip::AllBits);
-      } 
+      }
+    } else if (layer.optString("compression") == String("gzip")) {
+      ByteArray compressedData = base64Decode(layer.getString("data"));
+      ByteArray bytes = uncompressDataGzip(compressedData);
+      for (size_t i = 0; i + 3 < bytes.size(); i += 4) {
+        uint32_t gid = (uint8_t)bytes[i] | ((uint8_t)bytes[i + 1] << 8) | ((uint8_t)bytes[i + 2] << 16) | ((uint8_t)bytes[i + 3] << 24);
+        m_tileData.append(gid & ~TileFlip::AllBits);
+      }
+    } else if (layer.optString("compression") == String("")) {
+      ByteArray bytes = base64Decode(layer.getString("data"));
+      for (size_t i = 0; i + 3 < bytes.size(); i += 4) {
+        uint32_t gid = (uint8_t)bytes[i] | ((uint8_t)bytes[i + 1] << 8) | ((uint8_t)bytes[i + 2] << 16) | ((uint8_t)bytes[i + 3] << 24);
+        m_tileData.append(gid & ~TileFlip::AllBits);
+      }
     } else if (!layer.contains("compression")) {
       for (Json const& index : layer.getArray("data")) {
         // Ignore flipped tiles. Tiled can flip selected regions with X, but

--- a/source/game/StarDungeonTMXPart.cpp
+++ b/source/game/StarDungeonTMXPart.cpp
@@ -1,4 +1,5 @@
 #include "StarCompression.hpp"
+#include "StarZSTDCompression.hpp"
 #include "StarEncode.hpp"
 #include "StarRoot.hpp"
 #include "StarGameTypes.hpp"
@@ -170,6 +171,13 @@ namespace Dungeon {
         uint32_t gid = (uint8_t)bytes[i] | ((uint8_t)bytes[i + 1] << 8) | ((uint8_t)bytes[i + 2] << 16) | ((uint8_t)bytes[i + 3] << 24);
         m_tileData.append(gid & ~TileFlip::AllBits);
       }
+    } else if (layer.optString("compression") == String("zstd")) {
+      ByteArray compressedData = base64Decode(layer.getString("data"));
+      ByteArray bytes = ZstdCompression::decompress(compressedData);
+      for (size_t i = 0; i + 3 < bytes.size(); i += 4) {
+        uint32_t gid = (uint8_t)bytes[i] | ((uint8_t)bytes[i + 1] << 8) | ((uint8_t)bytes[i + 2] << 16) | ((uint8_t)bytes[i + 3] << 24);
+        m_tileData.append(gid & ~TileFlip::AllBits);
+      } 
     } else if (!layer.contains("compression")) {
       for (Json const& index : layer.getArray("data")) {
         // Ignore flipped tiles. Tiled can flip selected regions with X, but

--- a/source/game/StarDungeonTMXPart.cpp
+++ b/source/game/StarDungeonTMXPart.cpp
@@ -169,17 +169,17 @@ TMXTileLayer::TMXTileLayer(Json const& layer) {
     }
   } else {
     String compression = layer.getString("compression");
-    ByteArray compressedData = base64Decode(layer.getString("data"));
+    ByteArray base64Data = base64Decode(layer.getString("data"));
     ByteArray bytes;
         
-    if (compression == "") {
-      bytes = compressedData; // uncompressed base64
+    if (compression == "") { // uncompressed base64
+      bytes = base64Data;
     } else if (compression == "gzip") {
-      bytes = uncompressDataGzip(compressedData);
+      bytes = uncompressDataGzip(base64Data);
     } else if (compression == "zlib") {
-      bytes = uncompressData(compressedData);
+      bytes = uncompressData(base64Data);
     } else if (compression == "zstd") {
-      bytes = ZstdCompression::decompress(compressedData);
+      bytes = ZstdCompression::decompress(base64Data);
     } else {
       throw StarException::format("TMXTileLayer does not support compression mode {}", compression);
     }


### PR DESCRIPTION
Add Zstd, Gzip, and Base64 support to TMX implementation

This adds compression and decompression for Zstd, similar to what we have 
with Zlib, and adds Gzip reading via Zlib since both use the Deflate algorithm.

It uses these in our TMX implementation to extend our data layer format 
support from just CSV and Zlib to supporting CSV, Base64, Gzip, Zlib, and 
Zstd. These are basically all data layer formats that a modern version of 
Tiled can output.