### PR TITLE
reset findUniqueEntity promises when clearing world

### DIFF
--- a/source/game/StarWorldClient.cpp
+++ b/source/game/StarWorldClient.cpp
@@ -1925,6 +1925,7 @@ void WorldClient::clearWorld() {
   }
 
   m_entityMessageResponses = {};
+  m_findUniqueEntityResponses = {};
 
   m_forceRegions.clear();
 }


### PR DESCRIPTION
should fix findUniqueEntity getting 'stuck' if no response is received (may occur if a FindUniqueEntityPacket is sent just as you change worlds)