### PR TITLE
server and client custom worlds

### DIFF
--- a/source/client/StarClientApplication.cpp
+++ b/source/client/StarClientApplication.cpp
@@ -19,6 +19,7 @@
 #include "StarCurve25519.hpp"
 #include "StarInterpolation.hpp"
 
+#include "StarUniverseClientLuaBindings.hpp"
 #include "StarCameraLuaBindings.hpp"
 #include "StarCelestialLuaBindings.hpp"
 #include "StarClipboardLuaBindings.hpp"
@@ -667,8 +668,9 @@ void ClientApplication::changeState(MainAppState newState) {
 
     m_playerStorage = make_shared<PlayerStorage>(m_root->toStoragePath("player"));
     m_statistics = make_shared<Statistics>(m_root->toStoragePath("player"), app->statisticsService());
-    m_universeClient = make_shared<UniverseClient>(m_playerStorage, m_statistics);
+    m_universeClient = make_shared<UniverseClient>(m_playerStorage, m_statistics, m_root->toStoragePath("universeclient"));
 
+    m_universeClient->setLuaCallbacks("universe", LuaBindings::makeUniverseClientCallbacks(m_universeClient));
     m_universeClient->setLuaCallbacks("input", LuaBindings::makeInputCallbacks());
     m_universeClient->setLuaCallbacks("voice", LuaBindings::makeVoiceCallbacks());
     m_universeClient->setLuaCallbacks("camera", LuaBindings::makeCameraCallbacks(&m_worldPainter->camera()));

--- a/source/core/StarDataStream.cpp
+++ b/source/core/StarDataStream.cpp
@@ -6,7 +6,7 @@
 
 namespace Star {
 
-unsigned const CurrentStreamVersion = 14; // update OpenProtocolVersion too!
+unsigned const CurrentStreamVersion = 15; // update OpenProtocolVersion too!
 
 DataStream::DataStream()
   : m_byteOrder(ByteOrder::BigEndian),

--- a/source/core/StarNetCompatibility.cpp
+++ b/source/core/StarNetCompatibility.cpp
@@ -2,6 +2,6 @@
 
 namespace Star {
 
-VersionNumber const OpenProtocolVersion = 14; // update StreamCompatibilityVersion too!
+VersionNumber const OpenProtocolVersion = 15; // update StreamCompatibilityVersion too!
 
 }

--- a/source/frontend/StarMainInterface.cpp
+++ b/source/frontend/StarMainInterface.cpp
@@ -486,6 +486,12 @@ void MainInterface::handleInteractAction(InteractAction interactAction) {
           } else if (m_client->playerWorld().is<InstanceWorldId>()) {
             icon = worldTemplate->worldParameters()->typeName;
             planetName = worldTemplate->worldName();
+          } else if (m_client->playerWorld().is<CustomWorldId>()) {
+            icon = worldTemplate->worldParameters()->typeName;
+            planetName = worldTemplate->worldName();
+          } else if (m_client->playerWorld().is<ClientCustomWorldId>()) {
+            icon = worldTemplate->worldParameters()->typeName;
+            planetName = worldTemplate->worldName();
           } else {
             icon = "default";
             planetName = "???";

--- a/source/game/CMakeLists.txt
+++ b/source/game/CMakeLists.txt
@@ -257,6 +257,7 @@ SET (star_game_HEADERS
     scripting/StarTeamClientLuaBindings.hpp
     scripting/StarWorldLuaBindings.hpp
     scripting/StarUniverseServerLuaBindings.hpp
+    scripting/StarUniverseClientLuaBindings.hpp
     scripting/StarScriptableThread.hpp
 
     terrain/StarCacheSelector.hpp
@@ -502,6 +503,7 @@ SET (star_game_SOURCES
     scripting/StarTeamClientLuaBindings.cpp
     scripting/StarWorldLuaBindings.cpp
     scripting/StarUniverseServerLuaBindings.cpp
+    scripting/StarUniverseClientLuaBindings.cpp
     scripting/StarScriptableThread.cpp
 
     terrain/StarCacheSelector.cpp

--- a/source/game/StarClientContext.cpp
+++ b/source/game/StarClientContext.cpp
@@ -73,6 +73,10 @@ WorldChunks ClientContext::newShipUpdates() {
   return take(m_newShipUpdates);
 }
 
+StringMap<WorldChunks> ClientContext::newCustomWorldUpdates() {
+  return take(m_newCustomWorldUpdates);
+}
+
 ShipUpgrades ClientContext::shipUpgrades() const {
   return m_shipUpgrades.get();
 }
@@ -90,6 +94,13 @@ void ClientContext::readUpdate(ByteArray data, NetCompatibilityRules rules) {
   if (!shipUpdates.empty())
     m_newShipUpdates.merge(DataStreamBuffer::deserialize<WorldChunks>(std::move(shipUpdates)), true);
 
+  if (rules.version() >= 15) {
+    auto customWorldUpdates = ds.read<StringMap<ByteArray>>();
+    for (auto& p : customWorldUpdates) {
+      m_newCustomWorldUpdates[p.first].merge(DataStreamBuffer::deserialize<WorldChunks>(std::move(p.second)), true);
+    }
+  }
+  
   m_netGroup.readNetState(ds.read<ByteArray>(), 0.0f, rules);
 }
 

--- a/source/game/StarClientContext.hpp
+++ b/source/game/StarClientContext.hpp
@@ -39,6 +39,8 @@ public:
 
   WorldChunks newShipUpdates();
   ShipUpgrades shipUpgrades() const;
+  
+  StringMap<WorldChunks> newCustomWorldUpdates();
 
   void readUpdate(ByteArray data, NetCompatibilityRules rules);
   ByteArray writeUpdate(NetCompatibilityRules rules);
@@ -65,6 +67,7 @@ private:
   NetElementData<ShipUpgrades> m_shipUpgrades;
   NetElementData<CelestialCoordinate> m_shipCoordinate;
   WorldChunks m_newShipUpdates;
+  StringMap<WorldChunks> m_newCustomWorldUpdates;
 };
 
 }

--- a/source/game/StarNetPackets.cpp
+++ b/source/game/StarNetPackets.cpp
@@ -78,7 +78,10 @@ EnumMap<PacketType> const PacketTypeNames{
   {PacketType::SystemObjectSpawn, "SystemObjectSpawn"},
   // OpenStarbound packets
   {PacketType::ReplaceTileList, "ReplaceTileList"},
-  {PacketType::UpdateWorldTemplate, "UpdateWorldTemplate"}
+  {PacketType::UpdateWorldTemplate, "UpdateWorldTemplate"},
+  {PacketType::ClientCustomWorldRequest, "ClientCustomWorldRequest"},
+  {PacketType::ClientCustomWorldResponse, "ClientCustomWorldResponse"},
+  {PacketType::ClientCustomWorldCreate, "ClientCustomWorldCreate"}
 };
 
 EnumMap<NetCompressionMode> const NetCompressionModeNames {
@@ -172,6 +175,9 @@ PacketPtr createPacket(PacketType type) {
     // OpenStarbound
     case PacketType::ReplaceTileList: return make_shared<ReplaceTileListPacket>();
     case PacketType::UpdateWorldTemplate: return make_shared<UpdateWorldTemplatePacket>();
+    case PacketType::ClientCustomWorldRequest: return make_shared<ClientCustomWorldRequest>();
+    case PacketType::ClientCustomWorldResponse: return make_shared<ClientCustomWorldResponse>();
+    case PacketType::ClientCustomWorldCreate: return make_shared<ClientCustomWorldCreate>();
     default:
       throw StarPacketException(strf("Unrecognized packet type {}", (unsigned int)type));
   }
@@ -1442,6 +1448,48 @@ void UpdateWorldTemplatePacket::read(DataStream& ds) {
 }
 
 void UpdateWorldTemplatePacket::write(DataStream& ds) const {
+  ds.write(templateData);
+}
+
+
+
+ClientCustomWorldRequest::ClientCustomWorldRequest() {}
+
+ClientCustomWorldRequest::ClientCustomWorldRequest(String name) : name(std::move(name)) {}
+
+void ClientCustomWorldRequest::read(DataStream& ds) {
+  ds.read(name);
+}
+
+void ClientCustomWorldRequest::write(DataStream& ds) const {
+  ds.write(name);
+}
+
+ClientCustomWorldResponse::ClientCustomWorldResponse() {}
+
+ClientCustomWorldResponse::ClientCustomWorldResponse(String name, WorldChunks chunks) : name(std::move(name)), chunks(std::move(chunks)) {}
+
+void ClientCustomWorldResponse::read(DataStream& ds) {
+  ds.read(name);
+  ds.read(chunks);
+}
+
+void ClientCustomWorldResponse::write(DataStream& ds) const {
+  ds.write(name);
+  ds.write(chunks);
+}
+
+ClientCustomWorldCreate::ClientCustomWorldCreate() {}
+
+ClientCustomWorldCreate::ClientCustomWorldCreate(String name, Json templateData) : name(std::move(name)), templateData(std::move(templateData)) {}
+
+void ClientCustomWorldCreate::read(DataStream& ds) {
+  ds.read(name);
+  ds.read(templateData);
+}
+
+void ClientCustomWorldCreate::write(DataStream& ds) const {
+  ds.write(name);
   ds.write(templateData);
 }
 

--- a/source/game/StarNetPackets.hpp
+++ b/source/game/StarNetPackets.hpp
@@ -117,7 +117,10 @@ enum class PacketType : uint8_t {
 
   // OpenStarbound packets
   ReplaceTileList,
-  UpdateWorldTemplate
+  UpdateWorldTemplate,
+  ClientCustomWorldRequest,
+  ClientCustomWorldResponse,
+  ClientCustomWorldCreate
 };
 extern EnumMap<PacketType> const PacketTypeNames;
 
@@ -979,6 +982,38 @@ struct UpdateWorldTemplatePacket : PacketBase<PacketType::UpdateWorldTemplate> {
   void read(DataStream& ds) override;
   void write(DataStream& ds) const override;
 
+  Json templateData;
+};
+
+struct ClientCustomWorldRequest : PacketBase<PacketType::ClientCustomWorldRequest> {
+  ClientCustomWorldRequest();
+  ClientCustomWorldRequest(String name);
+
+  void read(DataStream& ds) override;
+  void write(DataStream& ds) const override;
+
+  String name;
+};
+
+struct ClientCustomWorldResponse : PacketBase<PacketType::ClientCustomWorldResponse> {
+  ClientCustomWorldResponse();
+  ClientCustomWorldResponse(String name, WorldChunks chunks);
+
+  void read(DataStream& ds) override;
+  void write(DataStream& ds) const override;
+
+  String name;
+  WorldChunks chunks;
+};
+
+struct ClientCustomWorldCreate : PacketBase<PacketType::ClientCustomWorldCreate> {
+  ClientCustomWorldCreate();
+  ClientCustomWorldCreate(String name, Json templateData);
+
+  void read(DataStream& ds) override;
+  void write(DataStream& ds) const override;
+
+  String name;
   Json templateData;
 };
 }

--- a/source/game/StarServerClientContext.cpp
+++ b/source/game/StarServerClientContext.cpp
@@ -202,13 +202,22 @@ ByteArray ServerClientContext::writeUpdate() {
 
   ByteArray netGroupUpdate;
   tie(netGroupUpdate, m_netVersion) = m_netGroup.writeNetState(m_netVersion, m_netRules);
+  
+  StringMap<ByteArray> customWorldChunksUpdate;
+  for (auto& p : m_customWorlds) {
+    if (!p.second.chunksUpdate.empty())
+      customWorldChunksUpdate[p.first] = DataStreamBuffer::serialize(take(p.second.chunksUpdate));
+  }
 
-  if (rpcUpdate.empty() && shipChunksUpdate.empty() && netGroupUpdate.empty())
+  if (rpcUpdate.empty() && shipChunksUpdate.empty() && netGroupUpdate.empty() && (m_netRules.version() < 15 || customWorldChunksUpdate.empty()))
     return {};
 
   DataStreamBuffer ds;
   ds.write(rpcUpdate);
   ds.write(shipChunksUpdate);
+  if (m_netRules.version() >= 15) {
+    ds.write(customWorldChunksUpdate);
+  }
   ds.write(netGroupUpdate);
 
   return ds.takeData();
@@ -276,6 +285,74 @@ WarpToWorld ServerClientContext::playerReviveWarp() const {
 void ServerClientContext::setPlayerReviveWarp(WarpToWorld warp) {
   RecursiveMutexLocker locker(m_mutex);
   m_reviveWarp = std::move(warp);
+}
+
+ServerClientContext::CustomWorld::CustomWorld() : chunks(WorldChunks()), chunksUpdate(WorldChunks()), active(false) {}
+ServerClientContext::CustomWorld::CustomWorld(WorldChunks initialChunks) : chunks(initialChunks), chunksUpdate(WorldChunks()), active(false) {}
+
+void ServerClientContext::customWorldRequested(String name, RpcThreadPromiseKeeper<WorldChunks> promise) {
+  RecursiveMutexLocker locker(m_mutex);
+  m_worldRequests.add(name,promise);
+}
+
+void ServerClientContext::customWorldReceived(String name, WorldChunks chunks) {
+  RecursiveMutexLocker locker(m_mutex);
+  if (auto promise = m_worldRequests.maybeTake(name)) {
+    (*promise).fulfill(chunks);
+  }
+  m_customWorlds.add(name,CustomWorld(std::move(chunks)));
+}
+
+void ServerClientContext::failWorldRequests() {
+  RecursiveMutexLocker locker(m_mutex);
+  for (auto& p : m_worldRequests) {
+    p.second.fail("Client disconnected");
+  }
+  m_worldRequests = {};
+}
+
+Maybe<WorldChunks> ServerClientContext::customWorldChunks(String name) const {
+  RecursiveMutexLocker locker(m_mutex);
+  if (m_customWorlds.contains(name)) {
+    return m_customWorlds.get(name).chunks;
+  } else {
+    return {};
+  }
+}
+
+void ServerClientContext::updateCustomWorldChunks(String name, WorldChunks newWorldChunks) {
+  RecursiveMutexLocker locker(m_mutex);
+  if (!m_customWorlds.contains(name)) {
+    m_customWorlds.add(name,CustomWorld());
+  }
+  auto &world = m_customWorlds.get(name);
+  world.chunksUpdate.merge(WorldStorage::getWorldChunksUpdate(world.chunks, newWorldChunks), true);
+  world.chunks = std::move(newWorldChunks);
+}
+
+void ServerClientContext::setCustomWorldActive(String name, bool active) {
+  RecursiveMutexLocker locker(m_mutex);
+  if (m_customWorlds.contains(name)) {
+    m_customWorlds.get(name).active = active;
+  }
+}
+
+List<String> ServerClientContext::customWorlds() const {
+  RecursiveMutexLocker locker(m_mutex);
+  return m_customWorlds.keys();
+}
+
+void ServerClientContext::cleanInactiveCustomWorlds() {
+  RecursiveMutexLocker locker(m_mutex);
+  for (auto worldName : m_customWorlds.keys()) {
+    if (m_customWorlds.contains(worldName)) {
+      auto &world = m_customWorlds.get(worldName);
+      if (!world.active && world.chunksUpdate.empty()) {
+        Logger::info("Removing inactive custom world '{}' for client '{}'",worldName,m_playerUuid.hex());
+        m_customWorlds.remove(worldName);
+      }
+    }
+  }
 }
 
 void ServerClientContext::loadServerData(Json const& store) {

--- a/source/game/StarServerClientContext.hpp
+++ b/source/game/StarServerClientContext.hpp
@@ -4,6 +4,7 @@
 #include "StarThread.hpp"
 #include "StarUuid.hpp"
 #include "StarJsonRpc.hpp"
+#include "StarRpcThreadPromise.hpp"
 #include "StarDamageTypes.hpp"
 #include "StarGameTypes.hpp"
 #include "StarHostAddress.hpp"
@@ -79,6 +80,17 @@ public:
 
   WarpToWorld playerReviveWarp() const;
   void setPlayerReviveWarp(WarpToWorld warp);
+  
+  void customWorldRequested(String name, RpcThreadPromiseKeeper<WorldChunks> promise);
+  void customWorldReceived(String name, WorldChunks chunks);
+  void failWorldRequests();
+  
+  Maybe<WorldChunks> customWorldChunks(String name) const;
+  void updateCustomWorldChunks(String name, WorldChunks newWorldChunks);
+  void setCustomWorldActive(String name, bool active);
+  List<String> customWorlds() const;
+  
+  void cleanInactiveCustomWorlds();
 
   // Store and load the data for this client that should be persisted on the
   // server, such as celestial log data, admin state, team, and current ship
@@ -89,6 +101,16 @@ public:
   int64_t creationTime() const;
 
 private:
+  struct CustomWorld {
+    WorldChunks chunks;
+    WorldChunks chunksUpdate;
+    
+    bool active;
+    
+    CustomWorld(WorldChunks initialChunks);
+    CustomWorld();
+  };
+  
   ConnectionId const m_clientId;
   Maybe<HostAddress> const m_remoteAddress;
   NetCompatibilityRules m_netRules;
@@ -113,6 +135,9 @@ private:
   NetElementTopGroup m_netGroup;
   uint64_t m_netVersion = 0;
   int64_t m_creationTime;
+  
+  StringMap<RpcThreadPromiseKeeper<WorldChunks>> m_worldRequests;
+  StringMap<CustomWorld> m_customWorlds;
 
   NetElementData<Maybe<pair<WarpAction, WarpMode>>> m_orbitWarpActionNetState;
   NetElementData<WorldId> m_playerWorldIdNetState;

--- a/source/game/StarTeamClient.cpp
+++ b/source/game/StarTeamClient.cpp
@@ -10,7 +10,10 @@
 #include "StarJsonRpc.hpp"
 
 namespace Star {
-
+  
+// update this in the rare case that backwards compat code has to be set up in TeamManager
+VersionNumber const TeamClientVersion = 1;
+  
 TeamClient::TeamClient(PlayerPtr mainPlayer, ClientContextPtr clientContext) {
   m_mainPlayer = mainPlayer;
   m_clientContext = clientContext;
@@ -156,6 +159,8 @@ void TeamClient::pullFullUpdate() {
   invokeRemote("team.fetchTeamStatus", request, [this](Json response) {
       m_fullUpdateRunning = false;
 
+      m_teamManagerVersion = response.optInt("version").value(0);
+      
       m_teamUuid = response.optString("teamUuid").apply(construct<Uuid>());
 
       if (m_teamUuid) {
@@ -232,6 +237,7 @@ void TeamClient::handleRpcResponses() {
 }
 
 void TeamClient::writePlayerData(JsonObject& request, PlayerPtr player, bool fullWrite) const {
+  request["version"] = TeamClientVersion;
   request["playerUuid"] = m_clientContext->playerUuid().hex();
   request["entity"] = player->entityId();
   request["health"] = player->health() / player->maxHealth();

--- a/source/game/StarTeamClient.hpp
+++ b/source/game/StarTeamClient.hpp
@@ -4,9 +4,12 @@
 #include "StarDrawable.hpp"
 #include "StarWarping.hpp"
 #include "StarJsonRpc.hpp"
+#include "StarVersion.hpp"
 
 namespace Star {
 
+extern VersionNumber const TeamClientVersion;
+  
 STAR_CLASS(Player);
 STAR_CLASS(ClientContext);
 STAR_CLASS(TeamClient);
@@ -82,6 +85,8 @@ private:
   double m_statusUpdateTimer;
 
   List<RpcResponseHandler> m_pendingResponses;
+  
+  int m_teamManagerVersion = 0;
 };
 
 }

--- a/source/game/StarTeamManager.cpp
+++ b/source/game/StarTeamManager.cpp
@@ -7,6 +7,9 @@
 #include "StarLogging.hpp"
 
 namespace Star {
+  
+// update this in the rare case that backwards compat code has to be set up in TeamClient
+VersionNumber const TeamManagerVersion = 0;
 
 TeamManager::TeamManager() {
   m_pvpTeamCounter = 1;
@@ -213,8 +216,10 @@ Json TeamManager::fetchTeamStatus(Json const& arguments) {
   }
 
   JsonObject result;
+  result["version"] = TeamManagerVersion;
   if (auto teamUuid = getTeam(playerUuid)) {
     auto& team = m_teams.get(*teamUuid);
+    auto& playerMem = team.members.get(playerUuid);
 
     result["teamUuid"] = teamUuid->hex();
     result["leader"] = team.leaderUuid.hex();
@@ -230,8 +235,8 @@ Json TeamManager::fetchTeamStatus(Json const& arguments) {
       member["energy"] = mem.energyPercentage;
       member["x"] = mem.position[0];
       member["y"] = mem.position[1];
-      if (mem.world.is<CustomWorldId>() || mem.world.is<ClientCustomWorldId>()) {
-        // TODO: check if they're new enough to work with new world ids.
+      if ((mem.world.is<CustomWorldId>() || mem.world.is<ClientCustomWorldId>()) && playerMem.version < 1) {
+        // caller is too old to handle custom worlds, pretend they're testarena instead to prevent invalid worldid disconnects
         member["world"] = "InstanceWorld:testarena";
       } else {
         member["world"] = printWorldId(mem.world);
@@ -272,6 +277,8 @@ Json TeamManager::updateStatus(Json const& arguments) {
       entry.world = parseWorldId(arguments.getString("world"));
     if (arguments.contains("portrait"))
       entry.portrait = jsonToList<Drawable>(arguments.get("portrait"));
+    if (arguments.contains("version"))
+      entry.version = arguments.getInt("version");
     return {};
   } else {
     return "notAMemberOfTeam";

--- a/source/game/StarTeamManager.cpp
+++ b/source/game/StarTeamManager.cpp
@@ -230,7 +230,12 @@ Json TeamManager::fetchTeamStatus(Json const& arguments) {
       member["energy"] = mem.energyPercentage;
       member["x"] = mem.position[0];
       member["y"] = mem.position[1];
-      member["world"] = printWorldId(mem.world);
+      if (mem.world.is<CustomWorldId>() || mem.world.is<ClientCustomWorldId>()) {
+        // TODO: check if they're new enough to work with new world ids.
+        member["world"] = "InstanceWorld:testarena";
+      } else {
+        member["world"] = printWorldId(mem.world);
+      }
       member["warpMode"] = WarpModeNames.getRight(mem.warpMode);
       member["portrait"] = jsonFromList(mem.portrait, mem_fn(&Drawable::toJson));
       members.push_back(member);

--- a/source/game/StarTeamManager.hpp
+++ b/source/game/StarTeamManager.hpp
@@ -6,8 +6,11 @@
 #include "StarWarping.hpp"
 #include "StarThread.hpp"
 #include "StarDamageTypes.hpp"
+#include "StarVersion.hpp"
 
 namespace Star {
+  
+extern VersionNumber const TeamManagerVersion;
 
 STAR_CLASS(TeamManager);
 
@@ -35,6 +38,8 @@ private:
     WorldId world;
     Vec2F position;
     WarpMode warpMode;
+    
+    int version = 0;
 
     List<Drawable> portrait;
   };

--- a/source/game/StarUniverseClient.cpp
+++ b/source/game/StarUniverseClient.cpp
@@ -26,10 +26,11 @@
 
 namespace Star {
 
-UniverseClient::UniverseClient(PlayerStoragePtr playerStorage, StatisticsPtr statistics) {
+UniverseClient::UniverseClient(PlayerStoragePtr playerStorage, StatisticsPtr statistics, String const& customWorldStorageDir) {
   m_storageTriggerDeadline = 0;
   m_playerStorage = std::move(playerStorage);
   m_statistics = std::move(statistics);
+  m_customWorldStorageDirectory = customWorldStorageDir;
   m_pause = false;
   m_luaRoot = make_shared<LuaRoot>();
   reset();
@@ -228,6 +229,19 @@ void UniverseClient::update(float dt) {
       warpPlayer(parseWarpAction(playerWarp->action), (bool)playerWarp->animation, playerWarp->animation.value("default"), playerWarp->deploy);
   }
 
+  if (m_pendingWarp) {
+    // completely forbid warps to custom worlds on old servers to prevent issues
+    if (m_connection->packetSocket().netRules().version() < 15) {
+      if (auto warpToWorld = m_pendingWarp.ptr<WarpToWorld>()) {
+        if (warpToWorld->world.is<CustomWorldId>() || warpToWorld->world.is<ClientCustomWorldId>()) {
+          Logger::warn("Attempting to warp to a custom world on an old server, cancelling.");
+          m_pendingWarp = WarpAction();
+          m_warping.reset();
+          m_warpDelay.reset();
+        }
+      }
+    }
+  }
   if (m_pendingWarp) {
     if ((m_warping && !m_mainPlayer->isTeleportingOut()) || (!m_warping && m_warpDelay.tick(dt))) {
       m_connection->pushSingle(make_shared<PlayerWarpPacket>(take(m_pendingWarp), m_mainPlayer->isDeploying()));
@@ -698,6 +712,14 @@ StatisticsPtr UniverseClient::statistics() const {
   return m_statistics;
 }
 
+void UniverseClient::createCustomWorld(String const& name, Json templateData) {
+  RecursiveMutexLocker locker(m_mutex);
+  String filename = File::relativeTo(m_customWorldStorageDirectory, strf("{}.world", name));
+  if (!File::exists(filename)) {
+    m_connection->pushSingle(make_shared<ClientCustomWorldCreate>(name, templateData));
+  }
+}
+
 bool UniverseClient::paused() const {
   return m_pause;
 }
@@ -734,6 +756,17 @@ void UniverseClient::handlePackets(List<PacketPtr> const& packets) {
       if (auto clientContextUpdate = as<ClientContextUpdatePacket>(packet)) {
         m_clientContext->readUpdate(clientContextUpdate->updateData, m_clientContext->netCompatibilityRules());
         m_playerStorage->applyShipUpdates(m_clientContext->playerUuid(), m_clientContext->newShipUpdates());
+        
+        auto customWorldUpdates = m_clientContext->newCustomWorldUpdates();
+        if (!customWorldUpdates.empty()) {
+          RecursiveMutexLocker locker(m_mutex);
+          for (auto p : customWorldUpdates) {
+            if (!p.second.empty()) {
+              String filePath = File::relativeTo(m_customWorldStorageDirectory, strf("{}.world", p.first));
+              WorldStorage::applyWorldChunksUpdateToFile(filePath, p.second);
+            }
+          }
+        }
 
         if (playerIsOriginal()) {
           m_mainPlayer->setShipUpgrades(m_clientContext->shipUpgrades());
@@ -786,6 +819,20 @@ void UniverseClient::handlePackets(List<PacketPtr> const& packets) {
         GlobalTimescale = clamp(pausePacket->timescale, 0.0f, 1024.f);
       } else if (auto serverInfoPacket = as<ServerInfoPacket>(packet)) {
         m_serverInfo = ServerInfo{serverInfoPacket->players, serverInfoPacket->maxPlayers};
+      } else if (auto clientCustomWorldRequest = as<ClientCustomWorldRequest>(packet)) {
+        RecursiveMutexLocker locker(m_mutex);
+        String filename = File::relativeTo(m_customWorldStorageDirectory, strf("{}.world", clientCustomWorldRequest->name));
+        if (File::exists(filename)) {
+          try {
+              m_connection->pushSingle(make_shared<ClientCustomWorldResponse>(clientCustomWorldRequest->name, WorldStorage::getWorldChunksFromFile(filename)));
+          } catch (StarException const& e) {
+            Logger::error("Failed to load custom world file {} : {}", filename, outputException(e, false));
+            m_connection->pushSingle(make_shared<ClientCustomWorldResponse>(clientCustomWorldRequest->name, WorldChunks()));
+          }
+        } else {
+          Logger::error("Custom world file {} does not exist", filename);
+          m_connection->pushSingle(make_shared<ClientCustomWorldResponse>(clientCustomWorldRequest->name, WorldChunks()));
+        }
       } else if (!m_systemWorldClient->handleIncomingPacket(packet)) {
         // see if the system world will handle it, otherwise pass it along to the world client
         m_worldClient->handleIncomingPackets({packet});

--- a/source/game/StarUniverseClient.hpp
+++ b/source/game/StarUniverseClient.hpp
@@ -34,7 +34,7 @@ STAR_CLASS(LuaRoot);
 
 class UniverseClient {
 public:
-  UniverseClient(PlayerStoragePtr playerStorage, StatisticsPtr statistics);
+  UniverseClient(PlayerStoragePtr playerStorage, StatisticsPtr statistics, String const& customWorldStorageDir);
   ~UniverseClient();
 
   void setMainPlayer(PlayerPtr player);
@@ -110,6 +110,8 @@ public:
   QuestManagerPtr questManager() const;
   PlayerStoragePtr playerStorage() const;
   StatisticsPtr statistics() const;
+  
+  void createCustomWorld(String const& name, Json templateData);
 
   bool paused() const;
 
@@ -123,10 +125,14 @@ private:
 
   void handlePackets(List<PacketPtr> const& packets);
   void reset();
+  
+  mutable RecursiveMutex m_mutex;
 
   PlayerStoragePtr m_playerStorage;
   StatisticsPtr m_statistics;
   PlayerPtr m_mainPlayer;
+  
+  String m_customWorldStorageDirectory;
 
   bool m_pause;
   ClockPtr m_universeClock;

--- a/source/game/StarUniverseConnection.cpp
+++ b/source/game/StarUniverseConnection.cpp
@@ -154,29 +154,36 @@ UniverseConnectionServer::UniverseConnectionServer(PacketReceiveCallback packetR
             if (!p.second->packetSocket || !p.second->packetSocket->isOpen())
               continue;
 
-            p.second->packetSocket->sendPackets(take(p.second->sendQueue));
-            dataTransmitted |= p.second->packetSocket->writeData();
+            try {
+              p.second->packetSocket->sendPackets(take(p.second->sendQueue));
+              dataTransmitted |= p.second->packetSocket->writeData();
 
-            dataTransmitted |= p.second->packetSocket->readData();
-            List<PacketPtr> receivePackets = p.second->packetSocket->receivePackets();
-            if (!receivePackets.empty()) {
-              p.second->lastActivityTime = Time::monotonicMilliseconds();
-              m_workerStats[i].packetsProcessed += receivePackets.size();
-              p.second->receiveQueue.appendAll(take(receivePackets));
-            }
-
-            if (!p.second->receiveQueue.empty()) {
-              List<PacketPtr> toReceive = List<PacketPtr>::from(take(p.second->receiveQueue));
-              connectionLocker.unlock();
-
-              try {
-                m_packetReceiver(this, p.first, std::move(toReceive));
-              } catch (std::exception const& e) {
-                Logger::error("Exception caught handling incoming server packets, disconnecting client '{}' {}", p.first, outputException(e, true));
-
-                connectionLocker.lock();
-                p.second->packetSocket->close();
+              dataTransmitted |= p.second->packetSocket->readData();
+              List<PacketPtr> receivePackets = p.second->packetSocket->receivePackets();
+              if (!receivePackets.empty()) {
+                p.second->lastActivityTime = Time::monotonicMilliseconds();
+                m_workerStats[i].packetsProcessed += receivePackets.size();
+                p.second->receiveQueue.appendAll(take(receivePackets));
               }
+
+              if (!p.second->receiveQueue.empty()) {
+                List<PacketPtr> toReceive = List<PacketPtr>::from(take(p.second->receiveQueue));
+                connectionLocker.unlock();
+
+                try {
+                  m_packetReceiver(this, p.first, std::move(toReceive));
+                } catch (std::exception const& e) {
+                  Logger::error("Exception caught handling incoming server packets, disconnecting client '{}' {}", p.first, outputException(e, true));
+
+                  connectionLocker.lock();
+                  p.second->packetSocket->close();
+                }
+              }
+            } catch (std::exception const& e) {
+              Logger::error("Exception caught receiving incoming server packets, disconnecting client '{}' {}", p.first, outputException(e, true));
+              
+              connectionLocker.lock();
+              p.second->packetSocket->close();
             }
           }
           m_workerStats[i].connectionsHandled = handledCount;

--- a/source/game/StarUniverseServer.cpp
+++ b/source/game/StarUniverseServer.cpp
@@ -18,7 +18,6 @@
 #include "StarTeamManager.hpp"
 #include "StarUniverseServerLuaBindings.hpp"
 #include "StarVersioningDatabase.hpp"
-#include "StarWorldTemplate.hpp"
 
 namespace Star {
 
@@ -638,6 +637,42 @@ void UniverseServer::run() {
   } catch (std::exception const& e) {
     Logger::error("UniverseServer: exception caught cleaning up: {}", outputException(e, true));
   }
+}
+
+UniverseServer::WorldServerPromise::WorldServerPromise(function<WorkerPoolPromise<WorldServerThreadPtr>(WorldChunks)> producer, RpcThreadPromise<WorldChunks> promise)
+  : currentPromise(promise), producer(producer) {}
+  
+UniverseServer::WorldServerPromise::WorldServerPromise(WorkerPoolPromise<WorldServerThreadPtr> promise)
+  : currentPromise(promise) {}
+  
+bool UniverseServer::WorldServerPromise::done() const {
+  if (auto wpp = currentPromise.ptr<WorkerPoolPromise<WorldServerThreadPtr>>()) {
+    return wpp->done();
+  } else if (auto rpcp = currentPromise.ptr<RpcThreadPromise<WorldChunks>>()) {
+    return rpcp->finished();
+  }
+  return false;
+}
+bool UniverseServer::WorldServerPromise::poll() {
+  if (auto wpp = currentPromise.ptr<WorkerPoolPromise<WorldServerThreadPtr>>()) {
+    return wpp->poll();
+  } else if (auto rpcp = currentPromise.ptr<RpcThreadPromise<WorldChunks>>()) {
+    if (rpcp->finished()) {
+      if (rpcp->succeeded()) {
+        currentPromise = (*producer)(*rpcp->result());
+      } else {
+        throw UniverseServerException(strf("UniverseServer: World server promise failed! {}", rpcp->error()));
+      }
+    }
+    return false;
+  }
+  return false;
+}
+WorldServerThreadPtr UniverseServer::WorldServerPromise::get() {
+  if (auto wpp = currentPromise.ptr<WorkerPoolPromise<WorldServerThreadPtr>>()) {
+    return wpp->get();
+  }
+  return nullptr;
 }
 
 void UniverseServer::processUniverseFlags() {
@@ -1274,6 +1309,13 @@ void UniverseServer::shutdownInactiveWorlds() {
           world->unloadAll(true);
           if (auto clientId = getClientForUuid(worldId.get<ClientShipWorldId>()))
             m_clients.get(*clientId)->updateShipChunks(world->readChunks());
+        } else if (worldId.is<ClientCustomWorldId>()) {
+          world->unloadAll(true);
+          auto ccwId = worldId.get<ClientCustomWorldId>();
+          if (auto clientId = getClientForUuid(ccwId.uuid)) {
+            m_clients.get(*clientId)->updateCustomWorldChunks(ccwId.name, world->readChunks());
+            m_clients.get(*clientId)->setCustomWorldActive(ccwId.name, false);
+          }
         }
 
         m_worlds.remove(worldId);
@@ -1327,6 +1369,14 @@ void UniverseServer::doTriggeredStorage() {
     for (auto const& p : m_clients) {
       if (auto shipWorld = getWorld(ClientShipWorldId(p.second->playerUuid())))
         p.second->updateShipChunks(shipWorld->readChunks());
+      
+      for (auto worldName : p.second->customWorlds()) {
+        if (auto world = getWorld(ClientCustomWorldId(p.second->playerUuid(),worldName))) {
+          p.second->updateCustomWorldChunks(worldName,world->readChunks());
+        }
+      }
+      
+      p.second->cleanInactiveCustomWorlds();
 
       auto versioningDatabase = Root::singleton().versioningDatabase();
       String clientContextFile = File::relativeTo(m_storageDirectory, strf("{}.clientcontext", p.second->playerUuid().hex()));
@@ -1652,7 +1702,9 @@ void UniverseServer::packetsReceived(UniverseConnectionServer*, ConnectionId cli
           if (warpToWorld->world.empty() || 
               warpToWorld->world.is<ClientShipWorldId>() || 
               warpToWorld->world.is<CelestialWorldId>() ||
-              warpToWorld->world.is<InstanceWorldId>()) {
+              warpToWorld->world.is<InstanceWorldId>() || 
+              warpToWorld->world.is<CustomWorldId>() ||
+              warpToWorld->world.is<ClientCustomWorldId>()) {
             blocked = false;
           }
         }
@@ -1723,6 +1775,22 @@ void UniverseServer::packetsReceived(UniverseConnectionServer*, ConnectionId cli
         if (auto currentWorld = clientContext->playerWorld())
           currentWorld->pushIncomingPackets(clientId, {std::move(packet)});
 
+      } else if (auto clientCustomWorldResponse = as<ClientCustomWorldResponse>(packet)) {
+        clientContext->customWorldReceived(clientCustomWorldResponse->name, clientCustomWorldResponse->chunks);
+      } else if (auto clientCustomWorldCreate = as<ClientCustomWorldCreate>(packet)) {
+        RecursiveMutexLocker locker(m_mainLock);
+        clientsLocker.lock();
+        
+        auto worldId = ClientCustomWorldId(clientContext->playerUuid(),clientCustomWorldCreate->name);
+        if (!m_worlds.contains(worldId)) {
+          auto worldTemplate = make_shared<WorldTemplate>(clientCustomWorldCreate->templateData);
+          if (auto promise = clientCustomWorldPromise(worldId,worldTemplate)) {
+            m_worlds.add(worldId, promise.take());
+          }
+        }
+        
+        clientsLocker.unlock();
+        locker.unlock();
       } else if (is<SystemObjectSpawnPacket>(packet)) {
         if (auto currentSystem = clientContext->systemWorld())
           currentSystem->pushIncomingPacket(clientId, std::move(packet));
@@ -1974,7 +2042,9 @@ void UniverseServer::acceptConnection(UniverseConnection connection, Maybe<HostA
         useReviveWarp = false;
     }
 
-    if (reviveWarp.world.is<ClientShipWorldId>() && reviveWarp.world.get<ClientShipWorldId>() != clientConnect->playerUuid)
+    if ((reviveWarp.world.is<ClientShipWorldId>() && reviveWarp.world.get<ClientShipWorldId>() != clientConnect->playerUuid)
+      || reviveWarp.world.is<ClientCustomWorldId>()
+    )
       useReviveWarp = false;
 
     if (useReviveWarp) {
@@ -2145,6 +2215,7 @@ void UniverseServer::doDisconnection(ConnectionId clientId, String const& reason
       systemWorld->removeClient(clientId);
 
     clientContext->clearSystemWorld();
+    clientContext->failWorldRequests();
 
     if (m_chatProcessor->hasClient(clientId))
       m_chatProcessor->disconnectClient(clientId);
@@ -2158,6 +2229,19 @@ void UniverseServer::doDisconnection(ConnectionId clientId, String const& reason
         shipWorld->stop();
         locker.lock();
       }
+      
+      // Send the client the last update for all custom worlds as well.
+      for (auto worldName : clientContext->customWorlds()) {
+        if (auto world = getWorld(ClientCustomWorldId(clientContext->playerUuid(), worldName))) {
+          locker.unlock();
+          world->unloadAll(true);
+          clientContext->updateCustomWorldChunks(worldName,world->readChunks());
+          clientContext->setCustomWorldActive(worldName,false);
+          world->stop();
+          locker.lock();
+        }
+      }
+      
       sendClientContextUpdate(clientContext);
 
       // Then send the disconnect packet.
@@ -2260,18 +2344,22 @@ Maybe<WorldServerThreadPtr> UniverseServer::triggerWorldCreation(WorldId const& 
   }
 }
 
-Maybe<WorkerPoolPromise<WorldServerThreadPtr>> UniverseServer::makeWorldPromise(WorldId const& worldId) {
+Maybe<UniverseServer::WorldServerPromise> UniverseServer::makeWorldPromise(WorldId const& worldId) {
   if (auto celestialWorld = worldId.ptr<CelestialWorldId>())
     return celestialWorldPromise(*celestialWorld);
   else if (auto shipWorld = worldId.ptr<ClientShipWorldId>())
     return shipWorldPromise(*shipWorld);
   else if (auto instanceWorld = worldId.ptr<InstanceWorldId>())
     return instanceWorldPromise(*instanceWorld);
+  else if (auto customWorld = worldId.ptr<CustomWorldId>())
+    return customWorldPromise(*customWorld);
+  else if (auto clientCustomWorld = worldId.ptr<ClientCustomWorldId>())
+    return clientCustomWorldPromise(*clientCustomWorld);
   else
     return {};
 }
 
-Maybe<WorkerPoolPromise<WorldServerThreadPtr>> UniverseServer::shipWorldPromise(
+Maybe<UniverseServer::WorldServerPromise> UniverseServer::shipWorldPromise(
   ClientShipWorldId const& clientShipWorldId) {
   auto clientId = clientForUuid(clientShipWorldId);
   if (!clientId)
@@ -2282,7 +2370,7 @@ Maybe<WorkerPoolPromise<WorldServerThreadPtr>> UniverseServer::shipWorldPromise(
   auto celestialDatabase = m_celestialDatabase;
   auto universeClock = m_universeClock;
 
-  return m_workerPool.addProducer<WorldServerThreadPtr>([this, clientShipWorldId, clientContext, speciesShips, celestialDatabase, universeClock]() {
+  return WorldServerPromise(m_workerPool.addProducer<WorldServerThreadPtr>([this, clientShipWorldId, clientContext, speciesShips, celestialDatabase, universeClock]() {
     WorldServerPtr shipWorld;
 
     auto shipChunks = clientContext->shipChunks();
@@ -2349,10 +2437,10 @@ Maybe<WorkerPoolPromise<WorldServerThreadPtr>> UniverseServer::shipWorldPromise(
     shipWorldThread->setUpdateAction(bind(&UniverseServer::worldUpdated, this, _1));
 
     return shipWorldThread;
-  });
+  }));
 }
 
-Maybe<WorkerPoolPromise<WorldServerThreadPtr>> UniverseServer::celestialWorldPromise(CelestialWorldId const& celestialWorldId) {
+Maybe<UniverseServer::WorldServerPromise> UniverseServer::celestialWorldPromise(CelestialWorldId const& celestialWorldId) {
   if (!celestialWorldId)
     return {};
 
@@ -2360,7 +2448,7 @@ Maybe<WorkerPoolPromise<WorldServerThreadPtr>> UniverseServer::celestialWorldPro
   auto celestialDatabase = m_celestialDatabase;
   auto universeClock = m_universeClock;
 
-  return m_workerPool.addProducer<WorldServerThreadPtr>([this, celestialWorldId, storageDirectory, celestialDatabase, universeClock]() {
+  return WorldServerPromise(m_workerPool.addProducer<WorldServerThreadPtr>([this, celestialWorldId, storageDirectory, celestialDatabase, universeClock]() {
     WorldServerPtr worldServer;
     String storageFile = File::relativeTo(storageDirectory, strf("{}.world", celestialWorldId.filename()));
     if (File::isFile(storageFile)) {
@@ -2390,13 +2478,13 @@ Maybe<WorkerPoolPromise<WorldServerThreadPtr>> UniverseServer::celestialWorldPro
     worldThread->setUpdateAction(bind(&UniverseServer::worldUpdated, this, _1));
 
     return worldThread;
-  });
+  }));
 }
 
-Maybe<WorkerPoolPromise<WorldServerThreadPtr>> UniverseServer::instanceWorldPromise(InstanceWorldId const& instanceWorldId) {
+Maybe<UniverseServer::WorldServerPromise> UniverseServer::instanceWorldPromise(InstanceWorldId const& instanceWorldId) {
   auto storageDirectory = m_storageDirectory;
   auto universeClock = m_universeClock;
-  return m_workerPool.addProducer<WorldServerThreadPtr>([this, storageDirectory, instanceWorldId, universeClock]() {
+  return WorldServerPromise(m_workerPool.addProducer<WorldServerThreadPtr>([this, storageDirectory, instanceWorldId, universeClock]() {
     Json worldConfig = Root::singleton().assets()->json("/instance_worlds.config").get(instanceWorldId.instance);
     uint64_t worldSeed;
     if (worldConfig.contains("seed"))
@@ -2511,7 +2599,119 @@ Maybe<WorkerPoolPromise<WorldServerThreadPtr>> UniverseServer::instanceWorldProm
     worldThread->setUpdateAction(bind(&UniverseServer::worldUpdated, this, _1));
 
     return worldThread;
-  });
+  }));
+}
+
+Maybe<UniverseServer::WorldServerPromise> UniverseServer::customWorldPromise(CustomWorldId const& customWorldId, Maybe<WorldTemplatePtr> worldTemplate) {
+  auto storageDirectory = m_storageDirectory;
+  auto universeClock = m_universeClock;
+  return WorldServerPromise(m_workerPool.addProducer<WorldServerThreadPtr>([this, customWorldId, worldTemplate, storageDirectory, universeClock]() {
+    WorldServerPtr worldServer;
+
+    String storageFile = File::relativeTo(storageDirectory, strf("custom_{}.world", customWorldId));
+    if (File::isFile(storageFile)) {
+      Logger::info("UniverseServer: Loading custom world '{}'", customWorldId);
+      worldServer = make_shared<WorldServer>(File::open(storageFile, IOMode::ReadWrite));
+    } else if (worldTemplate) {
+      Logger::info("UniverseServer: Creating custom world '{}'", customWorldId);
+      worldServer = make_shared<WorldServer>(*worldTemplate, File::open(storageFile, IOMode::ReadWrite | IOMode::Truncate));
+    } else {
+      throw UniverseServerException(strf("UniverseServer: Custom world '{}' does not exist!\n",customWorldId));
+    }
+
+    worldServer->setUniverseSettings(m_universeSettings);
+    worldServer->setReferenceClock(universeClock);
+
+    worldServer->initLua(this);
+
+    auto worldThread = make_shared<WorldServerThread>(worldServer, customWorldId);
+    worldThread->setPause(m_pause);
+    worldThread->start();
+    worldThread->setUpdateAction(bind(&UniverseServer::worldUpdated, this, _1));
+
+    return worldThread;
+  }));
+}
+
+Maybe<UniverseServer::WorldServerPromise> UniverseServer::clientCustomWorldPromise(ClientCustomWorldId const& clientCustomWorldId, Maybe<WorldTemplatePtr> worldTemplate) {
+  auto configuration = Root::singleton().configuration();
+  if (configuration->get("disallowClientCustomWorlds").optBool().value(false))
+    return {};
+  
+  auto clientId = clientForUuid(clientCustomWorldId.uuid);
+  if (!clientId)
+    return {};
+  
+  
+  auto clientContext = m_clients.get(*clientId);
+  if (clientContext->netRules().version() < 15) {
+    Logger::warn("UniverseServer: Attempting to request custom world from old client!");
+    return {};
+  }
+  
+  auto producer = [this, clientCustomWorldId, worldTemplate, clientContext](WorldChunks worldChunks) -> WorkerPoolPromise<WorldServerThreadPtr> {
+    auto universeClock = m_universeClock;
+    return m_workerPool.addProducer<WorldServerThreadPtr>([this, clientCustomWorldId, worldTemplate, clientContext, universeClock, worldChunks]() {
+      WorldServerPtr worldServer;
+      
+      if (!worldChunks.empty()) {
+        Logger::info("UniverseServer: Loading client custom world '{}' for '{}'", clientCustomWorldId.name, clientCustomWorldId.uuid.hex());
+        worldServer = make_shared<WorldServer>(worldChunks);
+      } else if (worldTemplate) {
+        Logger::info("UniverseServer: Creating client custom world '{}' for '{}'", clientCustomWorldId.name, clientCustomWorldId.uuid.hex());
+        worldServer = make_shared<WorldServer>(*worldTemplate, File::ephemeralFile());
+      } else {
+        throw UniverseServerException(strf("UniverseServer: Client custom world '{}' for '{}' does not exist!\n",clientCustomWorldId.name, clientCustomWorldId.uuid.hex()));
+      }
+
+      auto worldClock = make_shared<Clock>();
+      auto worldTime = worldServer->getProperty("customWorld.epoch");
+      if (!worldTime.canConvert(Json::Type::Float)) {
+        auto now = Time::timeSinceEpoch();
+        worldServer->setProperty("customWorld.epoch", now);
+      } else {
+        worldClock->setTime(Time::timeSinceEpoch() - worldTime.toDouble());
+      }
+
+      worldServer->setUniverseSettings(m_universeSettings);
+      worldServer->setReferenceClock(worldClock);
+      worldClock->start();
+
+      worldServer->initLua(this);
+
+      auto worldThread = make_shared<WorldServerThread>(worldServer, clientCustomWorldId);
+      worldThread->setPause(m_pause);
+      clientContext->updateCustomWorldChunks(clientCustomWorldId.name, worldThread->readChunks());
+      clientContext->setCustomWorldActive(clientCustomWorldId.name, true);
+      worldThread->start();
+      worldThread->setUpdateAction(bind(&UniverseServer::worldUpdated, this, _1));
+
+      return worldThread;
+    });
+  };
+  if (auto worldChunks = clientContext->customWorldChunks(clientCustomWorldId.name)) {
+    return WorldServerPromise(producer(*worldChunks));
+  } else {
+    // request the world
+    Logger::info("UniverseServer: Requesting client custom world '{}' for '{}'", clientCustomWorldId.name, clientCustomWorldId.uuid.hex());
+    auto pair = RpcThreadPromise<WorldChunks>::createPair();
+    clientContext->customWorldRequested(clientCustomWorldId.name,pair.second);
+    m_connectionServer->sendPackets(*clientId, {make_shared<ClientCustomWorldRequest>(clientCustomWorldId.name)});
+    
+    return WorldServerPromise(
+      producer,
+      pair.first
+    );
+  }
+}
+
+void UniverseServer::createCustomWorld(CustomWorldId const& customWorld, WorldTemplatePtr worldTemplate) {
+  RecursiveMutexLocker locker(m_mainLock);
+  if (!m_worlds.contains(customWorld)) {
+    if (auto promise = customWorldPromise(customWorld,worldTemplate)) {
+      m_worlds.add(customWorld, promise.take());
+    }
+  }
 }
 
 SystemWorldServerThreadPtr UniverseServer::createSystemWorld(Vec3I const& location) {

--- a/source/game/StarUniverseServer.hpp
+++ b/source/game/StarUniverseServer.hpp
@@ -7,6 +7,7 @@
 #include "StarCelestialCoordinate.hpp"
 #include "StarServerClientContext.hpp"
 #include "StarWorldServerThread.hpp"
+#include "StarWorldTemplate.hpp"
 #include "StarSystemWorldServerThread.hpp"
 #include "StarUniverseConnection.hpp"
 #include "StarUniverseSettings.hpp"
@@ -108,6 +109,8 @@ public:
   bool setWeather(CelestialCoordinate const& coordinate, String const& weatherName, bool force = false);
 
   StringList weatherList(CelestialCoordinate const& coordinate);
+  
+  void createCustomWorld(CustomWorldId const& customWorld, WorldTemplatePtr worldTemplate);
 
   bool sendPacket(ConnectionId clientId, PacketPtr packet);
 
@@ -120,6 +123,21 @@ private:
     String reason;
     Maybe<HostAddress> ip;
     Maybe<Uuid> uuid;
+  };
+  
+  struct WorldServerPromise {
+    Variant<WorkerPoolPromise<WorldServerThreadPtr>,RpcThreadPromise<WorldChunks>> currentPromise;
+    Maybe<function<WorkerPoolPromise<WorldServerThreadPtr>(WorldChunks)>> producer;
+    
+    double startTime;
+    
+    WorldServerPromise(function<WorkerPoolPromise<WorldServerThreadPtr>(WorldChunks)> producer, RpcThreadPromise<WorldChunks> promise);
+    WorldServerPromise(WorkerPoolPromise<WorldServerThreadPtr> promise);
+    
+    bool done() const;
+    bool poll();
+    
+    WorldServerThreadPtr get();
   };
 
   enum class TcpState : uint8_t { No, Yes, Fuck };
@@ -197,10 +215,12 @@ private:
 
   // Main lock and clients read lock must be held when calling world promise
   // generators
-  Maybe<WorkerPoolPromise<WorldServerThreadPtr>> makeWorldPromise(WorldId const& worldId);
-  Maybe<WorkerPoolPromise<WorldServerThreadPtr>> shipWorldPromise(ClientShipWorldId const& uuid);
-  Maybe<WorkerPoolPromise<WorldServerThreadPtr>> celestialWorldPromise(CelestialWorldId const& coordinate);
-  Maybe<WorkerPoolPromise<WorldServerThreadPtr>> instanceWorldPromise(InstanceWorldId const& instanceWorld);
+  Maybe<WorldServerPromise> makeWorldPromise(WorldId const& worldId);
+  Maybe<WorldServerPromise> shipWorldPromise(ClientShipWorldId const& uuid);
+  Maybe<WorldServerPromise> celestialWorldPromise(CelestialWorldId const& coordinate);
+  Maybe<WorldServerPromise> instanceWorldPromise(InstanceWorldId const& instanceWorld);
+  Maybe<WorldServerPromise> customWorldPromise(CustomWorldId const& customWorld, Maybe<WorldTemplatePtr> worldTemplate = {});
+  Maybe<WorldServerPromise> clientCustomWorldPromise(ClientCustomWorldId const& clientCustomWorld, Maybe<WorldTemplatePtr> worldTemplate = {});
 
   // If the system world is not created, initialize it, otherwise return the
   // already initialized one
@@ -240,7 +260,7 @@ private:
 
   shared_ptr<atomic<bool>> m_pause;
   bool m_secureWarps;
-  Map<WorldId, Maybe<WorkerPoolPromise<WorldServerThreadPtr>>> m_worlds;
+  Map<WorldId, Maybe<WorldServerPromise>> m_worlds;
   Map<InstanceWorldId, pair<int64_t, int64_t>> m_tempWorldIndex;
   Map<Vec3I, SystemWorldServerThreadPtr> m_systemWorlds;
   UniverseConnectionServerPtr m_connectionServer;

--- a/source/game/StarWarping.cpp
+++ b/source/game/StarWarping.cpp
@@ -43,6 +43,35 @@ DataStream& operator<<(DataStream& ds, InstanceWorldId const& instanceWorldId) {
   return ds;
 }
 
+ClientCustomWorldId::ClientCustomWorldId() {}
+
+ClientCustomWorldId::ClientCustomWorldId(Uuid uuid, String name)
+  : uuid(std::move(uuid)), name(std::move(name)) {}
+
+bool ClientCustomWorldId::operator==(ClientCustomWorldId const& rhs) const {
+  return tie(uuid, name) == tie(rhs.uuid, rhs.name);
+}
+
+bool ClientCustomWorldId::operator<(ClientCustomWorldId const& rhs) const {
+  return tie(uuid, name) < tie(rhs.uuid, rhs.name);
+}
+
+size_t hash<ClientCustomWorldId>::operator()(ClientCustomWorldId const& id) const {
+  return hashOf(id.uuid, id.name);
+}
+
+DataStream& operator>>(DataStream& ds, ClientCustomWorldId& clientWorldId) {
+  ds >> clientWorldId.uuid;
+  ds >> clientWorldId.name;
+  return ds;
+}
+
+DataStream& operator<<(DataStream& ds, ClientCustomWorldId const& clientWorldId) {
+  ds << clientWorldId.uuid;
+  ds << clientWorldId.name;
+  return ds;
+}
+
 String printWorldId(WorldId const& worldId) {
   if (auto instanceWorldId = worldId.ptr<InstanceWorldId>()) {
     if (instanceWorldId->level && *instanceWorldId->level < 0.0f)
@@ -55,6 +84,10 @@ String printWorldId(WorldId const& worldId) {
     return strf("CelestialWorld:{}", *celestialWorldId);
   } else if (auto clientShipWorldId = worldId.ptr<ClientShipWorldId>()) {
     return strf("ClientShipWorld:{}", clientShipWorldId->hex());
+  } else if (auto customWorldId = worldId.ptr<CustomWorldId>()) {
+    return strf("CustomWorld:{}", *customWorldId);
+  } else if (auto clientCustomWorldId = worldId.ptr<ClientCustomWorldId>()) {
+    return strf("ClientCustomWorld:{}:{}", clientCustomWorldId->uuid.hex(), clientCustomWorldId->name);
   } else {
     return "Nowhere";
   }
@@ -95,6 +128,14 @@ WorldId parseWorldId(String const& printedId) {
     return CelestialWorldId(CelestialCoordinate(parts.at(1)));
   } else if (type.equalsIgnoreCase("ClientShipWorld")) {
     return ClientShipWorldId(Uuid(parts.at(1)));
+  } else if (type.equalsIgnoreCase("CustomWorld")) {
+    return CustomWorldId(parts.at(1));
+  } else if (type.equalsIgnoreCase("ClientCustomWorld")) {
+    auto rest = parts.at(1).split(":", 1);
+    if (rest.size() <= 1 || rest.size() > 2)
+      throw StarException::format("Wrong number of parts in ClientCustomWorldId");
+    
+    return ClientCustomWorldId(Uuid(rest.at(0)),rest.at(1));
   } else if (type.equalsIgnoreCase("Nowhere")) {
     return {};
   } else {
@@ -114,6 +155,16 @@ std::ostream& operator<<(std::ostream& os, ClientShipWorldId const& worldId) {
 }
 
 std::ostream& operator<<(std::ostream& os, InstanceWorldId const& worldId) {
+  os << printWorldId(worldId);
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, CustomWorldId const& worldId) {
+  os << (String)worldId;
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, ClientCustomWorldId const& worldId) {
   os << printWorldId(worldId);
   return os;
 }

--- a/source/game/StarWarping.hpp
+++ b/source/game/StarWarping.hpp
@@ -35,9 +35,29 @@ struct hash<InstanceWorldId> {
 DataStream& operator>>(DataStream& ds, InstanceWorldId& missionWorldId);
 DataStream& operator<<(DataStream& ds, InstanceWorldId const& missionWorldId);
 
+struct ClientCustomWorldId {
+  Uuid uuid;
+  String name;
+
+  ClientCustomWorldId();
+  ClientCustomWorldId(Uuid uuid, String name);
+
+  bool operator==(ClientCustomWorldId const& rhs) const;
+  bool operator<(ClientCustomWorldId const& rhs) const;
+};
+
+template <>
+struct hash<ClientCustomWorldId> {
+  size_t operator()(ClientCustomWorldId const& id) const;
+};
+
+DataStream& operator>>(DataStream& ds, ClientCustomWorldId& clientWorldId);
+DataStream& operator<<(DataStream& ds, ClientCustomWorldId const& clientWorldId);
+
 strong_typedef(CelestialCoordinate, CelestialWorldId);
 strong_typedef(Uuid, ClientShipWorldId);
-typedef MVariant<CelestialWorldId, ClientShipWorldId, InstanceWorldId> WorldId;
+strong_typedef(String, CustomWorldId);
+typedef MVariant<CelestialWorldId, ClientShipWorldId, InstanceWorldId, CustomWorldId, ClientCustomWorldId> WorldId;
 
 String printWorldId(WorldId const& worldId);
 WorldId parseWorldId(String const& printedId);
@@ -46,6 +66,8 @@ WorldId parseWorldId(String const& printedId);
 std::ostream& operator<<(std::ostream& os, CelestialWorldId const& worldId);
 std::ostream& operator<<(std::ostream& os, ClientShipWorldId const& worldId);
 std::ostream& operator<<(std::ostream& os, InstanceWorldId const& worldId);
+std::ostream& operator<<(std::ostream& os, CustomWorldId const& worldId);
+std::ostream& operator<<(std::ostream& os, ClientCustomWorldId const& worldId);
 std::ostream& operator<<(std::ostream& os, WorldId const& worldId);
 
 strong_typedef(String, SpawnTargetUniqueEntity);
@@ -94,5 +116,7 @@ DataStream& operator<<(DataStream& ds, WarpToWorld const& warpToWorld);
 template <> struct fmt::formatter<Star::CelestialWorldId> : ostream_formatter {};
 template <> struct fmt::formatter<Star::ClientShipWorldId> : ostream_formatter {};
 template <> struct fmt::formatter<Star::InstanceWorldId> : ostream_formatter {};
+template <> struct fmt::formatter<Star::CustomWorldId> : ostream_formatter {};
+template <> struct fmt::formatter<Star::ClientCustomWorldId> : ostream_formatter {};
 template <> struct fmt::formatter<Star::WorldId> : ostream_formatter {};
 template <> struct fmt::formatter<Star::WarpToWorld> : ostream_formatter {};

--- a/source/game/scripting/StarUniverseClientLuaBindings.cpp
+++ b/source/game/scripting/StarUniverseClientLuaBindings.cpp
@@ -1,0 +1,50 @@
+#include "StarUniverseClientLuaBindings.hpp"
+#include "StarJsonExtra.hpp"
+#include "StarLuaGameConverters.hpp"
+#include "StarUniverseClient.hpp"
+#include "StarWorldTemplate.hpp"
+
+namespace Star {
+
+LuaCallbacks LuaBindings::makeUniverseClientCallbacks(UniverseClientPtr universe) {
+  LuaCallbacks callbacks;
+  
+  callbacks.registerCallback("createClientCustomWorld", [universe](String name, Json templateData) {
+    universe->createCustomWorld(name, templateData);
+  });
+  
+  callbacks.registerCallback("createClientCustomWorldFromConfig", [universe](String name, Json worldConfig) {
+    uint64_t worldSeed;
+    if (worldConfig.contains("seed"))
+      worldSeed = worldConfig.getUInt("seed");
+    else
+      worldSeed = Random::randu64();
+
+    String worldType = worldConfig.getString("type");
+
+    VisitableWorldParametersPtr worldParameters;
+    if (worldType.equalsIgnoreCase("Terrestrial"))
+      worldParameters = generateTerrestrialWorldParameters(worldConfig.getString("planetType"), worldConfig.getString("planetSize"), worldSeed);
+    else if (worldType.equalsIgnoreCase("Asteroids"))
+      worldParameters = generateAsteroidsWorldParameters(worldSeed);
+    else if (worldType.equalsIgnoreCase("FloatingDungeon"))
+      worldParameters = generateFloatingDungeonWorldParameters(worldConfig.getString("dungeonWorld"));
+    else
+      throw StarException(strf("Unknown world type: '{}'\n", worldType));
+
+    if (worldConfig.contains("level"))
+      worldParameters->threatLevel = worldConfig.getFloat("level");
+
+    if (worldConfig.contains("beamUpRule"))
+      worldParameters->beamUpRule = BeamUpRuleNames.getLeft(worldConfig.getString("beamUpRule"));
+    worldParameters->disableDeathDrops = worldConfig.getBool("disableDeathDrops", false);
+
+    SkyParameters skyParameters = SkyParameters(worldConfig.get("skyParameters", Json()));
+    auto worldTemplate = WorldTemplate(worldParameters, skyParameters, worldSeed);
+    universe->createCustomWorld(name, worldTemplate.store());
+  });
+
+  return callbacks;
+}
+
+}

--- a/source/game/scripting/StarUniverseClientLuaBindings.hpp
+++ b/source/game/scripting/StarUniverseClientLuaBindings.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "StarLua.hpp"
+#include "StarGameTypes.hpp"
+#include "StarRpcThreadPromise.hpp"
+
+namespace Star {
+
+STAR_CLASS(UniverseClient);
+
+namespace LuaBindings {
+  LuaCallbacks makeUniverseClientCallbacks(UniverseClientPtr universe);
+
+  namespace UniverseClientCallbacks {
+  }
+}
+}

--- a/source/game/scripting/StarUniverseServerLuaBindings.cpp
+++ b/source/game/scripting/StarUniverseServerLuaBindings.cpp
@@ -29,6 +29,41 @@ LuaCallbacks LuaBindings::makeUniverseServerCallbacks(UniverseServer* universe) 
   callbacks.registerCallback("warpClient", [universe](ConnectionId clientId, String action, Maybe<bool> deploy) {
     universe->clientWarpPlayer(clientId, parseWarpAction(action), deploy.value(false));
   });
+  
+  callbacks.registerCallback("createCustomWorld", [universe](String name, Json templateData) {
+    universe->createCustomWorld(CustomWorldId(name), make_shared<WorldTemplate>(templateData));
+  });
+  callbacks.registerCallback("createCustomWorldFromConfig", [universe](String name, Json worldConfig) {
+    uint64_t worldSeed;
+    if (worldConfig.contains("seed"))
+      worldSeed = worldConfig.getUInt("seed");
+    else
+      worldSeed = Random::randu64();
+
+    String worldType = worldConfig.getString("type");
+
+    VisitableWorldParametersPtr worldParameters;
+    if (worldType.equalsIgnoreCase("Terrestrial"))
+      worldParameters = generateTerrestrialWorldParameters(worldConfig.getString("planetType"), worldConfig.getString("planetSize"), worldSeed);
+    else if (worldType.equalsIgnoreCase("Asteroids"))
+      worldParameters = generateAsteroidsWorldParameters(worldSeed);
+    else if (worldType.equalsIgnoreCase("FloatingDungeon"))
+      worldParameters = generateFloatingDungeonWorldParameters(worldConfig.getString("dungeonWorld"));
+    else
+      throw StarException(strf("Unknown world type: '{}'\n", worldType));
+
+    if (worldConfig.contains("level"))
+      worldParameters->threatLevel = worldConfig.getFloat("level");
+
+    if (worldConfig.contains("beamUpRule"))
+      worldParameters->beamUpRule = BeamUpRuleNames.getLeft(worldConfig.getString("beamUpRule"));
+    worldParameters->disableDeathDrops = worldConfig.getBool("disableDeathDrops", false);
+
+    SkyParameters skyParameters = SkyParameters(worldConfig.get("skyParameters", Json()));
+    auto worldTemplate = make_shared<WorldTemplate>(worldParameters, skyParameters, worldSeed);
+    Json worldProperties = worldConfig.get("worldProperties", JsonObject{});
+    universe->createCustomWorld(CustomWorldId(name), worldTemplate);
+  });
 
   return callbacks;
 }

--- a/source/test/StarTestUniverse.cpp
+++ b/source/test/StarTestUniverse.cpp
@@ -20,7 +20,7 @@ TestUniverse::TestUniverse(Vec2U clientWindowSize) {
   auto playerStorage = make_shared<PlayerStorage>(File::relativeTo(m_storagePath, "player"));
   auto statistics = make_shared<Statistics>(File::relativeTo(m_storagePath, "statistics"));
   m_server = make_shared<UniverseServer>(File::relativeTo(m_storagePath, "universe"));
-  m_client = make_shared<UniverseClient>(playerStorage, statistics);
+  m_client = make_shared<UniverseClient>(playerStorage, statistics, File::relativeTo(m_storagePath, "universeclient"));
 
   m_server->start();
 


### PR DESCRIPTION
Server custom worlds can be accessed by warping to `CustomWorld:<name>`.
They can be created on the serverside only through either:
- manually placing a world at `storage/universe/custom_<name>.world`
- creating a world from template with `universe.createCustomWorld("<name>",Json worldTemplate)`
- creating a world from config (similar to instance world configs) with `universe.createCustomWorldFromConfig("<name>",Json worldConfig)`

Client custom worlds can be accessed by warping to `ClientCustomWorld:<player uuid>:<name>`.
They can be created on the clientside only through either:
- manually placing a world at `storage/universeclient/<name>.world`
- creating a world from template with `universe.createClientCustomWorld("<name>",Json worldTemplate)`
- creating a world from config (similar to instance world configs) with `universe.createClientCustomWorldFromConfig("<name>",Json worldConfig)`

Client custom worlds can be disabled from loading entirely with the `disallowClientCustomWorlds` bool in the server config.

Currently, old clients cannot access custom worlds, getting kicked to menu on attempting to. Some measures are in place to prevent old clients and old servers from being broken by other players via this change otherwise.