### PR TITLE
allow changing player render layer

### DIFF
--- a/source/game/StarPlayer.cpp
+++ b/source/game/StarPlayer.cpp
@@ -1243,7 +1243,14 @@ void Player::render(RenderCallback* renderCallback) {
   }
 
   auto loungeAnchor = as<LoungeAnchor>(m_movementController->entityAnchor());
-  EntityRenderLayer renderLayer = loungeAnchor ? loungeAnchor->loungeRenderLayer : RenderLayerPlayer;
+  
+  EntityRenderLayer renderLayer = RenderLayerPlayer;
+  if (auto overrideRenderLayer = getSecretProperty("overrideRenderLayer"); overrideRenderLayer.canConvert(Json::Type::Int)) {
+    renderLayer = overrideRenderLayer.toUInt();
+  }
+  if (loungeAnchor) {
+    renderLayer = loungeAnchor->loungeRenderLayer;
+  }
 
   renderCallback->addDrawables(drawables(), renderLayer);
   if (!isTeleporting())
@@ -1262,6 +1269,10 @@ void Player::render(RenderCallback* renderCallback) {
 void Player::renderLightSources(RenderCallback* renderCallback) {
   renderCallback->addLightSources(lightSources());
   m_deployment->renderLightSources(renderCallback);
+}
+
+void Player::setRenderLayer(Maybe<EntityRenderLayer> layer) {
+  setSecretProperty("overrideRenderLayer", layer ? Json(*layer) : Json());
 }
 
 Json Player::getGenericProperty(String const& name, Json const& defaultValue) const {

--- a/source/game/StarPlayer.hpp
+++ b/source/game/StarPlayer.hpp
@@ -208,6 +208,8 @@ public:
   void render(RenderCallback* renderCallback) override;
 
   void renderLightSources(RenderCallback* renderCallback) override;
+  
+  void setRenderLayer(Maybe<EntityRenderLayer> layer);
 
   Json getGenericProperty(String const& name, Json const& defaultValue = Json()) const;
   void setGenericProperty(String const& name, Json const& value);

--- a/source/game/scripting/StarPlayerLuaBindings.cpp
+++ b/source/game/scripting/StarPlayerLuaBindings.cpp
@@ -164,6 +164,13 @@ LuaCallbacks LuaBindings::makePlayerCallbacks(Player* player) {
 
   callbacks.registerCallback(   "interactRadius", [player]()         { return player->interactRadius();       });
   callbacks.registerCallback("setInteractRadius", [player](float radius) { player->setInteractRadius(radius); });
+  
+  callbacks.registerCallback("setRenderLayer", [player](Maybe<String> const& layer) { 
+    if (layer)
+      player->setRenderLayer(parseRenderLayer(*layer)); 
+    else
+      player->setRenderLayer({});
+  });
 
   callbacks.registerCallback("actionBarGroup", [player]() {
     return luaTupleReturn(player->inventory()->customBarGroup() + 1, player->inventory()->customBarGroups());


### PR DESCRIPTION
example for usage, as featured in my AbyssCore:
```lua
    message.setHandler("/abyssRenderLayer", function(_,l,c) 
        if not l then
            return "Unauthorized"
        end
        if not player.setRenderLayer then
            return "Your oSB is not new enough."
        end
        if #c <= 0 then
            player.setRenderLayer()
        else
            player.setRenderLayer(c)
        end
    end)
```