### PR TITLE
Perfectly Generic Item count fix and some small cleanups

### DIFF
--- a/scripts/ci/linux/run-server.sh
+++ b/scripts/ci/linux/run-server.sh
@@ -2,8 +2,8 @@
 
 cd "`dirname \"$0\"`"
 
-# Define hardcoded fallback terminals
-FALLBACK_TERMS="
+terms="
+xdg-terminal-exec
 x-terminal-emulator
 konsole
 gnome-terminal.wrapper
@@ -13,37 +13,8 @@ lxterm
 uxterm
 xterm"
 
-# Function to attempt launching server with a terminal
-launch_with_terminal() {
-  local term="$1"
-  shift
-  "$term" -e ./starbound_server "$@"
-  return $?
-}
-
-# Check for config file
-CONFIG_PATH=""
-if [ -f "$XDG_CONFIG_HOME/xdg-terminals.list" ]; then
-  CONFIG_PATH="$XDG_CONFIG_HOME/xdg-terminals.list"
-elif [ -f "$HOME/.config/xdg-terminals.list" ]; then
-  CONFIG_PATH="$HOME/.config/xdg-terminals.list"
-fi
-
-# Try config file terminal first (if it exists)
-if [ -n "$CONFIG_PATH" ]; then
-  CONFIG_TERM=$(grep -v '^#' "$CONFIG_PATH" | grep -v '^$' | tr '[:upper:]' '[:lower:]' | head -n 1 | sed 's/\.desktop$//' | awk -F. '{print $NF}')
-
-  if [ -n "$CONFIG_TERM" ]; then
-    launch_with_terminal "$CONFIG_TERM" "$@"
-    if [ $? -eq 0 ]; then
-      exit 0
-    fi
-  fi
-fi
-
-# Fall back to hardcoded terminal list
-for term in $FALLBACK_TERMS; do
-  launch_with_terminal "$term" "$@"
+for term in $terms; do
+  $term -- ./starbound_server $@
   if [ $? -eq 0 ]; then
     exit 0
   fi

--- a/source/application/StarMainApplication_sdl.cpp
+++ b/source/application/StarMainApplication_sdl.cpp
@@ -576,7 +576,6 @@ public:
     }
 
     SDL_SetHint(SDL_HINT_AUDIO_DEVICE_APP_ICON_NAME, "openstarbound");
-    SDL_SetHint(SDL_HINT_AUDIO_DEVICE_STREAM_NAME, "Audio");
 #endif
 
 #if defined(__APPLE__)

--- a/source/game/StarItemDatabase.cpp
+++ b/source/game/StarItemDatabase.cpp
@@ -536,13 +536,15 @@ ItemPtr ItemDatabase::tryCreateItem(ItemDescriptor const& descriptor, Maybe<floa
         if (descriptor.name() == "perfectlygenericitem") {
           Logger::error("Could not re-instantiate item '{}'. {}", descriptor, outputException(e, false));
           result = createItem(m_items.get("perfectlygenericitem").type, itemConfig("perfectlygenericitem", descriptor.parameters(), level, seed));
+          result->setCount(descriptor.count());
         } else {
           Logger::error("Could not instantiate item '{}'. {}", descriptor, outputException(e, false));
           result = createItem(m_items.get("perfectlygenericitem").type, itemConfig("perfectlygenericitem", JsonObject({
-            {"genericItemStorage", descriptor.toJson()},
+            {"genericItemStorage", descriptor.toJson().eraseKey("count")},
             {"shortdescription", descriptor.name()},
             {"description", "Reinstall the parent mod to return this item to normal"}
           }), {}, {}));
+          result->setCount(descriptor.count());
         }
       }
     } else


### PR DESCRIPTION
This primarily fixes the issue of "Perfectly Generic Item" not correctly storing the count value when generated after a mod is removed. With this change, it removes the count value in `genericItemStorage` so all items of the same kind can stack regardless of their pre-mod-removal stack size, and it then correctly sets the count value.

This PR also removes `SDL_HINT_AUDIO_DEVICE_STREAM_NAME` because whilst it works like described in the original adding PR #286, it sadly doesn't look so good in some other applications, particularly the ones managing audio streams or other audio systems. Because everything handles things differently, SDL's default of just showing the application name and stream name is the most robust solution.

It also reverts the changes in the Linux run-server script to be basically the original script with two changes while remaining functionally identical:

1. First, it adds `xdg-terminal-exec`. This is basically XDG's way of just getting the terminal. Somehow at the time of making the script change I didn't realise it exists and only knew about the list, even though they belong to the same specification. So oops there.

2. It changes the `-e` to `--`. This is generally preferred by most terminals, and `-e` has been deprecated by some terminals.