### PR TITLE
silence openGL errors when shader doesn't use all base uniforms

### DIFF
--- a/source/application/StarRenderer_opengl.cpp
+++ b/source/application/StarRenderer_opengl.cpp
@@ -1269,15 +1269,20 @@ void OpenGlRenderer::renderGlBuffer(GlRenderBuffer const& renderBuffer, Mat3F co
 
     glBindBuffer(GL_ARRAY_BUFFER, vb.vertexBuffer);
 
-    glEnableVertexAttribArray(m_positionAttribute);
-    glEnableVertexAttribArray(m_texCoordAttribute);
-    glEnableVertexAttribArray(m_colorAttribute);
-    glEnableVertexAttribArray(m_dataAttribute);
+    // check if these exist (might not in mod shaders) so we don't get a bunch of useless errors
+#define APPLY_IF_VALID(Func, Arg1, ...) \
+    if (Arg1 != -1) Func(Arg1 __VA_OPT__(,) __VA_ARGS__)
 
-    glVertexAttribPointer(m_positionAttribute, 2, GL_FLOAT, GL_FALSE, sizeof(GlRenderVertex), (GLvoid*)offsetof(GlRenderVertex, pos));
-    glVertexAttribPointer(m_texCoordAttribute, 2, GL_FLOAT, GL_FALSE, sizeof(GlRenderVertex), (GLvoid*)offsetof(GlRenderVertex, uv));
-    glVertexAttribPointer(m_colorAttribute, 4, GL_UNSIGNED_BYTE, GL_TRUE, sizeof(GlRenderVertex), (GLvoid*)offsetof(GlRenderVertex, color));
-    glVertexAttribIPointer(m_dataAttribute, 1, GL_INT, sizeof(GlRenderVertex), (GLvoid*)offsetof(GlRenderVertex, pack));
+    APPLY_IF_VALID(glEnableVertexAttribArray, m_positionAttribute);
+    APPLY_IF_VALID(glEnableVertexAttribArray, m_texCoordAttribute);
+    APPLY_IF_VALID(glEnableVertexAttribArray, m_colorAttribute);
+    APPLY_IF_VALID(glEnableVertexAttribArray, m_dataAttribute);
+
+    APPLY_IF_VALID(glVertexAttribPointer,  m_positionAttribute, 2, GL_FLOAT,         GL_FALSE, sizeof(GlRenderVertex), (GLvoid*)offsetof(GlRenderVertex, pos));
+    APPLY_IF_VALID(glVertexAttribPointer,  m_texCoordAttribute, 2, GL_FLOAT,         GL_FALSE, sizeof(GlRenderVertex), (GLvoid*)offsetof(GlRenderVertex, uv));
+    APPLY_IF_VALID(glVertexAttribPointer,  m_colorAttribute,    4, GL_UNSIGNED_BYTE, GL_TRUE,  sizeof(GlRenderVertex), (GLvoid*)offsetof(GlRenderVertex, color));
+    APPLY_IF_VALID(glVertexAttribIPointer, m_dataAttribute,     1, GL_INT,                     sizeof(GlRenderVertex), (GLvoid*)offsetof(GlRenderVertex, pack));
+#undef APPLY_IF_VALID
 
     glDrawArrays(GL_TRIANGLES, 0, vb.vertexCount);
   }


### PR DESCRIPTION
post-process shaders won't always have a use for All built-in uniforms (and some(?) shader compilers will ignore uniforms that are declared but not used), and the error messages produced when even One isn't used are a nuisance and Will flood your logs if openGL error logging is enabled.