### PR TITLE
Lua: add math.round and math.copysign

### DIFF
--- a/source/extern/lua/lmathlib.c
+++ b/source/extern/lua/lmathlib.c
@@ -298,6 +298,34 @@ static int math_type (lua_State *L) {
 
 /*
 ** {==================================================================
+** C99 functions
+** ===================================================================
+*/
+#if !defined(LUA_USE_C89)
+
+static int math_round (lua_State *L) {
+  if (lua_isinteger(L, 1))
+    lua_settop(L, 1);  /* integer is already round */
+  else {
+    lua_Number d = l_mathop(round)(luaL_checknumber(L, 1));
+    pushnumint(L, d);
+  }
+  return 1;
+}
+
+static int math_copysign (lua_State *L) {
+  lua_Number mag = luaL_checknumber(L, 1);
+  lua_Number sgn = luaL_optnumber(L, 2, 1);
+  lua_pushnumber(L, l_mathop(copysign)(mag, sgn));
+  return 1;
+}
+
+#endif
+/* }================================================================== */
+
+
+/*
+** {==================================================================
 ** Deprecated functions (for compatibility only)
 ** ===================================================================
 */
@@ -373,6 +401,10 @@ static const luaL_Reg mathlib[] = {
   {"sqrt",  math_sqrt},
   {"tan",   math_tan},
   {"type", math_type},
+#if !defined(LUA_USE_C89)
+  {"round", math_round},
+  {"copysign", math_copysign},
+#endif
 #if defined(LUA_COMPAT_MATHLIB)
   {"atan2", math_atan},
   {"cosh",   math_cosh},


### PR DESCRIPTION
Adds both `math.round` and `math.copysign` from C99 to Lua's core math library (Lua restricts itself to the limitations of C89 which OpenStarbound doesn't have to adhere to). Now numbers can be rounded easily/simply without "*hassle*"!
This PR was originally just going to be `math.round` (I think? it's been awhile since I thought about this) however after looking at https://github.com/OpenStarbound/OpenStarbound/blob/main/source/core/StarMathCommon.hpp I realized the addition of `math.copysign` would allow for the full set of Starbound's internal math function primitives to be represented via Lua, even if such a thing isn't really useful in practice I figured it's harmless so why not.

`math.copysign` is a bit lame since it's output is limited to the precision of floats/doubles however this is just how [`copysign`](https://en.cppreference.com/cpp/numeric/math/copysign) works in C/C++ for some reason. (I asked a friend after writing this and they said [`copysign`](https://en.cppreference.com/cpp/numeric/math/copysign) is seemingly just copied over from some IEEE standard which would explain why it's limited exclusively to floats and doubles but IMO it's still lame).

This PR does not include documentation for the newly added Lua functions.