### PR TITLE
Windows-Installer: make 64bit and NTFS compress PDB(s)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -140,7 +140,7 @@ jobs:
         run: |
           echo "Checking pre-installation..."
           
-          set "ISCC_PATH=%programfiles(x86)%\Inno Setup 6\ISCC.exe"
+          set "ISCC_PATH=%programfiles%\Inno Setup 7\ISCC.exe"
           
           if exist "%ISCC_PATH%" (
             echo ::warning::Inno Setup is already installed
@@ -149,7 +149,7 @@ jobs:
           
           echo "Downloading Inno Setup..."
   
-          set "_url_=https://jrsoftware.org/download.php/is.exe?site=1"
+          set "_url_=https://github.com/jrsoftware/issrc/releases/download/is-7_0_2/innosetup-7.0.2-x64.exe"
           set "_file_=innosetup.exe"
   
           curl -L -o "%tmp%\%_file_%" "%_url_%"
@@ -168,7 +168,7 @@ jobs:
       - name: Create Installer
         working-directory: ${{ github.workspace }}
         run: |
-          & "C:\Program Files (x86)\Inno Setup 6\iscc.exe" /Oinstaller scripts\inno\setup.iss
+          & "C:\Program Files\Inno Setup 7\iscc.exe" /Oinstaller scripts\inno\setup.iss
 
       - name: Upload Installer
         uses: actions/upload-artifact@v7.0.1

--- a/scripts/inno/setup.iss
+++ b/scripts/inno/setup.iss
@@ -36,7 +36,8 @@ Name: "desktopicon"; Description: "{cm:CreateDesktopIcon}"; GroupDescription: "{
 
 [Files]
 Source: "windows\win\{#AppExeName}"; DestDir: "{app}\win\"; Flags: ignoreversion
-Source: "windows\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "windows\*"; Excludes: "*.pdb"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "windows\*.pdb"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs setntfscompression
 ; NOTE: Don't use "Flags: ignoreversion" on any shared system files
 
 [Dirs]

--- a/scripts/inno/setup.iss
+++ b/scripts/inno/setup.iss
@@ -24,6 +24,7 @@ SetupIconFile=scripts\inno\openstarbound.ico
 Compression=lzma2/ultra64
 SolidCompression=yes
 ArchitecturesInstallIn64BitMode=x64
+SetupArchitecture=x64
 WizardStyle=modern
 WizardImageAlphaFormat=premultiplied
 WizardSmallImageFile=scripts\inno\small.bmp


### PR DESCRIPTION
applies NTFS compression (if supported) to the debugging symbols dropped by the Windows installer which reduces the final disk install size by around 331 MB.
AND
makes the Windows installer 64bit (also updates to Inno Setup 7 which is a prerequisite).