### PR TITLE
Fix oversight in reviving logic

### DIFF
--- a/source/game/StarUniverseClient.cpp
+++ b/source/game/StarUniverseClient.cpp
@@ -332,8 +332,10 @@ void UniverseClient::update(float dt) {
           m_pendingWarp = WarpAlias::OwnShip;
           m_warpDelay.reset();
         }
-        m_worldClient->reviveMainPlayer();
-        m_respawning = false;
+        if (!m_pendingWarp && !m_warping && m_worldClient->inWorld()) {
+          m_worldClient->reviveMainPlayer();
+          m_respawning = false;
+        }
       }
     } else {
       if (m_respawnTimer.tick(dt)) {


### PR DESCRIPTION
Fixed a small oversight I made when creating #471. Since warping is not instant, we must only revive the player once they have actually warped. This prevents effects of planets applying to the player when respawning to ship.