### PR TITLE
zlib-ng

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -488,7 +488,8 @@ if (STAR_USE_MIMALLOC)
   set(STAR_EXT_LIBS ${STAR_EXT_LIBS} $<IF:$<TARGET_EXISTS:mimalloc-static>,mimalloc-static,mimalloc>)
 endif()
 
-find_package(ZLIB REQUIRED)
+find_package(zlib-ng CONFIG REQUIRED)
+add_compile_definitions(WITH_GZFILEOP) # Needed to make zlib-ng have gz
 find_package(PNG REQUIRED)
 find_package(Freetype REQUIRED)
 find_package(cpr CONFIG REQUIRED)
@@ -505,7 +506,7 @@ include_directories(SYSTEM
 )
 
 set(STAR_EXT_LIBS ${STAR_EXT_LIBS}
-    ZLIB::ZLIB
+    zlib-ng::zlib
     PNG::PNG
     cpr::cpr
     $<IF:$<TARGET_EXISTS:Freetype::Freetype>,Freetype::Freetype,freetype>

--- a/source/core/StarCompression.cpp
+++ b/source/core/StarCompression.cpp
@@ -2,7 +2,7 @@
 #include "StarFormat.hpp"
 #include "StarLexicalCast.hpp"
 
-#include <zlib.h>
+#include <zlib-ng.h>
 #include <errno.h>
 #include <string.h>
 
@@ -15,29 +15,29 @@ void compressData(ByteArray const& in, ByteArray& out, CompressionLevel compress
     return;
 
   const size_t BUFSIZE = 32 * 1024;
-  auto tempBuffer = std::make_unique<unsigned char[]>(BUFSIZE);
+  auto tempBuffer = std::make_unique<uint8_t[]>(BUFSIZE);
 
-  z_stream strm{};
+  zng_stream strm{};
   strm.zalloc = Z_NULL;
   strm.zfree = Z_NULL;
   strm.opaque = Z_NULL;
-  int deflate_res = deflateInit(&strm, compression);
+  int deflate_res = zng_deflateInit(&strm, compression);
   if (deflate_res != Z_OK)
     throw IOException(strf("Failed to initialise deflate ({})", deflate_res));
 
-  strm.next_in = (unsigned char*)in.ptr();
+  strm.next_in = (const uint8_t*)in.ptr();
   strm.avail_in = in.size();
   strm.next_out = tempBuffer.get();
   strm.avail_out = BUFSIZE;
   while (deflate_res == Z_OK) {
-    deflate_res = deflate(&strm, Z_FINISH);
+    deflate_res = zng_deflate(&strm, Z_FINISH);
     if (strm.avail_out == 0) {
       out.append((char const*)tempBuffer.get(), BUFSIZE);
       strm.next_out = tempBuffer.get();
       strm.avail_out = BUFSIZE;
     }
   }
-  deflateEnd(&strm);
+  zng_deflateEnd(&strm);
 
   if (deflate_res != Z_STREAM_END)
     throw IOException(strf("Internal error in uncompressData, deflate_res is {}", deflate_res));
@@ -58,29 +58,29 @@ void uncompressData(const char* in, size_t inLen, ByteArray& out, size_t limit) 
     return;
 
   const size_t BUFSIZE = 32 * 1024;
-  auto tempBuffer = std::make_unique<unsigned char[]>(BUFSIZE);
+  auto tempBuffer = std::make_unique<uint8_t[]>(BUFSIZE);
 
-  z_stream strm{};
+  zng_stream strm{};
   strm.zalloc = Z_NULL;
   strm.zfree = Z_NULL;
   strm.opaque = Z_NULL;
-  int inflate_res = inflateInit(&strm);
+  int inflate_res = zng_inflateInit(&strm);
   if (inflate_res != Z_OK)
     throw IOException(strf("Failed to initialise inflate ({})", inflate_res));
 
-  strm.next_in = (unsigned char*)in;
+  strm.next_in = (const uint8_t*)in;
   strm.avail_in = inLen;
   strm.next_out = tempBuffer.get();
   strm.avail_out = BUFSIZE;
 
   while (inflate_res == Z_OK || inflate_res == Z_BUF_ERROR) {
-    inflate_res = inflate(&strm, Z_FINISH);
+    inflate_res = zng_inflate(&strm, Z_FINISH);
     if (strm.avail_out == 0) {
       out.append((char const*)tempBuffer.get(), BUFSIZE);
       strm.next_out = tempBuffer.get();
       strm.avail_out = BUFSIZE;
       if (limit && out.size() >= limit) {
-        inflateEnd(&strm);
+        zng_inflateEnd(&strm);
         throw IOException(strf("hit uncompressData limit of {} bytes", limit));
         break;
       }
@@ -88,7 +88,7 @@ void uncompressData(const char* in, size_t inLen, ByteArray& out, size_t limit) 
       break;
     }
   }
-  inflateEnd(&strm);
+  zng_inflateEnd(&strm);
 
   if (inflate_res != Z_STREAM_END)
     throw IOException(strf("Internal error in uncompressData, inflate_res is {}", inflate_res));
@@ -117,29 +117,29 @@ void uncompressDataGzip(const char* in, size_t inLen, ByteArray& out, size_t lim
     return;
 
   const size_t BUFSIZE = 32 * 1024;
-  auto tempBuffer = std::make_unique<unsigned char[]>(BUFSIZE);
+  auto tempBuffer = std::make_unique<uint8_t[]>(BUFSIZE);
 
-  z_stream strm{};
+  zng_stream strm{};
   strm.zalloc = Z_NULL;
   strm.zfree = Z_NULL;
   strm.opaque = Z_NULL;
-  int inflate_res = inflateInit2(&strm, 31);
+  int inflate_res = zng_inflateInit2(&strm, 31);
   if (inflate_res != Z_OK)
     throw IOException(strf("Failed to initialise inflate ({})", inflate_res));
 
-  strm.next_in = (unsigned char*)in;
+  strm.next_in = (const uint8_t*)in;
   strm.avail_in = inLen;
   strm.next_out = tempBuffer.get();
   strm.avail_out = BUFSIZE;
 
   while (inflate_res == Z_OK || inflate_res == Z_BUF_ERROR) {
-    inflate_res = inflate(&strm, Z_FINISH);
+    inflate_res = zng_inflate(&strm, Z_FINISH);
     if (strm.avail_out == 0) {
       out.append((char const*)tempBuffer.get(), BUFSIZE);
       strm.next_out = tempBuffer.get();
       strm.avail_out = BUFSIZE;
       if (limit && out.size() >= limit) {
-        inflateEnd(&strm);
+        zng_inflateEnd(&strm);
         throw IOException(strf("hit uncompressDataGzip limit of {} bytes", limit));
         break;
       }
@@ -147,7 +147,7 @@ void uncompressDataGzip(const char* in, size_t inLen, ByteArray& out, size_t lim
       break;
     }
   }
-  inflateEnd(&strm);
+  zng_inflateEnd(&strm);
 
   if (inflate_res != Z_STREAM_END)
     throw IOException(strf("Internal error in uncompressDataGzip, inflate_res is {}", inflate_res));
@@ -188,7 +188,7 @@ CompressedFile::~CompressedFile() {
 }
 
 StreamOffset CompressedFile::pos() {
-  return gztell((gzFile)m_file);
+  return zng_gztell((gzFile)m_file);
 }
 
 void CompressedFile::seek(StreamOffset offset, IOSeek seekMode) {
@@ -196,9 +196,9 @@ void CompressedFile::seek(StreamOffset offset, IOSeek seekMode) {
 
   int retCode;
   if (seekMode == IOSeek::Relative) {
-    retCode = gzseek((gzFile)m_file, (z_off_t)offset, SEEK_CUR);
+    retCode = zng_gzseek((gzFile)m_file, (z_off_t)offset, SEEK_CUR);
   } else if (seekMode == IOSeek::Absolute) {
-    retCode = gzseek((gzFile)m_file, (z_off_t)offset, SEEK_SET);
+    retCode = zng_gzseek((gzFile)m_file, (z_off_t)offset, SEEK_SET);
   } else {
     throw IOException("Cannot seek with SeekEnd in compressed file");
   }
@@ -206,7 +206,7 @@ void CompressedFile::seek(StreamOffset offset, IOSeek seekMode) {
   StreamOffset endPos = pos();
 
   if (retCode < 0) {
-    throw IOException::format("Seek error: {}", gzerror((gzFile)m_file, 0));
+    throw IOException::format("Seek error: {}", zng_gzerror((gzFile)m_file, 0));
   } else if ((seekMode == IOSeek::Relative && begPos + offset != endPos)
       || (seekMode == IOSeek::Absolute && offset != endPos)) {
     throw EofException("Error, unexpected end of file found");
@@ -214,18 +214,18 @@ void CompressedFile::seek(StreamOffset offset, IOSeek seekMode) {
 }
 
 bool CompressedFile::atEnd() {
-  return gzeof((gzFile)m_file);
+  return zng_gzeof((gzFile)m_file);
 }
 
 size_t CompressedFile::read(char* data, size_t len) {
   if (len == 0)
     return 0;
 
-  int ret = gzread((gzFile)m_file, data, len);
+  int ret = zng_gzread((gzFile)m_file, data, len);
   if (ret == 0)
     throw EofException("Error, unexpected end of file found");
   else if (ret == -1)
-    throw IOException::format("Read error: {}", gzerror((gzFile)m_file, 0));
+    throw IOException::format("Read error: {}", zng_gzerror((gzFile)m_file, 0));
   else
     return (size_t)ret;
 }
@@ -234,9 +234,9 @@ size_t CompressedFile::write(const char* data, size_t len) {
   if (len == 0)
     return 0;
 
-  int ret = gzwrite((gzFile)m_file, data, len);
+  int ret = zng_gzwrite((gzFile)m_file, data, len);
   if (ret == 0)
-    throw IOException::format("Write error: {}", gzerror((gzFile)m_file, 0));
+    throw IOException::format("Write error: {}", zng_gzerror((gzFile)m_file, 0));
   else
     return (size_t)ret;
 }
@@ -260,7 +260,7 @@ void CompressedFile::open(IOMode mode, CompressionLevel compression) {
 }
 
 void CompressedFile::sync() {
-  gzflush((gzFile)m_file, Z_FULL_FLUSH);
+  zng_gzflush((gzFile)m_file, Z_FULL_FLUSH);
 }
 
 void CompressedFile::open(IOMode mode) {
@@ -279,7 +279,7 @@ void CompressedFile::open(IOMode mode) {
 
   modeString += toString(m_compression);
 
-  m_file = gzopen(m_filename.utf8Ptr(), modeString.utf8Ptr());
+  m_file = zng_gzopen(m_filename.utf8Ptr(), modeString.utf8Ptr());
 
   if (!m_file)
     throw IOException::format("Cannot open filename '{}'", m_filename);
@@ -287,7 +287,7 @@ void CompressedFile::open(IOMode mode) {
 
 void CompressedFile::close() {
   if (m_file)
-    gzclose((gzFile)m_file);
+    zng_gzclose((gzFile)m_file);
   m_file = 0;
   setMode(IOMode::Closed);
 }

--- a/source/vcpkg.json
+++ b/source/vcpkg.json
@@ -6,7 +6,7 @@
     { "name": "sdl3", "platform": "!linux" },
     { "name": "cpptrace", "platform": "!windows" },
     "libvorbis",
-    "zlib",
+    "zlib-ng",
     "freetype",
     "libpng",
     "opus",


### PR DESCRIPTION
So I finally found out how to get zlib-ng (native mode) working.

The main thing that was causing me issues porting to zlib-ng native before was the lack of gzfile functions. It turns out that adding `add_compile_definitions(WITH_GZFILEOP)` fixes that. Other than that, this just correctly ports over our zlib compression code to zlib-ng native.

For reference, I decided to look into native mode because it seems like it won't have any risks of things breaking. If anyone is interested, the differences: https://github.com/zlib-ng/zlib-ng/blob/develop/PORTING.md#zlib-ng-native-mode

Just to say, this isn't my idea. I just wasn't able to forget the one message on the Discord talking about it, so I have been trying to get this to work for a decent while since then.