### PR TITLE
fix shaders (semi)permamently breaking when MSAA or HDR toggled

### DIFF
--- a/source/application/StarRenderer_opengl.cpp
+++ b/source/application/StarRenderer_opengl.cpp
@@ -311,6 +311,14 @@ OpenGlRenderer::GlFrameBuffer::~GlFrameBuffer() {
 void OpenGlRenderer::loadConfig(Json const& config) {
   m_frameBuffers.clear();
 
+  // Effects will keep any framebuffer textures they use
+  // alive indefinitely, so clear them out here as well
+  for (auto& effect : m_effects) {
+    for (auto& texture : effect.second.textures) {
+      texture.second.textureValue.reset();
+    }
+  }
+
   for (auto& pair : config.getObject("frameBuffers", {})) {
     Json config = pair.second;
     config = config.set("multisample", m_multiSampling);


### PR DESCRIPTION
effects keep strong references to any textures they reference - including framebuffer textures, which can cause them to get Jammed Up with stale refs, preventing the new framebuffers' textures from being used by shaders.
this just manually cleans up effect texture references when framebuffers are remade. this Does include non-framebuffer textures (i.e. the lightmap), though in testing this wasn't much of a problem (i could Very Rarely notice a seemingly-lightmap-related flicker when rapidly toggling HDR on and off, though iirc i experienced the same on my old fix-msaa-shaders branch, which cleared only framebuffer texture refs).

(on affected builds, this can be manually fixed by running `/hotreload`, which forces shaders to be reloaded.)

this DOES NOT fix shaders not working at all when MSAA is Enabled (working on it).