### PR TITLE
Installer: NTFS compress PDB files

### DIFF
--- a/scripts/inno/setup.iss
+++ b/scripts/inno/setup.iss
@@ -36,7 +36,8 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 
 [Files]
 Source: "windows\win\{#AppExeName}"; DestDir: "{app}\win\"; Flags: ignoreversion
-Source: "windows\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "windows\*"; Excludes: "*.pdb"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "windows\*.pdb"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs setntfscompression
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Dirs]


### PR DESCRIPTION
applies NTFS compression (if supported) to the debugging symbols dropped by the installer.

this reduces the final disk install size by around 331 MB