### PR TITLE
fix weather particles bug

### DIFF
--- a/source/game/StarWeather.cpp
+++ b/source/game/StarWeather.cpp
@@ -387,7 +387,7 @@ void ClientWeather::spawnWeatherParticles(RectF newClientRegion, float dt) {
   for (auto const& particleConfig : m_currentWeatherType->particles) {
     // Move client region to same wrap region as newClientRegion
     RectF visibleRegion(m_worldGeometry.nearestTo(newClientRegion.min(), m_lastParticleVisibleRegion.min()),
-        m_worldGeometry.nearestTo(newClientRegion.min(), m_lastParticleVisibleRegion.max()));
+        m_worldGeometry.nearestTo(newClientRegion.max(), m_lastParticleVisibleRegion.max()));
 
     Vec2F targetVelocity = particleConfig.particle.velocity + Vec2F(wind(), 0);
     float angleChange = Vec2F::angleBetween2(Vec2F(0, 1), targetVelocity);


### PR DESCRIPTION
So, the weather system used `min` at a place where it should have been `max`. This caused weather to spawn a drastically growing amount of particles on small world sizes when the zoom level is at 1. The dungeon used to find this issue is `thalassooutpost` from `StarForge`.

Here are some images showing before and after the fix:
Before:
<img width="1538" height="1268" alt="bug3" src="https://github.com/user-attachments/assets/0721e5d4-a8b7-4a01-8264-f6d1743d95b1" />

After:
<img width="1537" height="1039" alt="bug" src="https://github.com/user-attachments/assets/cb14cc5e-0601-4e92-8b0a-8c9c029c0979" />

As was visible in the second image, yes, this reveals a different bug as well. It seems like something related to sectors breaks as well under such conditions. I have tried fixing that as well but haven't found any solutions. This issue can result in situations where most of the map that should be loaded is not, as can be seen in the next image:
<img width="1488" height="1108" alt="bug4" src="https://github.com/user-attachments/assets/6ecf3e9a-db14-4140-985f-22151661b5e3" />
I hope that the steps described to reproduce are clear so others can take a look at what might be breaking the sector rendering, as I haven't found anything that looked wrong related to it.

