### PR TITLE
Unify version info

### DIFF
--- a/source/base/StarVersionOptionParser.cpp
+++ b/source/base/StarVersionOptionParser.cpp
@@ -3,8 +3,13 @@
 
 namespace Star {
 
-void VersionOptionParser::printVersion(std::ostream& os, String const& name) {
-  format(os, "OpenStarbound {} v{} for v{} ({}) Source ID: {}\n", name, OpenStarVersionString, StarVersionString, StarArchitectureString, StarSourceIdentifierString);
+void VersionOptionParser::printVersion(std::ostream& os) {  
+  String displayName = m_versionName ? *m_versionName : String();  
+  format(os, "OpenStarbound{} v{} for v{} ({}) Source ID: {}\n", displayName.empty() ? "" : strf(" {}", displayName), OpenStarVersionString, StarVersionString, StarArchitectureString, StarSourceIdentifierString);  
+}
+
+void VersionOptionParser::setVersionName(String const& name) {
+  m_versionName = name;
 }
 
 VersionOptionParser::VersionOptionParser() {

--- a/source/base/StarVersionOptionParser.cpp
+++ b/source/base/StarVersionOptionParser.cpp
@@ -3,9 +3,8 @@
 
 namespace Star {
 
-void VersionOptionParser::printVersion(std::ostream& os) {
-  format(os, "Starbound Version {} ({})\n", StarVersionString, StarArchitectureString);
-  format(os, "Source Identifier - {}\n", StarSourceIdentifierString);
+void VersionOptionParser::printVersion(std::ostream& os, String const& name) {
+  format(os, "OpenStarbound {} v{} for v{} ({}) Source ID: {}\n", name, OpenStarVersionString, StarVersionString, StarArchitectureString, StarSourceIdentifierString);
 }
 
 VersionOptionParser::VersionOptionParser() {

--- a/source/base/StarVersionOptionParser.cpp
+++ b/source/base/StarVersionOptionParser.cpp
@@ -3,7 +3,7 @@
 
 namespace Star {
 
-void VersionOptionParser::printVersion(std::ostream& os) {  
+void VersionOptionParser::printVersion(std::ostream& os) const {  
   String displayName = m_versionName ? *m_versionName : String();  
   format(os, "OpenStarbound{} v{} for v{} ({}) Source ID: {}\n", displayName.empty() ? "" : strf(" {}", displayName), OpenStarVersionString, StarVersionString, StarArchitectureString, StarSourceIdentifierString);  
 }

--- a/source/base/StarVersionOptionParser.cpp
+++ b/source/base/StarVersionOptionParser.cpp
@@ -3,9 +3,9 @@
 
 namespace Star {
 
-void VersionOptionParser::printVersion(std::ostream& os) const {  
-  String displayName = m_versionName ? *m_versionName : String();  
-  format(os, "OpenStarbound{} v{} for v{} ({}) Source ID: {}\n", displayName.empty() ? "" : strf(" {}", displayName), OpenStarVersionString, StarVersionString, StarArchitectureString, StarSourceIdentifierString);  
+String VersionOptionParser::getVersionString() const {
+  String displayName = m_versionName ? *m_versionName : String();
+  return strf("OpenStarbound{} v{} for v{} ({}) Source ID: {}", displayName.empty() ? "" : strf(" {}", displayName), OpenStarVersionString, StarVersionString, StarArchitectureString, StarSourceIdentifierString);
 }
 
 void VersionOptionParser::setVersionName(String const& name) {
@@ -23,7 +23,7 @@ VersionOptionParser::Options VersionOptionParser::parseOrDie(StringList const& c
   tie(options, errors) = OptionParser::parseOptions(cmdLineArguments);
 
   if (options.switches.contains("version"))
-    printVersion(std::cout);
+    coutf("{}\n", getVersionString());
 
   if (options.switches.contains("help"))
     printHelp(std::cout);

--- a/source/base/StarVersionOptionParser.hpp
+++ b/source/base/StarVersionOptionParser.hpp
@@ -9,8 +9,7 @@ namespace Star {
 // version and exit.
 class VersionOptionParser : public OptionParser {
 public:
-  void printVersion(std::ostream& os) const;
-  
+  String getVersionString() const;
   void setVersionName(String const& name);
 
   VersionOptionParser();

--- a/source/base/StarVersionOptionParser.hpp
+++ b/source/base/StarVersionOptionParser.hpp
@@ -9,7 +9,7 @@ namespace Star {
 // version and exit.
 class VersionOptionParser : public OptionParser {
 public:
-  void printVersion(std::ostream& os);
+  void printVersion(std::ostream& os) const;
   
   void setVersionName(String const& name);
 

--- a/source/base/StarVersionOptionParser.hpp
+++ b/source/base/StarVersionOptionParser.hpp
@@ -10,6 +10,8 @@ namespace Star {
 class VersionOptionParser : public OptionParser {
 public:
   static void printVersion(std::ostream& os);
+  
+  void setVersionName(String const& name);
 
   VersionOptionParser();
 
@@ -19,6 +21,9 @@ public:
 
   // First sets the command name based on argv[0], then calls parseOrDie.
   Options commandParseOrDie(int argc, char** argv);
+
+private:
+  Maybe<String> m_versionName;
 };
 
 }

--- a/source/base/StarVersionOptionParser.hpp
+++ b/source/base/StarVersionOptionParser.hpp
@@ -9,7 +9,7 @@ namespace Star {
 // version and exit.
 class VersionOptionParser : public OptionParser {
 public:
-  static void printVersion(std::ostream& os);
+  void printVersion(std::ostream& os);
   
   void setVersionName(String const& name);
 

--- a/source/client/StarClientApplication.cpp
+++ b/source/client/StarClientApplication.cpp
@@ -6,7 +6,7 @@
 #include "StarLogging.hpp"
 #include "StarJsonExtra.hpp"
 #include "StarRoot.hpp"
-#include "StarVersion.hpp"
+#include "StarVersionOptionParser.hpp"
 #include "StarPlayer.hpp"
 #include "StarPlayerStorage.hpp"
 #include "StarPlayerLog.hpp"
@@ -161,8 +161,9 @@ Json const AdditionalDefaultConfiguration = Json::parseJson(R"JSON(
 
 void ClientApplication::startup(StringList const& cmdLineArgs) {
   RootLoader rootLoader({AdditionalAssetsSettings, AdditionalDefaultConfiguration, String("starbound.log"), LogLevel::Info, false, String("starbound.config")});
+  rootLoader.setVersionName("Client");  
   m_root = rootLoader.initOrDie(cmdLineArgs).first;
-  Logger::info("OpenStarbound Client v{} for v{} ({}) Source ID: {}", OpenStarVersionString, StarVersionString, StarArchitectureString, StarSourceIdentifierString);
+  Logger::info("{}", rootLoader.getVersionString());
   #ifdef __clang__
   Logger::info("Compiled with Clang {}", __clang_version__);
   #endif

--- a/source/server/main.cpp
+++ b/source/server/main.cpp
@@ -5,7 +5,7 @@
 #include "StarUniverseServer.hpp"
 #include "StarRootLoader.hpp"
 #include "StarConfiguration.hpp"
-#include "StarVersion.hpp"
+#include "StarVersionOptionParser.hpp"
 #include "StarServerQueryThread.hpp"
 #include "StarServerRconThread.hpp"
 #include "StarSignalHandler.hpp"
@@ -44,6 +44,7 @@ int main(int argc, char** argv) {
     SetThreadStackGuarantee(&exceptionStackSize);
     #endif
     RootLoader rootLoader({{}, AdditionalDefaultConfiguration, String("starbound_server.log"), LogLevel::Info, false, String("starbound_server.config")});
+    rootLoader.setVersionName("Server");
     RootUPtr root = rootLoader.commandInitOrDie(argc, argv).first;
     root->fullyLoad();
 
@@ -53,7 +54,7 @@ int main(int argc, char** argv) {
 
     auto configuration = root->configuration();
     {
-      Logger::info("OpenStarbound Server v{} for v{} ({}) Source ID: {} Protocol: {}", OpenStarVersionString, StarVersionString, StarArchitectureString, StarSourceIdentifierString, StarProtocolVersion);
+      Logger::info("{}", rootLoader.getVersionString());
 
       float updateRate = 1.0f / GlobalTimestep;
       if (auto jUpdateRate = configuration->get("updateRate")) {

--- a/source/utility/asset_packer.cpp
+++ b/source/utility/asset_packer.cpp
@@ -11,6 +11,7 @@ int main(int argc, char** argv) {
     double startTime = Time::monotonicTime();
 
     VersionOptionParser optParse;
+    optParse.setVersionName("Asset Packer");
     optParse.setSummary("Packs asset folder into a starbound .pak file");
     optParse.addParameter("c", "configFile", OptionParser::Optional, "JSON file with ignore lists and ordering info");
     optParse.addSwitch("s", "Enable server mode");

--- a/source/utility/asset_unpacker.cpp
+++ b/source/utility/asset_unpacker.cpp
@@ -11,6 +11,7 @@ int main(int argc, char** argv) {
     double startTime = Time::monotonicTime();
 
     VersionOptionParser optParse;
+    optParse.setVersionName("Asset Unpacker");
     optParse.setSummary("Unpacks a starbound .pak file into an asset folder");
     optParse.addSwitch("v", "Verbose, list each file extracted");
     optParse.addArgument("input pak path", OptionParser::Required, "Path to the .pak file to unpack");

--- a/source/utility/btree_repacker.cpp
+++ b/source/utility/btree_repacker.cpp
@@ -10,6 +10,7 @@ int main(int argc, char** argv) {
     double startTime = Time::monotonicTime();
 
     VersionOptionParser optParse;
+    optParse.setVersionName("Btree Repacker");
     optParse.setSummary("Repacks a Starbound BTree file to shrink its file size");
     optParse.addArgument("input file path", OptionParser::Required, "Path to the BTree to be repacked");
     optParse.addArgument("output filename", OptionParser::Optional, "Output BTree file");


### PR DESCRIPTION
This PR unifies the version info systems by converting the print function into a get function. This change allows the function to accept a defined name (e.g., `"Client"`, `"Server"`, `"Asset Packer"`) to append to the version string. 

If no name is provided, the output will display only `"OpenStarbound"` followed by the version information.