### PR TITLE
move doDisconnect and removeClient invokes

### DIFF
--- a/source/game/StarUniverseServer.cpp
+++ b/source/game/StarUniverseServer.cpp
@@ -2119,6 +2119,9 @@ void UniverseServer::doDisconnection(ConnectionId clientId, String const& reason
   RecursiveMutexLocker locker(m_mainLock);
   WriteLocker clientsLocker(m_clientsLock);
   if (auto clientContext = m_clients.value(clientId)) {
+    for (auto& p : m_scriptContexts)
+      p.second->invoke("doDisconnection", clientId);
+
     m_teamManager->playerDisconnected(clientContext->playerUuid());
     clientsLocker.unlock();
     // The client should revive at their ship if they are in an un-revivable
@@ -2177,8 +2180,6 @@ void UniverseServer::doDisconnection(ConnectionId clientId, String const& reason
     }
     clientsLocker.unlock();
 
-    for (auto& p : m_scriptContexts)
-      p.second->invoke("doDisconnection", clientId);
   }
 }
 

--- a/source/game/StarWorldServer.cpp
+++ b/source/game/StarWorldServer.cpp
@@ -293,6 +293,9 @@ bool WorldServer::addClient(ConnectionId clientId, SpawnTarget const& spawnTarge
 List<PacketPtr> WorldServer::removeClient(ConnectionId clientId) {
   auto const& info = m_clientInfo.get(clientId);
 
+  for (auto& p : m_scriptContexts)
+    p.second->invoke("removeClient", clientId);
+
   for (auto const& entityId : m_entityMap->entityIds()) {
     if (connectionForEntity(entityId) == clientId)
       removeEntity(entityId, false);
@@ -315,9 +318,6 @@ List<PacketPtr> WorldServer::removeClient(ConnectionId clientId) {
   m_clientInfo.remove(clientId);
 
   packets.append(make_shared<WorldStopPacket>("Removed"));
-
-  for (auto& p : m_scriptContexts)
-    p.second->invoke("removeClient", clientId);
 
   return packets;
 }


### PR DESCRIPTION
moves the invoke from the end of the relevant functions when disconnecting a client and removing a client from a world to the beginning

The player entity would still exist in world when the invoke happens, thus allowing the script to do more specific actions to what state the player may have been in when the invoke happened, as the entity has yet to be removed from the world allowing the script to read any relevant data such as the position or stats 