### PR TITLE
small Command changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Note: Mods that use StarExtensions features often work with OpenStarbound, StarE
     * `/settileprotection`
       * You can now specify as many dungeon IDs as you want: `/settileprotection 69 420 false`
       * You can now specify a range: /settileprotection 0..65535 true
+    * `/admin`
+      * You can now admin other players: `/admin playerSpecifier` (requires OpenSB server)
 ### Bug Fixes
 * Invalid character inventories are updated when loading in, allowing players to swap inventory mods with pre-existing characters.
 * Fix vanilla world file size bloating issue.

--- a/source/game/StarCommandProcessor.cpp
+++ b/source/game/StarCommandProcessor.cpp
@@ -102,7 +102,7 @@ String CommandProcessor::admin(ConnectionId connectionId, String const& argument
   ConnectionId targetClientId = connectionId;
 
   if (!arguments.empty()) {
-    if (auto errorMsg = adminCheck(connectionId, "admin a user"))
+    if (auto errorMsg = adminCheck(connectionId, "make user admin"))
       return *errorMsg;
 
     auto targetCid = playerCidFromCommand(arguments[0], m_universe);

--- a/source/game/StarCommandProcessor.cpp
+++ b/source/game/StarCommandProcessor.cpp
@@ -980,8 +980,8 @@ Maybe<ConnectionId> CommandProcessor::playerCidFromCommand(String const& player,
   return universe->findNick(player);
 }
 
-const StringMap<std::function<String(CommandProcessor*, ConnectionId, String)>> CommandProcessor::s_commandMap = []() {
-  StringMap<std::function<String(CommandProcessor*, ConnectionId, String)>> map;
+const CaseInsensitiveStringMap<std::function<String(CommandProcessor*, ConnectionId, String)>> CommandProcessor::s_commandMap = []() {
+  CaseInsensitiveStringMap<std::function<String(CommandProcessor*, ConnectionId, String)>> map;
 	
   auto add = [&map](const char* cmd, String (CommandProcessor::*func)(ConnectionId, const String&)) {
     map[cmd] = [func](CommandProcessor* self, ConnectionId cid, const String& args) {

--- a/source/game/StarCommandProcessor.hpp
+++ b/source/game/StarCommandProcessor.hpp
@@ -61,7 +61,7 @@ private:
   String setWeather(ConnectionId connectionId, String const& argumentString);
   String setEnvironmentBiome(ConnectionId connectionId, String const& argumentString);
 
-  static const StringMap<std::function<String(CommandProcessor*, ConnectionId, String)>> s_commandMap;
+  static const CaseInsensitiveStringMap<std::function<String(CommandProcessor*, ConnectionId, String)>> s_commandMap;
 
   mutable Mutex m_mutex;
 


### PR DESCRIPTION
- Replaced `StringMap` with `CaseInsensitiveStringMap` in `CommandProcessor`, making **all commands case-insensitive** (previously only client commands were).
- Updated the admin user error message to match the syntax of the admin self error.
- Updated `README.md` to document the new `admin` command behavior.