### PR TITLE
fix rendering issues on small worlds.

### DIFF
--- a/source/game/StarTileDrawer.cpp
+++ b/source/game/StarTileDrawer.cpp
@@ -176,7 +176,7 @@ MutexLocker TileDrawer::lockRenderData() {
 }
 
 RenderTile const& TileDrawer::getRenderTile(WorldRenderData const& renderData, Vec2I const& worldPos) {
-  Vec2I arrayPos = renderData.geometry.diff(worldPos, renderData.tileMinPosition);
+  Vec2I arrayPos = Vec2I(renderData.geometry.pdiff(worldPos[0], renderData.tileMinPosition[0]), worldPos[1] - renderData.tileMinPosition[1]);
 
   Vec2I size = Vec2I(renderData.tiles.size());
   if (arrayPos[0] >= 0 && arrayPos[1] >= 0 && arrayPos[0] < size[0] && arrayPos[1] < size[1])

--- a/source/game/StarTileDrawer.hpp
+++ b/source/game/StarTileDrawer.hpp
@@ -61,7 +61,8 @@ private:
 
 template <typename Function>
 void TileDrawer::forEachRenderTile(WorldRenderData const& renderData, RectI const& worldCoordRange, Function&& function) {
-  RectI indexRect = RectI::withSize(renderData.geometry.diff(worldCoordRange.min(), renderData.tileMinPosition), worldCoordRange.size());
+  Vec2I indexMin(renderData.geometry.pdiff(worldCoordRange.min()[0], renderData.tileMinPosition[0]), worldCoordRange.min()[1] - renderData.tileMinPosition[1]);
+  RectI indexRect = RectI::withSize(indexMin, worldCoordRange.size());
   indexRect.limit(RectI::withSize(Vec2I(0, 0), Vec2I(renderData.tiles.size())));
 
   if (!indexRect.isEmpty()) {

--- a/source/game/StarTileDrawer.hpp
+++ b/source/game/StarTileDrawer.hpp
@@ -61,8 +61,7 @@ private:
 
 template <typename Function>
 void TileDrawer::forEachRenderTile(WorldRenderData const& renderData, RectI const& worldCoordRange, Function&& function) {
-  Vec2I indexMin(renderData.geometry.pdiff(worldCoordRange.min()[0], renderData.tileMinPosition[0]), worldCoordRange.min()[1] - renderData.tileMinPosition[1]);
-  RectI indexRect = RectI::withSize(indexMin, worldCoordRange.size());
+  RectI indexRect = RectI::withSize(Vec2I(renderData.geometry.pdiff(worldCoordRange.min()[0], renderData.tileMinPosition[0]), worldCoordRange.min()[1] - renderData.tileMinPosition[1]), worldCoordRange.size());
   indexRect.limit(RectI::withSize(Vec2I(0, 0), Vec2I(renderData.tiles.size())));
 
   if (!indexRect.isEmpty()) {

--- a/source/game/StarWorldClient.cpp
+++ b/source/game/StarWorldClient.cpp
@@ -633,7 +633,7 @@ void WorldClient::render(WorldRenderData& renderData, unsigned bufferTiles) {
     });
 
   for (auto& pair : m_predictedTiles) {
-    Vec2I tileArrayPos = m_geometry.diff(pair.first, renderData.tileMinPosition);
+    Vec2I tileArrayPos(m_geometry.pdiff(pair.first[0], renderData.tileMinPosition[0]), pair.first[1] - renderData.tileMinPosition[1]);
     if (tileArrayPos[0] >= 0 && tileArrayPos[0] < (int)renderData.tiles.size(0) && tileArrayPos[1] >= 0 && tileArrayPos[1] < (int)renderData.tiles.size(1)) {
       RenderTile& renderTile = renderData.tiles(tileArrayPos[0], tileArrayPos[1]);
       PredictedTile& p = pair.second;
@@ -654,7 +654,7 @@ void WorldClient::render(WorldRenderData& renderData, unsigned bufferTiles) {
   }
 
   for (auto const& previewTile : m_previewTiles) {
-    Vec2I tileArrayPos = m_geometry.diff(previewTile.position, renderData.tileMinPosition);
+    Vec2I tileArrayPos(m_geometry.pdiff(previewTile.position[0], renderData.tileMinPosition[0]), previewTile.position[1] - renderData.tileMinPosition[1]);
     if (tileArrayPos[0] >= 0 && tileArrayPos[0] < (int)renderData.tiles.size(0) && tileArrayPos[1] >= 0 && tileArrayPos[1] < (int)renderData.tiles.size(1)) {
       RenderTile& renderTile = renderData.tiles(tileArrayPos[0], tileArrayPos[1]);
 
@@ -1476,7 +1476,7 @@ bool WorldClient::waitForLighting(WorldRenderData* renderData) {
   if (renderData && !m_lightMap.empty()) {
     for (auto& previewTile : m_previewTiles) {
       if (previewTile.updateLight) {
-        Vec2I lightArrayPos = m_geometry.diff(previewTile.position, m_lightMinPosition);
+        Vec2I lightArrayPos(m_geometry.pdiff(previewTile.position[0], m_lightMinPosition[0]), previewTile.position[1] - m_lightMinPosition[1]);
         if (lightArrayPos[0] >= 0 && lightArrayPos[0] < (int)m_lightMap.width()
          && lightArrayPos[1] >= 0 && lightArrayPos[1] < (int)m_lightMap.height())
           m_lightMap.set(lightArrayPos[0], lightArrayPos[1], Color::v3bToFloat(previewTile.light));

--- a/source/game/StarWorldClient.cpp
+++ b/source/game/StarWorldClient.cpp
@@ -1749,8 +1749,15 @@ void WorldClient::lightingCalc() {
 
   prepLocker.unlock();
 
+  Vec2I regionMin = m_lightingCalculator.calculationRegion().min();
+  auto resolvePosition = [&](Vec2F const& pos) -> Vec2F {
+    float xFloor = floor(pos[0]);
+    float xOffset = (float)m_geometry.pdiff((int)xFloor, regionMin[0]) + (pos[0] - xFloor);
+    return Vec2F(regionMin[0] + xOffset, pos[1]);
+  };
+
   for (auto const& light : lights) {
-    Vec2F position = m_geometry.nearestTo(Vec2F(m_lightingCalculator.calculationRegion().min()), light.position);
+    Vec2F position = resolvePosition(light.position);
     if (light.type == LightType::Spread)
       m_lightingCalculator.addSpreadLight(position, light.color);
     else {
@@ -1768,7 +1775,7 @@ void WorldClient::lightingCalc() {
   }
 
   for (auto const& lightPair : particleLights) {
-    Vec2F position = m_geometry.nearestTo(Vec2F(m_lightingCalculator.calculationRegion().min()), lightPair.first);
+    Vec2F position = resolvePosition(lightPair.first);
     m_lightingCalculator.addSpreadLight(position, lightPair.second);
   }
 


### PR DESCRIPTION
So, after a bit more looking through the code, I have found the issues causing the rendering bug mentioned in my last PR and fixed all cases of it. In most cases, it was just that `diff` was used where `pdiff` should have been used. The lighting calc was also changed to get its position now through `pdiff`, as it had the same issue, even though it didn't use `diff`.

Also, whilst I'm at it, could you take a look at #560? I have changed its log messages to be better. If there still is an issue with it, I would appreciate a comment.