### PR TITLE
Client subworlds

### DIFF
--- a/assets/opensb/client.config.patch
+++ b/assets/opensb/client.config.patch
@@ -11,5 +11,12 @@
     "letterbox" : false
   },
   "postProcessLayers": [],
-  "postProcessGroups": {}
+  "postProcessGroups": {},
+  
+  "worldScriptContexts":{},
+  "mainWorldScriptContexts":{},
+  "subWorldScriptContexts":{},
+  
+  "idleSubWorldExpireTime":10.0,
+  "subWorldUpdateMeasureWindow" : 0.5
 }

--- a/doc/lua/entityuserdata.md
+++ b/doc/lua/entityuserdata.md
@@ -1,0 +1,588 @@
+This is documentation on the Entity userdata object returned by world.entity(EntityId entity).
+
+This userdata only needs to be acquired once per entity; it updates with the entity.
+It even continues to function after the entity is destroyed, keeping the entity in memory for as long as this userdata is kept in memory.
+As such, it is recommended to destroy references to this in your scripts after they are no longer needed.
+Some functions may throw errors if used on dead entities.
+
+---
+
+#### `bool` entity:exists()
+
+Returns `true` if this entity exists in a world and `false` otherwise.
+
+---
+
+#### `EntityId` entity:id()
+
+Returns the entity's id.
+
+---
+
+#### `DamageTeam` entity:damageTeam()
+
+Returns the current damage team (team type and team number) of this entity.
+
+---
+
+#### `bool` entity:canDamage(`EntityId` targetId)
+
+Returns `true` if this entity can damage the specified target entity using their current damage teams and `false` otherwise.
+
+---
+
+#### `bool` entity:aggressive()
+
+Returns `true` if this entity is an aggressive monster or NPC and `false` otherwise.
+
+---
+
+#### `String` entity:type()
+
+Returns the entity type name of this entity.
+
+---
+
+#### `Vec2F` entity:aimPosition()
+
+Returns the aim position of this entity.
+
+---
+
+#### `Vec2F` entity:position()
+
+Returns the current world position of this entity.
+
+---
+
+#### `Vec2F` entity:mouthPosition()
+
+Returns the current world mouth position of the entity if it is a player, monster, NPC, or object, or `nil` if the entity doesn't exist or isn't a valid type.
+
+---
+
+#### `Vec2F` entity:velocity()
+
+Returns the current velocity of the entity if it is a vehicle, monster, NPC, player, or projectile and `nil` otherwise.
+
+---
+
+#### `Vec2F` entity:metaBoundBox()
+
+Returns the meta bound box of the entity, if any.
+
+---
+
+#### `unsigned` entity:currency(`String` currencyType)
+
+Returns the entity's stock of the specified currency type, or `nil` if the entity is not a player.
+
+---
+
+#### `unsigned` entity:hasCountOfItem(`Json` itemDescriptor, [`bool` exactMatch])
+
+Returns the nubmer of the specified item that the entity is currently carrying, or `nil` if the entity is not a player. If exactMatch is `true` then parameters as well as item name must match.
+
+NOTE: This function currently does not work correctly over the network, making it inaccurate when not used from client side scripts such as status.
+
+---
+
+#### `Vec2F` entity:health()
+
+Returns a `Vec2F` containing the entity's current and maximum health if the entity is a player, monster or NPC and `nil` otherwise.
+
+---
+
+#### `String` entity:species()
+
+Returns the name of the specified entity's species if it is a player or NPC and `nil` otherwise.
+
+---
+
+#### `String` entity:gender()
+
+Returns the name of the entity's gender if it is a player or NPC and `nil` otherwise.
+
+---
+
+#### `String` entity:name()
+
+Returns a `String` name of the entity which has different behavior for different entity types. For players, monsters and NPCs, this will be the configured name of the specific entity. For objects or vehicles, this will be the name of the object or vehicle type. For item drops, this will be the name of the contained item.
+
+---
+
+#### `Json` entity:nametag()
+
+Returns data on the nametag of the entity, if the entity has nametags.
+
+---
+
+#### `String` entity:typeName()
+
+Similar to entity:name but returns the names of configured types for NPCs and monsters.
+
+---
+
+#### `String` entity:description([`String` species])
+
+Returns the configured description for the entity if it has one. Will return a species-specific description if species is specified and a generic description otherwise.
+
+---
+
+#### `JsonArray` entity:portrait(`String` portraitMode)
+
+Generates a portrait of the entity in the specified portrait mode and returns a list of drawables, or `nil` if the entity is not a portrait entity.
+
+---
+
+#### `String` entity:handItem(`String` handName)
+
+Returns the name of the item held in the specified hand of the entity, or `nil` if the entity is not holding an item or is not a player or NPC. Hand name should be specified as "primary" or "alt".
+
+---
+
+#### `ItemDescriptor` entity:handItemDescriptor(`String` handName)
+
+Similar to entity:handItem but returns the full descriptor of the item rather than the name.
+
+---
+
+#### `String` entity:uniqueId(`EntityId` entityId)
+
+Returns the unique id of the entity, or `nil` if the entity does not have a unique id.
+
+---
+
+#### `Json` entity:statusProperty(`String` name, [`Json` default])
+
+Returns the value of the entity's status property, or defaultValue or `nil` if the parameter is not set.
+Returns `nil` if the entity is not an actor entity. Actor entities are players, npcs, and monsters.
+
+---
+
+#### `Maybe<float>` entity:stat(`String` name)
+
+Returns the value of the entity's stat or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:statPositive(`String` name)
+
+Returns whether the entity's stat is positive or not, or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<StringList>` entity:resourceNames()
+
+Returns the names of all the entity's resources or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<float>` entity:resource(`String` name)
+
+Returns the value of the entity's specified resource or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:isResource(`String` name)
+
+Returns whether this resource exists on the entity, or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:resourcePositive(`String` name)
+
+Returns whether the entity's specified resource is positive or not, or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:resourceLocked(`String` name)
+
+Returns whether the entity's specified resource is locked or not, or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<float>` entity:resourceMax(`String` name)
+
+Returns the maximum value of the entity's specified resource or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<float>` entity:resourcePercentage(`String` name)
+
+Returns the percentage of max of the entity's specified resource or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<JsonArray>` entity:getPersistentEffects(`String` name)
+
+Returns the entity's active persistent effects under the given category or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<List<JsonArray>>` entity:activeUniqueStatusEffectSummary()
+
+Returns the active unique status effects of the entity or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:uniqueStatusEffectActive(`String` name)
+
+Returns if the specified status effect is active on the entity or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<float>` entity:mass()
+
+Returns the entity's mass or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<RectF>` entity:boundBox()
+
+Returns the entity's collision poly bound box or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<PolyF>` entity:collisionPoly()
+
+Returns the entity's collision poly or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<PolyF>` entity:collisionBody()
+
+Returns the entity's collision body or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<RectF>` entity:collisionBoundBox()
+
+Returns the entity's collision poly bound box in world space coordinates or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<RectF>` entity:localBoundBox()
+
+Returns the entity's movement controller local bound box or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<float>` entity:rotation()
+
+Returns the entity's rotation or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:isColliding()
+
+Returns if the entity is colliding or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:isNullColliding()
+
+Returns if the entity is colliding with null collision or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:isCollisionStuck()
+
+Returns if the entity is sticking or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<float>` entity:stickingDirection()
+
+Returns the direction the entity is sticking at or `nil` if the entity is not an actor entity or isn't stuck.
+
+---
+
+#### `Maybe<float>` entity:liquidPercentage()
+
+Returns the entity's percentage of being submerged in liquid or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<LiquidId>` entity:liquidId()
+
+Returns the liquid the entity is submerged in or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:onGround()
+
+Returns if the entity is on the ground or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:zeroG()
+
+Returns if the entity is in zero-G movement or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:atWorldLimit()
+
+Returns if the entity is at the world limit or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<Json>` entity:baseMovementParameters()
+
+Returns the entity's base movement parameters or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<Json>` entity:movementParameters()
+
+Returns the entity's current movement parameters or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:walking()
+
+Returns if the entity is walking or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:running()
+
+Returns if the entity is running or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<int>` entity:facingDirection()
+
+Returns the entity's facing direction or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<int>` entity:movingDirection()
+
+Returns the entity's moving direction or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:crouching()
+
+Returns if the entity is crouching or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:flying()
+
+Returns if the entity is flying or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:falling()
+
+Returns if the entity is falling or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:canJump()
+
+Returns if the entity can jump or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:jumping()
+
+Returns if the entity is jumping or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:groundMovement()
+
+Returns if the entity is in ground movement or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Maybe<bool>` entity:liquidMovement()
+
+Returns if the entity is in liquid movement or `nil` if the entity is not an actor entity.
+
+---
+
+#### `Json` entity:getParameter(`String` parameterName, [`Json` defaultValue])
+
+Returns the value of the entity's parameter, or defaultValue or `nil` if the parameter is not set.
+Returns `nil` if the entity is not an entity parameters can be read from.
+Currently, parameters can only be read from npcs, objects, projectiles, and stagehands.
+---
+
+#### `List<Vec2I>` entity:objectSpaces()
+
+Returns a list of tile positions that the entity occupies, or `nil` if the entity is not an object.
+
+---
+
+#### `int` entity:farmableStage()
+
+Returns the current growth stage of the specified farmable object, or `nil` if the entity is not a farmable object.
+
+---
+
+#### `int` entity:containerSize()
+
+Returns the total capacity of the entity, or `nil` if the entity is not a container.
+
+---
+
+#### `bool` entity:containerClose()
+
+Visually closes the entity. Returns `true` if the entity is a container and `false` otherwise.
+
+---
+
+#### `bool` entity:containerOpen()
+
+Visually opens the entity. Returns `true` if the entity is a container and `false` otherwise.
+
+---
+
+#### `JsonArray` entity:containerItems()
+
+Returns a list of pairs of item descriptors and container positions of all items in the entity, or `nil` if the entity is not a container.
+
+---
+
+#### `ItemDescriptor` entity:containerItemAt(`unsigned` offset)
+
+Returns an item descriptor of the item at the specified position in the entity, or `nil` if the entity is not a container or the offset is out of range.
+
+---
+
+#### `bool` entity:containerConsume(`ItemDescriptor` item)
+
+Attempts to consume items from the entity that match the specified item descriptor and returns `true` if successful, `false` if unsuccessful, or `nil` if the entity is not a container. Only succeeds if the full count of the specified item can be consumed.
+
+---
+
+#### `bool` entity:containerConsumeAt(`unsigned` offset, `unsigned` count)
+
+Similar to world.containerConsume but only considers the specified slot within the entity.
+
+---
+
+#### `unsigned` entity:containerAvailable(`ItemDescriptor` item)
+
+Returns the number of the specified item that are currently available to consume in the entity, or `nil` if the entity is not a container.
+
+---
+
+#### `JsonArray` entity:containerTakeAll()
+
+Similar to world.containerItems but consumes all items in the entity.
+
+---
+
+#### `ItemDescriptor` entity:containerTakeAt(`unsigned` offset)
+
+Similar to world.containerItemAt, but consumes all items in the specified slot of the entity.
+
+---
+
+#### `ItemDescriptor` entity:containerTakeNumItemsAt(`unsigned` offset, `unsigned` count)
+
+Similar to world.containerTakeAt, but consumes up to (but not necessarily equal to) the specified count of items from the specified slot of the entity and returns only the items consumed.
+
+---
+
+#### `unsigned` entity:containerItemsCanFit(`ItemDescriptor` item)
+
+Returns the number of times the specified item can fit in the entity, or `nil` if the entity is not a container.
+
+---
+
+#### `Json` entity:containerItemsFitWhere(`ItemDescriptor` items)
+
+Returns a JsonObject containing a list of "slots" the specified item would fit and the count of "leftover" items that would remain after attempting to add the items. Returns `nil` if the entity is not a container.
+
+---
+
+#### `ItemDescriptor` entity:containerAddItems(`ItemDescriptor` items)
+
+Adds the specified items to the entity. Returns the leftover items after filling the entity, or all items if the entity is not a container.
+
+---
+
+#### `ItemDescriptor` entity:containerStackItems(`ItemDescriptor` items)
+
+Similar to world.containerAddItems but will only combine items with existing stacks and will not fill empty slots.
+
+---
+
+#### `ItemDescriptor` entity:containerPutItemsAt(`ItemDescriptor` items, `unsigned` offset)
+
+Similar to world.containerAddItems but only considers the specified slot in the entity.
+
+---
+
+#### `ItemDescriptor` entity:containerItemApply(`ItemDescriptor` items, `unsigned` offset)
+
+Attempts to combine the specified items with the current contents (if any) of the container slot and returns any items unable to be placed into the slot.
+
+---
+
+#### `ItemDescriptor` entity:containerSwapItemsNoCombine(`ItemDescriptor` items, `unsigned` offset)
+
+Places the specified items into the entity slot and returns the previous contents of the slot if successful, or the original items if unsuccessful.
+
+---
+
+#### `ItemDescriptor` entity:containerSwapItems(`ItemDescriptor` items, `unsigned` offset)
+
+A combination of world.containerItemApply and world.containerSwapItemsNoCombine that attempts to combine items before swapping and returns the leftovers if stacking was successful or the previous contents of the container slot if the items did not stack.
+
+---
+
+#### `LuaValue` entity:callScript(`String` functionName, [`LuaValue` args ...])
+
+Attempts to call the specified function name in the context of the entity with the specified arguments and returns the result. This method is synchronous and thus can only be used on local master entities, i.e. scripts run on the server may only call scripted entities that are also server-side master and scripts run on the client may only call scripted entities that are client-side master on that client. For more featureful entity messaging, use entity:sendMessage.
+
+---
+
+#### `RpcPromise<Json>` entity:sendMessage(`String` messageType, [`LuaValue` args ...])
+
+Sends an asynchronous message to the entity with the specified message type and arguments and returns an `RpcPromise` which can be used to receive the result of the message when available. See the message table for information on entity message handling. This function __should not be called in any entity's init function__ as the sending entity will not have been fully loaded.
+
+---
+
+#### `List<EntityId>` entity:loungingEntities()
+
+Returns every entity lounging on the entity.
+
+---
+
+#### `bool` entity:loungeableOccupied()
+
+Checks whether the specified loungeable entity is currently occupied and returns `true` if it is occupied, `false` if it is unoccupied, or `nil` if it is not a loungeable entity.
+
+---
+
+#### `int` entity:loungeableAnchorCount()
+
+Returns the amount of anchors on the entity or `nil` if it is not a loungeable entity.
+
+---
+
+#### `bool` entity:isInteractive()
+
+Returns `true` if the entity is player interactive and `false` otherwise.
+
+---
+
+#### `int` entity:movingCollisionCount()
+
+Returns the amount of moving collisions in the entity.
+
+---
+
+#### `PhysicsMovingCollision` entity:movingCollision(`int` index)
+
+Returns the entity's moving collision at the given index, or `nil` if it is disabled or does not exist.
+
+---

--- a/doc/lua/openstarbound/hooks.md
+++ b/doc/lua/openstarbound/hooks.md
@@ -1,0 +1,110 @@
+# Hooks
+
+OpenStarbound adds several new script contexts as well as Lua hooks for these contexts.
+
+---
+
+## Player
+
+Some additional callbacks are added to generic player script contexts.
+
+---
+
+#### `void` postUpdate()
+
+Invoked on update, after everything else on the player updates.
+
+---
+
+#### `void` refreshHumanoidParameters()
+
+Invoked on humanoid parameters being refreshed.
+
+---
+
+## UniverseServer
+
+UniverseServer script contexts can be created by adding them to `universe_server.config` under `scriptContexts`, functionally similar to generic player scripts.
+
+---
+
+#### `void` acceptConnection(`ConnectionId` clientId)
+
+Invoked when a client connects to the server.
+
+---
+
+#### `void` doDisconnection(`ConnectionId` clientId)
+
+Invoked when a client disconnects from the server.
+
+---
+
+#### `Json` overrideWarp(`Json` warpAction, `ConnectionId` clientId, `bool` deploy)
+
+Invoked when a client warps anywhere.
+If a value is returned, the warp is overridden:
+    `worldId` specifies which world the client is overridden to warp to. If unspecified, defaults to the client's current world.
+    `spawnTarget` specifies a spawn target.
+
+---
+
+## UniverseClient
+
+UniverseClient script contexts can be created by adding them to `client.config` under `universeScriptContexts`, functionally similar to generic player scripts.
+
+---
+
+#### `void` clientCustomWorldLoaded(`String` name, `String` worldId)
+
+Invoked when one of this client's custom worlds is loaded, if the server is new enough to notify this client.
+
+---
+
+#### `void` shipWorldLoaded(`String` worldId)
+
+Invoked when this client's ship world is loaded, if the server is new enough to notify this client.
+
+---
+
+#### `void` serverWorldLoaded(`String` worldId)
+
+Invoked when any world is loaded on the server, if the server is configured to notify this client.
+
+---
+
+#### `void` subWorldRejected(`ClientSubWorldId` subWorldId)
+
+Invoked when a requested subworld is rejected.
+
+---
+
+## WorldServer
+
+WorldServer script contexts can be created by adding them to `worldserver.config` under `scriptContexts`, functionally similar to generic player scripts.
+
+---
+
+#### `void` addClient(`ConnectionId` clientId, `bool` isLocal)
+
+Invoked when a client or subworld enters the world.
+Subworlds have the `ConnectionId` of their client + 16383.
+
+---
+
+#### `void` removeClient(`ConnectionId` clientId)
+
+Invoked when a client or subworld leaves the world.
+
+---
+
+## WorldClient
+
+WorldClient script contexts can be created by adding them to `client.config` under `worldScriptContexts`, `mainWorldScriptContexts`, and `subWorldScriptContexts`.
+They are functionally similar to generic player scripts.
+
+---
+
+#### `void` preUninit()
+
+Invoked when the world is unloading, prior to entities being removed.

--- a/doc/lua/openstarbound/universe.md
+++ b/doc/lua/openstarbound/universe.md
@@ -119,6 +119,18 @@ seconds) performs a temporary ban when provided.
 
 ---
 
+#### `void` universe.warpClient(`ConnectionId` clientId, `String` action, [`bool` deploy])
+
+Warps a client to a given world.
+
+---
+
+#### `unsigned` universe.clientOpenProtocolVersion(`ConnectionId` clientId)
+
+Returns the OpenProtocolVersion used for networking with the client.
+
+---
+
 #### `void` universe.createCustomWorld(`String` name, `Json` template)
 
 Creates a new custom world with the given name from the given template.
@@ -148,3 +160,74 @@ Its world ID will be `ClientCustomWorld:<client uuid>:<name>`, and it will be st
 
 Creates a new custom world with the given name from the given config. This config functions similarly to instance world configs.
 Otherwise, functionally similar to `universe.createClientCustomWorld`.
+
+---
+
+#### `unsigned` universe.clientUuid()
+
+Returns the client uuid. This is the uuid of the player the client joined with, which is the uuid present in client custom world IDs and the client's shipworld ID.
+
+---
+
+#### `unsigned` universe.serverOpenProtocolVersion()
+
+Returns the OpenProtocolVersion used for networking with the server.
+
+---
+
+#### `Vec2U` universe.playerCount()
+
+Returns the server's current player count and maximum players.
+
+---
+
+#### `bool` universe.subWorldActive(`String` worldId)
+
+Returns if a subworld is currently active or requested on the given world.
+
+---
+
+#### `void` universe.loadSubWorld(`String` worldId)
+
+Loads the given world as a subworld if it is not loaded.
+Subworlds are client worlds that are considered headless. 
+They do not render, they do not have a main player, and they do not have a screen.
+World script contexts are required to do anything with them.
+`clientPresenceMaster` entities are required to load anything in them.
+They automatically unload after a few seconds of no activity. (No entities, no incoming messages.)
+
+They function independently of the client main world, persisting even if the player warps elsewhere. 
+Subworld master entities are considered different master to client main world entities.
+
+---
+
+#### `void` universe.unloadSubWorld(`String` worldId)
+
+If a subworld is active on the given world, unloads it.
+
+---
+
+#### `RpcThreadPromise<Json>` universe.sendSubWorldMessage(`String` worldId, `String` messageName, [`Json` args ...])
+
+Loads the given world as a subworld if it is not loaded.
+If it is loaded, sends a message to the subworld on the given world.
+
+---
+
+#### `RpcPromise<Json>` universe.sendMainWorldMessage(`String` messageName, [`Json` args ...])
+
+Sends a message to the client's main world. The message is handled immediately, so the RpcPromise will immediately be finished once returned.
+
+---
+
+#### `LuaValue` universe.callScriptContext(`String` contextName, `String` function, [`LuaValue` args ...])
+
+Calls a function on the given universe client script context.
+
+---
+
+#### `LuaValue` universe.callMainWorldScriptContext(`String` contextName, `String` function, [`LuaValue` args ...])
+
+Calls a function on the given script context on the client's main world.
+
+

--- a/doc/lua/openstarbound/universe.md
+++ b/doc/lua/openstarbound/universe.md
@@ -1,7 +1,10 @@
 # Universe
 
-Server-side scripts gain access to a new `universe` table that exposes administrative helpers for connected clients and worlds.
-All of these functions are only available in contexts that already run on the server (such as world scripts or the command
+Server-side and client-side scripts gain access to a `universe` table that exposes helpers for worlds, as well as administrative helpers for connected clients on server-side scripts.
+
+--- 
+
+The following callbacks are only available in contexts that run on the server (such as world scripts or the command
 processor).
 
 ---
@@ -113,3 +116,35 @@ Disconnects the client, optionally providing a disconnect reason.
 
 Bans a client by connection ID. The `banIp` and `banUuid` parameters control which identifiers are recorded; `timeout` (in
 seconds) performs a temporary ban when provided.
+
+---
+
+#### `void` universe.createCustomWorld(`String` name, `Json` template)
+
+Creates a new custom world with the given name from the given template.
+Its world ID will be `CustomWorld:<name>`, and it will be stored under the server's `universe/custom_<name>.world`
+
+---
+
+#### `void` universe.createCustomWorldFromConfig(`String` name, `Json` config)
+
+Creates a new custom world with the given name from the given config. This config functions similarly to instance world configs.
+Otherwise, functionally similar to `universe.createCustomWorld`.
+
+---
+
+The following functions are available on all scripts on the client main thread.
+
+---
+
+#### `void` universe.createClientCustomWorld(`String` name, `Json` template)
+
+Creates a new client custom world with the given name from the given template.
+Its world ID will be `ClientCustomWorld:<client uuid>:<name>`, and it will be stored under the client's `universeclient/<name>.world`
+
+---
+
+#### `void` universe.createClientCustomWorldFromConfig(`String` name, `Json` config)
+
+Creates a new custom world with the given name from the given config. This config functions similarly to instance world configs.
+Otherwise, functionally similar to `universe.createClientCustomWorld`.

--- a/doc/lua/openstarbound/world.md
+++ b/doc/lua/openstarbound/world.md
@@ -22,13 +22,44 @@ Attempts a wire connection between the two objects positioned at `outputPosition
 
 ---
 
+#### `Maybe<LuaValue>` world.callScriptContext(`String` contextName, `String` functionName, [`LuaValue` args ...])
+
+Calls a function in the specified world script context.
+
+---
+
+#### `List<EntityId>` world.entities([`Json` options])
+
+Queries the entire world for entities. Takes the same options as entity queries, but should be more efficient especially on very large worlds.
+For server worlds, this returns every entity on the world with the given criteria, or every entity if none are provided.
+For client worlds, this returns every entity that is loaded and known to the client.
+
+---
+
+#### `Entity` world.entity(`EntityId` id)
+
+Returns the entity with the given id as a userdata. 
+This has some additional methods that can be used to acquire data from the entity that cannot be obtained otherwise.
+
+Clean this up properly when the entity no longer exists or is no longer being used.
+Besides the client main player, Entity instances are not reused.
+Holding an Entity instance in Lua will keep the entity present in memory even after its destruction.
+
+---
+
 The following additional world bindings are available only for scripts running on the client.
+
+---
+
+#### List<EntityId> world.players()
+
+A client version of the server binding. Returns every player loaded on the client world.
 
 ---
 
 #### `entityId` world.mainPlayer()
 
-Returns the entity ID of the player hosting the world.
+Returns the entity ID of the client world's main player. Returns `nil` if this is a subworld.
 
 ---
 
@@ -40,7 +71,26 @@ Returns the current cursor aim position of the specified entity.
 
 #### `bool` world.inWorld()
 
-Returns whether any players are in the world.
+Returns if the client world is actually in a world.
+
+---
+
+#### `bool` world.headless()
+
+Returns true if the client world is a subworld.
+
+---
+
+#### `ClientSubWorldId` world.subWorldId()
+
+Returns the current world's subworld id. If the world is not a subworld, this is 0.
+This is the same number visible in the `/debug` log map.
+
+---
+
+#### `void` world.unload()
+
+If this is a subworld, requests to unload it.
 
 ---
 
@@ -63,12 +113,6 @@ Returns the amount of time an ephemeral world persists when it is inactive.
 #### `String` world.id()
 
 Returns a `String` representation of the world's id.
-
----
-
-#### `Maybe<LuaValue>` world.callScriptContext(`String` contextName, `String` functionName, [`LuaValue` args ...])
-
-Calls a function in the specified world script context.
 
 ---
 

--- a/source/core/StarDataStream.cpp
+++ b/source/core/StarDataStream.cpp
@@ -6,7 +6,7 @@
 
 namespace Star {
 
-unsigned const CurrentStreamVersion = 15; // update OpenProtocolVersion too!
+unsigned const CurrentStreamVersion = 16; // update OpenProtocolVersion too!
 
 DataStream::DataStream()
   : m_byteOrder(ByteOrder::BigEndian),

--- a/source/core/StarNetCompatibility.cpp
+++ b/source/core/StarNetCompatibility.cpp
@@ -2,6 +2,6 @@
 
 namespace Star {
 
-VersionNumber const OpenProtocolVersion = 15; // update StreamCompatibilityVersion too!
+VersionNumber const OpenProtocolVersion = 16; // update StreamCompatibilityVersion too!
 
 }

--- a/source/game/CMakeLists.txt
+++ b/source/game/CMakeLists.txt
@@ -165,6 +165,8 @@ SET (star_game_HEADERS
     StarWiring.hpp
     StarWorldCamera.hpp
     StarWorldClient.hpp
+    StarWorldThreadedClient.hpp
+    StarWorldClientThread.hpp
     StarWorldClientState.hpp
     StarWorldGeneration.hpp
     StarWorldImpl.hpp
@@ -432,6 +434,8 @@ SET (star_game_SOURCES
     StarWiring.cpp
     StarWorldCamera.cpp
     StarWorldClient.cpp
+    StarWorldThreadedClient.cpp
+    StarWorldClientThread.cpp
     StarWorldClientState.cpp
     StarWorldGeneration.cpp
     StarWorldLayout.cpp

--- a/source/game/CMakeLists.txt
+++ b/source/game/CMakeLists.txt
@@ -165,7 +165,6 @@ SET (star_game_HEADERS
     StarWiring.hpp
     StarWorldCamera.hpp
     StarWorldClient.hpp
-    StarWorldThreadedClient.hpp
     StarWorldClientThread.hpp
     StarWorldClientState.hpp
     StarWorldGeneration.hpp
@@ -434,7 +433,6 @@ SET (star_game_SOURCES
     StarWiring.cpp
     StarWorldCamera.cpp
     StarWorldClient.cpp
-    StarWorldThreadedClient.cpp
     StarWorldClientThread.cpp
     StarWorldClientState.cpp
     StarWorldGeneration.cpp

--- a/source/game/StarGameTypes.cpp
+++ b/source/game/StarGameTypes.cpp
@@ -60,7 +60,7 @@ EnumMap<Rarity> const RarityNames{
 std::pair<EntityId, EntityId> connectionEntitySpace(ConnectionId connectionId) {
   if (connectionId == ServerConnectionId) {
     return {MinServerEntityId, MaxServerEntityId};
-  } else if (connectionId >= MinClientConnectionId && connectionId <= MaxClientConnectionId) {
+  } else if (connectionId >= MinClientConnectionId && connectionId <= MaxClientSubWorldConnectionId) {
     EntityId beginIdSpace = (EntityId)connectionId * -65536;
     EntityId endIdSpace = beginIdSpace + 65535;
     return {beginIdSpace, endIdSpace};

--- a/source/game/StarGameTypes.hpp
+++ b/source/game/StarGameTypes.hpp
@@ -116,7 +116,26 @@ typedef uint16_t ConnectionId;
 ConnectionId const ServerConnectionId = 0;
 // Minimum and maximum valid client ids
 ConnectionId const MinClientConnectionId = 1;
-ConnectionId const MaxClientConnectionId = 32767;
+ConnectionId const MaxClientConnectionId = 16383;
+ConnectionId const MinClientSubWorldConnectionId = MaxClientConnectionId+1;
+ConnectionId const MaxClientSubWorldConnectionId = MaxClientConnectionId-MinClientConnectionId+MinClientSubWorldConnectionId;
+
+inline ConnectionId mainToSubWorldConnectionId(ConnectionId const& id) {
+  return id-MinClientConnectionId+MinClientSubWorldConnectionId;
+}
+inline ConnectionId maybeMainToSubWorldConnectionId(ConnectionId const& id) {
+  return id >= MinClientSubWorldConnectionId ? id-MinClientConnectionId+MinClientSubWorldConnectionId : id;
+}
+inline ConnectionId subWorldToMainConnectionId(ConnectionId const& id) {
+  return id-MinClientSubWorldConnectionId+MinClientConnectionId;
+}
+
+// for client sub-world threads. indexes by *world* rather than by thread.
+// this should allow the client to possibly split the subworlds to multiple threads in the future.
+typedef uint16_t ClientSubWorldId;
+ConnectionId const MainClientWorldId = 0;
+ConnectionId const MinClientSubWorldId = 1;
+ConnectionId const MaxClientSubWorldId = highest<ClientSubWorldId>();
 
 template <typename Vec2T>
 inline Vec2F centerOfTile(Vec2T const& tile) {

--- a/source/game/StarNetPackets.cpp
+++ b/source/game/StarNetPackets.cpp
@@ -1508,8 +1508,8 @@ ClientSubWorldPackets::ClientSubWorldPackets(ClientSubWorldId const& subWorldId,
 void ClientSubWorldPackets::read(DataStream& ds) {
   ds.read(subWorldId);
   // note: this approach may have an issue with packet size
-  size_t count = ds.read<size_t>();
-  for (size_t i = 0; i < count; i++) {
+  uint32_t count = ds.read<uint32_t>();
+  for (uint32_t i = 0; i < count; i++) {
     auto packetType = ds.read<PacketType>();
     PacketPtr packet = createPacket(packetType);
     packet->read(ds);
@@ -1519,7 +1519,7 @@ void ClientSubWorldPackets::read(DataStream& ds) {
 
 void ClientSubWorldPackets::write(DataStream& ds) const {
   ds.write(subWorldId);
-  ds.write(packets.count());
+  ds.write<uint32_t>(packets.count());
   for (PacketPtr const& packet : packets) {
     auto packetType = packet->type();
     ds.write(packetType);

--- a/source/game/StarNetPackets.cpp
+++ b/source/game/StarNetPackets.cpp
@@ -81,7 +81,11 @@ EnumMap<PacketType> const PacketTypeNames{
   {PacketType::UpdateWorldTemplate, "UpdateWorldTemplate"},
   {PacketType::ClientCustomWorldRequest, "ClientCustomWorldRequest"},
   {PacketType::ClientCustomWorldResponse, "ClientCustomWorldResponse"},
-  {PacketType::ClientCustomWorldCreate, "ClientCustomWorldCreate"}
+  {PacketType::ClientCustomWorldCreate, "ClientCustomWorldCreate"},
+  {PacketType::ClientSubWorldPackets, "ClientSubWorldPackets"},
+  {PacketType::ClientSubWorldRequest, "ClientSubWorldRequest"},
+  {PacketType::ClientSubWorldReject, "ClientSubWorldReject"},
+  {PacketType::NotifyWorldLoad, "NotifyWorldLoad"}
 };
 
 EnumMap<NetCompressionMode> const NetCompressionModeNames {
@@ -178,6 +182,10 @@ PacketPtr createPacket(PacketType type) {
     case PacketType::ClientCustomWorldRequest: return make_shared<ClientCustomWorldRequest>();
     case PacketType::ClientCustomWorldResponse: return make_shared<ClientCustomWorldResponse>();
     case PacketType::ClientCustomWorldCreate: return make_shared<ClientCustomWorldCreate>();
+    case PacketType::ClientSubWorldPackets: return make_shared<ClientSubWorldPackets>();
+    case PacketType::ClientSubWorldRequest: return make_shared<ClientSubWorldRequest>();
+    case PacketType::ClientSubWorldReject: return make_shared<ClientSubWorldReject>();
+    case PacketType::NotifyWorldLoad: return make_shared<NotifyWorldLoad>();
     default:
       throw StarPacketException(strf("Unrecognized packet type {}", (unsigned int)type));
   }
@@ -1491,6 +1499,70 @@ void ClientCustomWorldCreate::read(DataStream& ds) {
 void ClientCustomWorldCreate::write(DataStream& ds) const {
   ds.write(name);
   ds.write(templateData);
+}
+
+ClientSubWorldPackets::ClientSubWorldPackets() {}
+
+ClientSubWorldPackets::ClientSubWorldPackets(ClientSubWorldId const& subWorldId, List<PacketPtr> packets) : subWorldId(subWorldId), packets(std::move(packets)) {}
+
+void ClientSubWorldPackets::read(DataStream& ds) {
+  ds.read(subWorldId);
+  // note: this approach may have an issue with packet size
+  size_t count = ds.read<size_t>();
+  for (size_t i = 0; i < count; i++) {
+    auto packetType = ds.read<PacketType>();
+    PacketPtr packet = createPacket(packetType);
+    packet->read(ds);
+    packets.append(packet);
+  }
+}
+
+void ClientSubWorldPackets::write(DataStream& ds) const {
+  ds.write(subWorldId);
+  ds.write(packets.count());
+  for (PacketPtr const& packet : packets) {
+    auto packetType = packet->type();
+    ds.write(packetType);
+    packet->write(ds);
+  }
+}
+
+ClientSubWorldRequest::ClientSubWorldRequest() {}
+
+ClientSubWorldRequest::ClientSubWorldRequest(ClientSubWorldId const& subWorldId, WorldId worldId) : subWorldId(subWorldId), worldId(std::move(worldId)) {}
+
+void ClientSubWorldRequest::read(DataStream& ds) {
+  ds.read(subWorldId);
+  ds.read(worldId);
+}
+
+void ClientSubWorldRequest::write(DataStream& ds) const {
+  ds.write(subWorldId);
+  ds.write(worldId);
+}
+
+ClientSubWorldReject::ClientSubWorldReject() {}
+
+ClientSubWorldReject::ClientSubWorldReject(ClientSubWorldId const& subWorldId) : subWorldId(subWorldId) {}
+
+void ClientSubWorldReject::read(DataStream& ds) {
+  ds.read(subWorldId);
+}
+
+void ClientSubWorldReject::write(DataStream& ds) const {
+  ds.write(subWorldId);
+}
+
+NotifyWorldLoad::NotifyWorldLoad() {}
+
+NotifyWorldLoad::NotifyWorldLoad(WorldId worldId) : worldId(std::move(worldId)) {}
+
+void NotifyWorldLoad::read(DataStream& ds) {
+  ds.read(worldId);
+}
+
+void NotifyWorldLoad::write(DataStream& ds) const {
+  ds.write(worldId);
 }
 
 }

--- a/source/game/StarNetPackets.hpp
+++ b/source/game/StarNetPackets.hpp
@@ -118,9 +118,15 @@ enum class PacketType : uint8_t {
   // OpenStarbound packets
   ReplaceTileList,
   UpdateWorldTemplate,
+  
   ClientCustomWorldRequest,
   ClientCustomWorldResponse,
-  ClientCustomWorldCreate
+  ClientCustomWorldCreate,
+  
+  ClientSubWorldPackets,
+  ClientSubWorldRequest,
+  ClientSubWorldReject,
+  NotifyWorldLoad
 };
 extern EnumMap<PacketType> const PacketTypeNames;
 
@@ -1015,5 +1021,48 @@ struct ClientCustomWorldCreate : PacketBase<PacketType::ClientCustomWorldCreate>
 
   String name;
   Json templateData;
+};
+
+// wrapper packet for client world threads
+struct ClientSubWorldPackets : PacketBase<PacketType::ClientSubWorldPackets> {
+  ClientSubWorldPackets();
+  ClientSubWorldPackets(ClientSubWorldId const& subWorldId, List<PacketPtr> packets);
+
+  void read(DataStream& ds) override;
+  void write(DataStream& ds) const override;
+
+  ClientSubWorldId subWorldId;
+  List<PacketPtr> packets;
+};
+
+struct ClientSubWorldRequest : PacketBase<PacketType::ClientSubWorldRequest> {
+  ClientSubWorldRequest();
+  ClientSubWorldRequest(ClientSubWorldId const& subWorldId, WorldId worldId);
+
+  void read(DataStream& ds) override;
+  void write(DataStream& ds) const override;
+
+  ClientSubWorldId subWorldId;
+  WorldId worldId;
+};
+
+struct ClientSubWorldReject : PacketBase<PacketType::ClientSubWorldReject> {
+  ClientSubWorldReject();
+  ClientSubWorldReject(ClientSubWorldId const& subWorldId);
+
+  void read(DataStream& ds) override;
+  void write(DataStream& ds) const override;
+
+  ClientSubWorldId subWorldId;
+};
+
+struct NotifyWorldLoad : PacketBase<PacketType::NotifyWorldLoad> {
+  NotifyWorldLoad();
+  NotifyWorldLoad(WorldId worldId);
+
+  void read(DataStream& ds) override;
+  void write(DataStream& ds) const override;
+
+  WorldId worldId;
 };
 }

--- a/source/game/StarServerClientContext.cpp
+++ b/source/game/StarServerClientContext.cpp
@@ -267,6 +267,37 @@ void ServerClientContext::clearPlayerWorld() {
   setPlayerWorld({});
 }
 
+void ServerClientContext::setSubWorld(ClientSubWorldId subWorldId, WorldServerThreadPtr worldThread) {
+  RecursiveMutexLocker locker(m_mutex);
+  if (m_subWorldThreads[subWorldId] == worldThread)
+    return;
+
+  m_subWorldThreads[subWorldId] = std::move(worldThread);
+}
+
+WorldServerThreadPtr ServerClientContext::subWorld(ClientSubWorldId subWorldId) const {
+  RecursiveMutexLocker locker(m_mutex);
+  if (m_subWorldThreads.contains(subWorldId)) {
+    return m_subWorldThreads.get(subWorldId);
+  } else {
+    return {};
+  }
+}
+
+bool ServerClientContext::hasSubWorld(ClientSubWorldId subWorldId) const {
+  RecursiveMutexLocker locker(m_mutex);
+  return m_subWorldThreads.contains(subWorldId);
+}
+
+void ServerClientContext::clearSubWorld(ClientSubWorldId subWorldId) {
+  m_subWorldThreads.remove(subWorldId);
+}
+
+List<ClientSubWorldId> ServerClientContext::subWorlds() const {
+  RecursiveMutexLocker locker(m_mutex);
+  return m_subWorldThreads.keys();
+}
+
 WarpToWorld ServerClientContext::playerReturnWarp() const {
   RecursiveMutexLocker locker(m_mutex);
   return m_returnWarp;

--- a/source/game/StarServerClientContext.hpp
+++ b/source/game/StarServerClientContext.hpp
@@ -71,6 +71,12 @@ public:
   WorldId playerWorldId() const;
   void clearPlayerWorld();
 
+  void setSubWorld(ClientSubWorldId subWorldId, WorldServerThreadPtr worldThread);
+  WorldServerThreadPtr subWorld(ClientSubWorldId subWorldId) const;
+  bool hasSubWorld(ClientSubWorldId subWorldId) const;
+  void clearSubWorld(ClientSubWorldId subWorldId);
+  List<ClientSubWorldId> subWorlds() const;
+
   void setSystemWorld(SystemWorldServerThreadPtr systemWorldThread);
   SystemWorldServerThreadPtr systemWorld() const;
   void clearSystemWorld();
@@ -129,6 +135,8 @@ private:
   WorldServerThreadPtr m_worldThread;
   WarpToWorld m_returnWarp;
   WarpToWorld m_reviveWarp;
+  
+  HashMap<ClientSubWorldId, WorldServerThreadPtr> m_subWorldThreads;
 
   SystemWorldServerThreadPtr m_systemWorldThread;
 

--- a/source/game/StarUniverseClient.cpp
+++ b/source/game/StarUniverseClient.cpp
@@ -31,8 +31,9 @@ UniverseClient::UniverseClient(PlayerStoragePtr playerStorage, StatisticsPtr sta
   m_playerStorage = std::move(playerStorage);
   m_statistics = std::move(statistics);
   m_customWorldStorageDirectory = customWorldStorageDir;
-  m_pause = false;
+  m_pause = make_shared<atomic<bool>>(false);
   m_luaRoot = make_shared<LuaRoot>();
+  m_subWorldThreads = IdMap<ClientSubWorldId,WorldClientThreadPtr>(MinClientSubWorldId,MaxClientSubWorldId);
   reset();
 }
 
@@ -210,6 +211,10 @@ Maybe<String> UniverseClient::disconnectReason() const {
   return m_disconnectReason;
 }
 
+unsigned UniverseClient::connectionVersion() {
+  return m_connection->packetSocket().netRules().version();
+}
+
 WorldClientPtr UniverseClient::worldClient() const {
   return m_worldClient;
 }
@@ -290,14 +295,17 @@ void UniverseClient::update(float dt) {
 
   m_statistics->update();
 
-  if (!m_pause) {
+  if (!*m_pause) {
     m_worldClient->update(dt);
     for (auto& p : m_scriptContexts)
       p.second->update();
   }
   m_connection->push(m_worldClient->getOutgoingPackets());
+  for (auto& p : m_subWorldThreads) {
+    m_connection->push(p.second->pullOutgoingPackets());
+  }
 
-  if (!m_pause)
+  if (!*m_pause)
     m_systemWorldClient->update(dt);
   m_connection->push(m_systemWorldClient->pullOutgoingPackets());
 
@@ -337,6 +345,20 @@ void UniverseClient::update(float dt) {
     }
 
     m_storageTriggerDeadline = Time::monotonicMilliseconds() + assets->json("/client.config:storageTriggerInterval").toUInt();
+    
+    // clean up inactive/errored subworlds as well
+    for (auto const& subWorldId : m_subWorldThreads.keys()) {
+      auto thread = m_subWorldThreads.get(subWorldId);
+      if (thread->errorOccurred() || thread->shouldExpire()) {
+        Logger::info("UniverseClient: Cleaning up subworld {}.",subWorldId);
+        thread->stop();
+        m_subWorldThreads.remove(subWorldId);
+        if (m_subWorlds.hasLeftValue(subWorldId)) {
+          m_subWorlds.removeLeft(subWorldId);
+          m_connection->pushSingle(make_shared<ClientSubWorldRequest>(subWorldId, WorldId()));
+        }
+      }
+    }
   }
 
   if (!m_worldClient->mainPlayerDead() || m_mainPlayer->modeConfig().permadeath) {
@@ -712,20 +734,119 @@ StatisticsPtr UniverseClient::statistics() const {
   return m_statistics;
 }
 
+UniverseClient::ScriptComponentPtr UniverseClient::scriptContext(String const& contextName) {
+  if (auto context = m_scriptContexts.ptr(contextName))
+    return *context;
+  else
+    return nullptr;
+}
+
 void UniverseClient::createCustomWorld(String const& name, Json templateData) {
   RecursiveMutexLocker locker(m_mutex);
+  if (!File::isDirectory(m_customWorldStorageDirectory)) {
+    Logger::info("UniverseClient: Creating universe client storage directory");
+    File::makeDirectory(m_customWorldStorageDirectory);
+  }
   String filename = File::relativeTo(m_customWorldStorageDirectory, strf("{}.world", name));
   if (!File::exists(filename)) {
     m_connection->pushSingle(make_shared<ClientCustomWorldCreate>(name, templateData));
   }
 }
 
+ClientSubWorldId UniverseClient::createSubWorld() {
+  auto swid = m_subWorldThreads.nextId();
+  auto thread = make_shared<WorldClientThread>(swid);
+  thread->setPause(m_pause);
+  thread->start();
+  m_subWorldThreads.add(swid,thread);
+  return swid;
+}
+
+void UniverseClient::setSubWorldWorld(ClientSubWorldId subWorldId, WorldId worldId) {
+  // asks to change worlds. the server's response will update the thread (in WorldStop and WorldStart packets)
+  if (m_connection->packetSocket().netRules().version() < 16) {
+    // server too old, don't.
+    Logger::error("UniverseClient: Not setting subworld world, server is too old.");
+    return;
+  }
+  if (worldId) {
+    if (m_subWorlds.hasRightValue(worldId)) {
+      Logger::error("UniverseClient: Not setting subworld world, one is already on world {}.",worldId);
+      return;
+    }
+    Logger::info("UniverseClient: Requesting subworld {} on world {}", subWorldId, worldId);
+    m_subWorlds.add(subWorldId,worldId);
+  } else if (m_subWorlds.hasLeftValue(subWorldId)) {
+    // clear the world
+    Logger::info("UniverseClient: Requesting destroy of subworld {}", subWorldId, worldId);
+    m_subWorlds.removeLeft(subWorldId);
+  }
+  m_connection->pushSingle(make_shared<ClientSubWorldRequest>(subWorldId,worldId));
+}
+
+bool UniverseClient::subWorldExistsOnWorld(WorldId worldId) const {
+  return m_subWorlds.hasRightValue(worldId);
+}
+
+ClientSubWorldId UniverseClient::getSubWorldOnWorld(WorldId worldId) {
+  // will always return a subworld id for a world. creates one if one is not present.
+  if (m_subWorlds.hasRightValue(worldId)) {
+    return m_subWorlds.getLeft(worldId); // a subworld already exists here, return that
+  }
+  ClientSubWorldId swid = 0;
+  for (auto const& p : m_subWorldThreads) {
+    if (p.second->errorOccurred()) {
+      continue;
+    }
+    if (!m_subWorlds.hasLeftValue(p.first)) {
+      swid = p.first; // reuse an existing subworld
+      break;
+    }
+  }
+  if (swid == 0) {
+    swid = createSubWorld(); // create a new one
+  }
+  if (worldId) {
+    setSubWorldWorld(swid, worldId);
+  }
+  return swid;
+}
+
+void UniverseClient::destroySubWorldOnWorld(WorldId worldId) {
+  if (!m_subWorlds.hasRightValue(worldId)) {
+    return;
+  }
+  setSubWorldWorld(m_subWorlds.getLeft(worldId), WorldId());
+}
+
+RpcThreadPromise<Json> UniverseClient::sendSubWorldOnWorldMessage(WorldId const& worldId, String const& message, JsonArray const& args) {
+  if (m_connection->packetSocket().netRules().version() < 16) {
+    return RpcThreadPromise<Json>::createFailed("Server too old");
+  }
+  auto subWorldId = getSubWorldOnWorld(worldId);
+  auto pair = RpcThreadPromise<Json>::createPair();
+  m_subWorldThreads.get(subWorldId)->passMessage({message, args, pair.second});
+  return pair.first;
+}
+
+// though it resolves instantly, still use a promise for consistency
+RpcPromise<Json> UniverseClient::sendMainWorldMessage(String const& message, JsonArray const& args) {
+  if (!isConnected()) {
+    return RpcPromise<Json>::createFailed("Not connected");
+  }
+  if (auto resp = m_worldClient->receiveMessage(ServerConnectionId, message, args)) {
+    return RpcPromise<Json>::createFulfilled(*resp);
+  } else {
+    return RpcPromise<Json>::createFailed("Message not handled by world");
+  }
+}
+
 bool UniverseClient::paused() const {
-  return m_pause;
+  return *m_pause;
 }
 
 void UniverseClient::setPause(bool pause) {
-  m_pause = pause;
+  *m_pause = pause;
 
   if (pause)
     m_universeClock->stop();
@@ -833,6 +954,40 @@ void UniverseClient::handlePackets(List<PacketPtr> const& packets) {
           Logger::error("Custom world file {} does not exist", filename);
           m_connection->pushSingle(make_shared<ClientCustomWorldResponse>(clientCustomWorldRequest->name, WorldChunks()));
         }
+      } else if (auto worldLoadNotification = as<NotifyWorldLoad>(packet)) {
+        if (auto customWorldId = worldLoadNotification->worldId.ptr<ClientCustomWorldId>()) {
+          if (customWorldId->uuid == m_clientContext->playerUuid()) {
+            for (auto& p : m_scriptContexts) {
+              p.second->invoke("clientCustomWorldLoaded",customWorldId->name,printWorldId(worldLoadNotification->worldId));
+            }
+          }
+        } else if (auto shipWorldId = worldLoadNotification->worldId.ptr<ClientShipWorldId>()) {
+          if (*shipWorldId == m_clientContext->playerUuid()) {
+            for (auto& p : m_scriptContexts) {
+              p.second->invoke("shipWorldLoaded",printWorldId(worldLoadNotification->worldId));
+            }
+          }
+        }
+        for (auto& p : m_scriptContexts) {
+          p.second->invoke("serverWorldLoaded",printWorldId(worldLoadNotification->worldId));
+        }
+      } else if (auto cwtReject = as<ClientSubWorldReject>(packet)) {
+        Logger::warn("UniverseClient: Subworld {} rejected by server", cwtReject->subWorldId);
+        if (m_subWorlds.hasLeftValue(cwtReject->subWorldId)) {
+          m_subWorlds.removeLeft(cwtReject->subWorldId);
+          // thread will time out on its own if left unused.
+        }
+        for (auto& p : m_scriptContexts) {
+          p.second->invoke("subWorldRejected",cwtReject->subWorldId);
+        }
+      } else if (auto cwtPacket = as<ClientSubWorldPackets>(packet)) {
+        // packets for a world thread
+        if (m_subWorldThreads.contains(cwtPacket->subWorldId)) {
+          auto worldThread = m_subWorldThreads.get(cwtPacket->subWorldId);
+          worldThread->pushIncomingPackets(cwtPacket->packets);
+        } else {
+          Logger::warn("UniverseClient: Received packets for non-existent subworld {}", cwtPacket->subWorldId);
+        }
       } else if (!m_systemWorldClient->handleIncomingPacket(packet)) {
         // see if the system world will handle it, otherwise pass it along to the world client
         m_worldClient->handleIncomingPackets({packet});
@@ -847,7 +1002,12 @@ void UniverseClient::handlePackets(List<PacketPtr> const& packets) {
 
 void UniverseClient::reset() {
   stopLua();
+  for (auto const& p : m_subWorldThreads) {
+    p.second->stop();
+  }
 
+  m_subWorlds.clear();
+  m_subWorldThreads.clear();
   m_universeClock.reset();
   m_worldClient.reset();
   m_celestialDatabase.reset();

--- a/source/game/StarUniverseClient.cpp
+++ b/source/game/StarUniverseClient.cpp
@@ -301,8 +301,10 @@ void UniverseClient::update(float dt) {
       p.second->update();
   }
   m_connection->push(m_worldClient->getOutgoingPackets());
-  for (auto& p : m_subWorldThreads) {
-    m_connection->push(p.second->pullOutgoingPackets());
+  if (m_connection->packetSocket().netRules().version() >= 16) {
+    for (auto& p : m_subWorldThreads) {
+      m_connection->push(p.second->pullOutgoingPackets());
+    }
   }
 
   if (!*m_pause)

--- a/source/game/StarUniverseClient.hpp
+++ b/source/game/StarUniverseClient.hpp
@@ -9,6 +9,7 @@
 #include "StarAiTypes.hpp"
 #include "StarSky.hpp"
 #include "StarUniverseConnection.hpp"
+#include "StarWorldClientThread.hpp"
 #include "StarLuaComponents.hpp"
 
 namespace Star {
@@ -34,6 +35,9 @@ STAR_CLASS(LuaRoot);
 
 class UniverseClient {
 public:
+  typedef LuaUpdatableComponent<LuaBaseComponent> ScriptComponent;
+  typedef shared_ptr<ScriptComponent> ScriptComponentPtr;
+  
   UniverseClient(PlayerStoragePtr playerStorage, StatisticsPtr statistics, String const& customWorldStorageDir);
   ~UniverseClient();
 
@@ -45,6 +49,8 @@ public:
   bool isConnected() const;
   void disconnect();
   Maybe<String> disconnectReason() const;
+  
+  unsigned connectionVersion();
 
   // WorldClient may be null if the UniverseClient is not connected.
   WorldClientPtr worldClient() const;
@@ -110,8 +116,19 @@ public:
   QuestManagerPtr questManager() const;
   PlayerStoragePtr playerStorage() const;
   StatisticsPtr statistics() const;
+
+  ScriptComponentPtr scriptContext(String const& contextName);
   
   void createCustomWorld(String const& name, Json templateData);
+  
+  ClientSubWorldId createSubWorld();
+  void setSubWorldWorld(ClientSubWorldId subWorldId, WorldId worldId = WorldId());
+  bool subWorldExistsOnWorld(WorldId worldId) const;
+  ClientSubWorldId getSubWorldOnWorld(WorldId worldId);
+  void destroySubWorldOnWorld(WorldId worldId);
+
+  RpcThreadPromise<Json> sendSubWorldOnWorldMessage(WorldId const& worldId, String const& message, JsonArray const& args = {});
+  RpcPromise<Json> sendMainWorldMessage(String const& message, JsonArray const& args = {});
 
   bool paused() const;
 
@@ -134,7 +151,7 @@ private:
   
   String m_customWorldStorageDirectory;
 
-  bool m_pause;
+  shared_ptr<atomic<bool>> m_pause;
   ClockPtr m_universeClock;
   WorldClientPtr m_worldClient;
   SystemWorldClientPtr m_systemWorldClient;
@@ -163,10 +180,11 @@ private:
   Maybe<String> m_disconnectReason;
 
   LuaRootPtr m_luaRoot;
-
-  typedef LuaUpdatableComponent<LuaBaseComponent> ScriptComponent;
-  typedef shared_ptr<ScriptComponent> ScriptComponentPtr;
+  
   StringMap<ScriptComponentPtr> m_scriptContexts;
+  
+  BiMap<ClientSubWorldId, WorldId> m_subWorlds;
+  IdMap<ClientSubWorldId,WorldClientThreadPtr> m_subWorldThreads;
 
   ReloadPlayerCallback m_playerReloadPreCallback;
   ReloadPlayerCallback m_playerReloadCallback;

--- a/source/game/StarUniverseServer.cpp
+++ b/source/game/StarUniverseServer.cpp
@@ -224,6 +224,14 @@ String UniverseServer::clientDescriptor(ConnectionId clientId) const {
     return "disconnected_client";
 }
 
+unsigned UniverseServer::clientConnectionVersion(ConnectionId clientId) const {
+  ReadLocker clientsLocker(m_clientsLock);
+  if (auto clientContext = m_clients.value(clientId))
+    return clientContext->netRules().version();
+  else
+    return 0;
+}
+
 String UniverseServer::clientNick(ConnectionId clientId) const {
   return m_chatProcessor->connectionNick(clientId);
 }
@@ -1015,9 +1023,46 @@ void UniverseServer::warpPlayers() {
         m_pendingPlayerWarps.remove(clientId);
       }
     } else {
-      // If the world is not created yet, just set a new warp again to wait for
-      // it to create.
-      m_pendingPlayerWarps[clientId] = {warpAction, deploy};
+      // If the world is not created yet, just wait for it to create.
+      //m_pendingPlayerWarps[clientId] = {warpAction, deploy}; // Bott: ...there's no point to setting it again like this since it's already set. Nothing above removes it by this point.
+    }
+  }
+  
+  for (auto const& clientId : m_pendingSubWorlds.keys()) {
+    auto& pendingSubWorlds = m_pendingSubWorlds.get(clientId);
+    auto clientContext = m_clients.value(clientId);
+    if (!clientContext)
+      continue;
+
+    for (auto const& swid : pendingSubWorlds.keys()) {
+      auto& worldId = pendingSubWorlds.get(swid);
+      if (auto maybeToWorld = triggerWorldCreation(worldId)) {
+        Logger::info("UniverseServer: Sending player {} subworld {} to {}", clientId, swid, printWorldId(worldId));
+        if (auto toWorld = maybeToWorld.value()) {
+          locker.unlock();
+
+          bool clientAdded = toWorld && toWorld->addClient(mainToSubWorldConnectionId(clientId), SpawnTarget(), !clientContext->remoteAddress(), clientContext->canBecomeAdmin(), clientContext->netRules(), swid);
+
+          locker.lock();
+          if (clientAdded) {
+            clientContext->setSubWorld(swid,toWorld);
+            //m_chatProcessor->joinChannel(clientId, printWorldId(warpToWorld.world));
+            
+          } else {
+            Logger::info("UniverseServer: Player {} subworld {} failed", clientId, swid);
+            m_connectionServer->sendPackets(clientId, {make_shared<ClientSubWorldReject>(swid)});
+          }
+        } else {
+          Logger::info("UniverseServer: Player {} subworld {} failed, invalid world '{}' or world failed to load", clientId, swid, printWorldId(worldId));
+          m_connectionServer->sendPackets(clientId, {make_shared<ClientSubWorldReject>(swid)});
+        }
+        pendingSubWorlds.remove(swid);
+      } else {
+        // If the world is not created yet, wait for it to create.
+      }
+    }
+    if (pendingSubWorlds.empty()) {
+      m_pendingSubWorlds.remove(clientId);
     }
   }
 }
@@ -1281,7 +1326,7 @@ void UniverseServer::shutdownInactiveWorlds() {
         world->stop();
         Logger::error("UniverseServer: World {} has stopped due to an error", worldId);
         worldDiedWithError(world->worldId());
-      } else if (world->noClients()) {
+      } else if (world->noClients() && world->shouldExpire()) {
         bool anyPendingWarps = false;
         for (auto const& p : m_pendingPlayerWarps) {
           if (resolveWarpAction(p.second.first, p.first, p.second.second).world == world->worldId()) {
@@ -1289,8 +1334,22 @@ void UniverseServer::shutdownInactiveWorlds() {
             break;
           }
         }
+        if (!anyPendingWarps) {
+          for (auto const& p : m_pendingSubWorlds) {
+            for (auto const& ps : p.second) {
+              if (ps.second == world->worldId()) {
+                // not really a warp, but close enough.
+                anyPendingWarps = true;
+                break;
+              } 
+            }
+            if (anyPendingWarps) {
+              break;
+            }
+          }
+        }
 
-        if (!anyPendingWarps && world->shouldExpire()) {
+        if (!anyPendingWarps) {
           Logger::info("UniverseServer: Stopping idle world {}", worldId);
           world->stop();
         }
@@ -1300,9 +1359,18 @@ void UniverseServer::shutdownInactiveWorlds() {
       if (world->isJoined()) {
         auto kickClients = world->clients();
         if (!kickClients.empty()) {
-          Logger::info("UniverseServer: World {} shutdown, kicking {} players to their own ships", worldId, world->clients().size());
-          for (auto clientId : world->clients())
-            clientWarpPlayer(clientId, WarpAlias::OwnShip);
+          Logger::info("UniverseServer: World {} shutdown, kicking/removing {} players/subworlds", worldId, world->clients().size());
+          for (auto clientId : world->clients()) {
+            if (clientId >= MinClientSubWorldConnectionId) {
+              // subworlds are immediately removed
+              auto swid = world->clientSubWorld(clientId);
+              auto cid = subWorldToMainConnectionId(clientId);
+              m_connectionServer->sendPackets(cid, world->removeClient(clientId));
+              m_clients.get(cid)->clearSubWorld(swid);
+            } else {
+              clientWarpPlayer(clientId, WarpAlias::OwnShip);
+            }
+          }
         }
 
         if (worldId.is<ClientShipWorldId>()) {
@@ -1673,7 +1741,12 @@ void UniverseServer::addCelestialRequests(ConnectionId clientId, List<CelestialR
 void UniverseServer::worldUpdated(WorldServerThread* server) {
   for (auto clientId : server->clients()) {
     auto packets = server->pullOutgoingPackets(clientId);
-    m_connectionServer->sendPackets(clientId, std::move(packets));
+    if (clientId >= MinClientSubWorldConnectionId) {
+      // this is just going to be one wrapper packet.
+      m_connectionServer->sendPackets(subWorldToMainConnectionId(clientId), std::move(packets));
+    } else {
+      m_connectionServer->sendPackets(clientId, std::move(packets));
+    }
   }
 }
 
@@ -1791,6 +1864,45 @@ void UniverseServer::packetsReceived(UniverseConnectionServer*, ConnectionId cli
         
         clientsLocker.unlock();
         locker.unlock();
+      } else if (auto cwtRequest = as<ClientSubWorldRequest>(packet)) {
+        if (auto currentWorld = clientContext->subWorld(cwtRequest->subWorldId)) {
+          //Logger::info("UniverseServer: Clearing client {} subworld {} world", clientId, cwtRequest->subWorldId);
+          m_connectionServer->sendPackets(clientId, currentWorld->removeClient(mainToSubWorldConnectionId(clientId)));
+          clientContext->clearSubWorld(cwtRequest->subWorldId);
+        }
+        if (cwtRequest->worldId) {
+          auto configuration = Root::singleton().configuration();
+          bool ownWorld = false;
+          if (auto shipWorldId = cwtRequest->worldId.ptr<ClientShipWorldId>()) {
+            ownWorld = (*shipWorldId) == clientContext->playerUuid();
+          } else if (auto customWorldId = cwtRequest->worldId.ptr<ClientCustomWorldId>()) {
+            ownWorld = customWorldId->uuid == clientContext->playerUuid();
+          }
+          if (
+            configuration->get("disallowClientSubWorlds").optBool().value(false)
+            || !(ownWorld
+              || configuration->get("allowClientSubWorldsAllWorlds").optBool().value(true)
+              || clientContext->isAdmin()
+              || (cwtRequest->worldId == clientContext->playerWorldId() && configuration->get("allowClientSubWorldsCurrentWorld").optBool().value(true)))
+          ) {
+            // not valid, immediately reject it
+            Logger::info("UniverseServer: Rejecting client {} subworld {} request for world {}", clientId, cwtRequest->subWorldId, cwtRequest->worldId);
+            m_connectionServer->sendPackets(clientId, {make_shared<ClientSubWorldReject>(cwtRequest->subWorldId)});
+          } else {
+            //Logger::info("UniverseServer: Accepting client {} subworld {} on world {}", clientId, cwtRequest->subWorldId, cwtRequest->worldId);
+            m_pendingSubWorlds[clientId][cwtRequest->subWorldId] = cwtRequest->worldId;
+          }
+        } else {
+          if (m_pendingSubWorlds.contains(clientId)) {
+            if (m_pendingSubWorlds[clientId].contains(cwtRequest->subWorldId)) {
+              //Logger::info("UniverseServer: Cancelling pending client {} subworld {}", clientId, cwtRequest->subWorldId);
+              m_pendingSubWorlds[clientId].remove(cwtRequest->subWorldId);
+            }
+          }
+        }
+      } else if (auto cwtPackets = as<ClientSubWorldPackets>(packet)) {
+        if (auto currentWorld = clientContext->subWorld(cwtPackets->subWorldId))
+          currentWorld->pushIncomingPackets(mainToSubWorldConnectionId(clientId), std::move(cwtPackets->packets));
       } else if (is<SystemObjectSpawnPacket>(packet)) {
         if (auto currentSystem = clientContext->systemWorld())
           currentSystem->pushIncomingPacket(clientId, std::move(packet));
@@ -2207,6 +2319,15 @@ void UniverseServer::doDisconnection(ConnectionId clientId, String const& reason
       m_chatProcessor->leaveChannel(clientId, printWorldId(currentWorld->worldId()));
       locker.lock();
     }
+    
+    // clean up subworlds as well
+    for (auto const& subWorldId : clientContext->subWorlds()) {
+      auto currentWorld = clientContext->subWorld(subWorldId);
+      locker.unlock();
+      auto finalPackets = currentWorld->removeClient(mainToSubWorldConnectionId(clientId));
+      m_connectionServer->sendPackets(clientId, finalPackets);
+      locker.lock();
+    }
 
     clientContext->clearPlayerWorld();
     clientContext->setPlayerReviveWarp(reviveWarp);
@@ -2435,6 +2556,8 @@ Maybe<UniverseServer::WorldServerPromise> UniverseServer::shipWorldPromise(
     clientContext->updateShipChunks(shipWorldThread->readChunks());
     shipWorldThread->start();
     shipWorldThread->setUpdateAction(bind(&UniverseServer::worldUpdated, this, _1));
+    
+    notifyWorldCreated(clientShipWorldId);
 
     return shipWorldThread;
   }));
@@ -2476,6 +2599,8 @@ Maybe<UniverseServer::WorldServerPromise> UniverseServer::celestialWorldPromise(
     worldThread->setPause(m_pause);
     worldThread->start();
     worldThread->setUpdateAction(bind(&UniverseServer::worldUpdated, this, _1));
+    
+    notifyWorldCreated(celestialWorldId);
 
     return worldThread;
   }));
@@ -2597,6 +2722,8 @@ Maybe<UniverseServer::WorldServerPromise> UniverseServer::instanceWorldPromise(I
     worldThread->setPause(m_pause);
     worldThread->start();
     worldThread->setUpdateAction(bind(&UniverseServer::worldUpdated, this, _1));
+    
+    notifyWorldCreated(instanceWorldId);
 
     return worldThread;
   }));
@@ -2628,6 +2755,8 @@ Maybe<UniverseServer::WorldServerPromise> UniverseServer::customWorldPromise(Cus
     worldThread->setPause(m_pause);
     worldThread->start();
     worldThread->setUpdateAction(bind(&UniverseServer::worldUpdated, this, _1));
+    
+    notifyWorldCreated(customWorldId);
 
     return worldThread;
   }));
@@ -2685,6 +2814,8 @@ Maybe<UniverseServer::WorldServerPromise> UniverseServer::clientCustomWorldPromi
       clientContext->setCustomWorldActive(clientCustomWorldId.name, true);
       worldThread->start();
       worldThread->setUpdateAction(bind(&UniverseServer::worldUpdated, this, _1));
+    
+      notifyWorldCreated(clientCustomWorldId);
 
       return worldThread;
     });
@@ -2702,6 +2833,49 @@ Maybe<UniverseServer::WorldServerPromise> UniverseServer::clientCustomWorldPromi
       producer,
       pair.first
     );
+  }
+}
+
+void UniverseServer::notifyWorldCreated(WorldId const& worldId) {
+  auto configuration = Root::singleton().configuration();
+  ReadLocker clientsLocker(m_clientsLock);
+  
+  bool notifyAll = configuration->get("notifyClientsOnWorldCreate").optBool().value(false);
+  if (notifyAll || configuration->get("notifyAdminsOnWorldCreate").optBool().value(false)) {
+    for (auto const& p : m_clients) {
+      if (p.second->netRules().version() >= 16) {
+        if (notifyAll || p.second->isAdmin()) {
+          m_connectionServer->sendPackets(p.first, {make_shared<NotifyWorldLoad>(worldId)});
+        } else {
+          bool ownWorld = false;
+          if (auto shipWorldId = worldId.ptr<ClientShipWorldId>()) {
+            ownWorld = (*shipWorldId) == p.second->playerUuid();
+          } else if (auto customWorldId = worldId.ptr<ClientCustomWorldId>()) {
+            ownWorld = customWorldId->uuid == p.second->playerUuid();
+          }
+          if (ownWorld) {
+            m_connectionServer->sendPackets(p.first, {make_shared<NotifyWorldLoad>(worldId)});
+          }
+        }
+      }
+    }
+  } else {
+    // notify only the world owner
+    Maybe<Uuid> uuid = {};
+    if (auto shipWorldId = worldId.ptr<ClientShipWorldId>()) {
+      uuid = *shipWorldId;
+    } else if (auto customWorldId = worldId.ptr<ClientCustomWorldId>()) {
+      uuid = customWorldId->uuid;
+    }
+    if (uuid) {
+      auto clientId = clientForUuid(*uuid);
+      if (clientId) {
+        auto clientContext = m_clients.get(*clientId);
+        if (clientContext->netRules().version() >= 16) {
+          m_connectionServer->sendPackets(*clientId, {make_shared<NotifyWorldLoad>(worldId)});
+        }
+      }
+    }
   }
 }
 

--- a/source/game/StarUniverseServer.hpp
+++ b/source/game/StarUniverseServer.hpp
@@ -62,6 +62,7 @@ public:
   bool isConnectedClient(ConnectionId clientId) const;
 
   String clientDescriptor(ConnectionId clientId) const;
+  unsigned clientConnectionVersion(ConnectionId clientId) const;
 
   String clientNick(ConnectionId clientId) const;
   Maybe<ConnectionId> findNick(String const& nick) const;
@@ -221,6 +222,8 @@ private:
   Maybe<WorldServerPromise> instanceWorldPromise(InstanceWorldId const& instanceWorld);
   Maybe<WorldServerPromise> customWorldPromise(CustomWorldId const& customWorld, Maybe<WorldTemplatePtr> worldTemplate = {});
   Maybe<WorldServerPromise> clientCustomWorldPromise(ClientCustomWorldId const& clientCustomWorld, Maybe<WorldTemplatePtr> worldTemplate = {});
+  
+  void notifyWorldCreated(WorldId const& worldId);
 
   // If the system world is not created, initialize it, otherwise return the
   // already initialized one
@@ -274,6 +277,7 @@ private:
   TeamManagerPtr m_teamManager;
 
   HashMap<ConnectionId, pair<WarpAction, bool>> m_pendingPlayerWarps;
+  HashMap<ConnectionId, HashMap<ClientSubWorldId, WorldId>> m_pendingSubWorlds;
   HashMap<ConnectionId, pair<tuple<Vec3I, SystemLocation, Json>, Maybe<double>>> m_queuedFlights;
   HashMap<ConnectionId, tuple<Vec3I, SystemLocation, Json>> m_pendingFlights;
   HashMap<ConnectionId, CelestialCoordinate> m_pendingArrivals;

--- a/source/game/StarWeather.cpp
+++ b/source/game/StarWeather.cpp
@@ -337,13 +337,13 @@ void ClientWeather::update(double dt) {
   if (m_currentWeatherIndex == NPos) {
     m_currentWeatherType = {};
   } else {
-    if (m_visibleRegion.yMax() > m_undergroundLevel)
+    if (m_visibleRegion == RectI() || m_visibleRegion.yMax() > m_undergroundLevel)
       m_currentWeatherType = Root::singleton().biomeDatabase()->weatherType(m_weatherPool.item(m_currentWeatherIndex));
     else
       m_currentWeatherType = {};
   }
 
-  if (m_currentWeatherType)
+  if (m_currentWeatherType && m_visibleRegion != RectI())
     spawnWeatherParticles(RectF(m_visibleRegion), dt);
 }
 

--- a/source/game/StarWorldClient.cpp
+++ b/source/game/StarWorldClient.cpp
@@ -1025,7 +1025,7 @@ void WorldClient::handleIncomingPackets(List<PacketPtr> const& packets) {
         tile->liquid = liquidUpdate->liquidUpdate.liquidLevel();
 
     } else if (auto giveItem = as<GiveItemPacket>(packet)) {
-      if (!m_headless) {
+      if (m_headless) {
         // TODO: call something on world script
       } else {
         tryGiveMainPlayerItem(itemDatabase->item(giveItem->item));

--- a/source/game/StarWorldClient.cpp
+++ b/source/game/StarWorldClient.cpp
@@ -29,10 +29,16 @@ const std::string SECRET_BROADCAST_PREFIX = "\0Broadcast\0"s;
 
 const float WorldClient::DropDist = 6.0f;
 WorldClient::WorldClient(PlayerPtr mainPlayer, LuaRootPtr luaRoot) {
+  // main client world, set up to render
   auto& root = Root::singleton();
   auto assets = root.assets();
 
   m_clientConfig = assets->json("/client.config");
+  
+  m_expiryTimer = GameTimer(0);
+  
+  m_headless = false;
+  m_subWorldId = MainClientWorldId;
 
   m_currentStep = 0;
   m_currentTime = 0;
@@ -95,6 +101,46 @@ WorldClient::WorldClient(PlayerPtr mainPlayer, LuaRootPtr luaRoot) {
   clearWorld();
 }
 
+WorldClient::WorldClient(ClientSubWorldId subWorldId) {
+  // client subworld, doesn't render
+  auto& root = Root::singleton();
+  auto assets = root.assets();
+
+  m_clientConfig = assets->json("/client.config");
+  
+  m_expiryTimer = GameTimer(m_clientConfig.getFloat("idleSubWorldExpireTime"));
+  
+  m_headless = true;
+
+  m_currentStep = 0;
+  m_currentTime = 0;
+
+  m_inWorld = false;
+  m_subWorldId = subWorldId;
+
+  m_luaRoot = make_shared<LuaRoot>();
+  m_luaRoot->luaEngine().setNullTerminated(false);
+  m_luaRoot->tuneAutoGarbageCollection(m_clientConfig.getFloat("luaGcPause"), m_clientConfig.getFloat("luaGcStepMultiplier"));
+
+  m_collisionGenerator.init([this](int x, int y) {
+    if (!m_predictedTiles.empty()) {
+      if (auto p = m_predictedTiles.ptr({x, y})) {
+        if (p->collision)
+          return *p->collision;
+      }
+    }
+    return m_tileArray->tile({x, y}).collision;
+  });
+
+  m_modifiedTilePredictionTimeout = (int)round(m_clientConfig.getFloat("modifiedTilePredictionTimeout") / GlobalTimestep);
+
+  m_latency = 0.0;
+
+  m_damageNotificationBatchDuration = m_clientConfig.getFloat("damageNotificationBatchDuration");
+
+  clearWorld();
+}
+
 WorldClient::~WorldClient() {
   if (m_lightingThread) {
     m_stopLightingThread = true;
@@ -112,6 +158,14 @@ bool WorldClient::inWorld() const {
   return m_inWorld;
 }
 
+bool WorldClient::isHeadless() const {
+  return m_headless;
+}
+
+ClientSubWorldId WorldClient::subWorldId() const {
+  return m_subWorldId;
+}
+
 bool WorldClient::inSpace() const {
   if (!m_sky)
     return false;
@@ -125,14 +179,14 @@ bool WorldClient::flying() const {
 }
 
 bool WorldClient::mainPlayerDead() const {
-  if (inWorld())
+  if (inWorld() && !m_headless)
     return !m_entityMap->get<Player>(m_mainPlayer->entityId());
   else
     return false;
 }
 
 void WorldClient::reviveMainPlayer() {
-  if (inWorld() && mainPlayerDead()) {
+  if (inWorld() && !m_headless && mainPlayerDead()) {
     m_mainPlayer->revive(m_playerStart);
     m_mainPlayer->init(this, m_entityMap->reserveEntityId(), EntityMode::Master);
     m_entityMap->addEntity(m_mainPlayer);
@@ -462,6 +516,9 @@ WorldClientState& WorldClient::clientState() {
 }
 
 void WorldClient::render(WorldRenderData& renderData, unsigned bufferTiles) {
+  if (m_headless)
+    return;
+  
   if (!m_lightingThread && m_asyncLighting)
     m_lightingThread = Thread::invoke("WorldClient::lightingMain", mem_fn(&WorldClient::lightingMain), this);
 
@@ -951,12 +1008,14 @@ void WorldClient::handleIncomingPackets(List<PacketPtr> const& packets) {
             m_predictedTiles.erase(findPrediction);
         }
 
-        if (auto placeMaterial = modification.second.ptr<PlaceMaterial>()) {
-          auto stack = materialDatabase->materialItemDrop(placeMaterial->material);
-          tryGiveMainPlayerItem(itemDatabase->item(stack), true);
-        } else if (auto placeMod = modification.second.ptr<PlaceMod>()) {
-          auto stack = materialDatabase->modItemDrop(placeMod->mod);
-          tryGiveMainPlayerItem(itemDatabase->item(stack), true);
+        if (!m_headless) {
+          if (auto placeMaterial = modification.second.ptr<PlaceMaterial>()) {
+            auto stack = materialDatabase->materialItemDrop(placeMaterial->material);
+            tryGiveMainPlayerItem(itemDatabase->item(stack), true);
+          } else if (auto placeMod = modification.second.ptr<PlaceMod>()) {
+            auto stack = materialDatabase->modItemDrop(placeMod->mod);
+            tryGiveMainPlayerItem(itemDatabase->item(stack), true);
+          }
         }
       }
 
@@ -966,7 +1025,11 @@ void WorldClient::handleIncomingPackets(List<PacketPtr> const& packets) {
         tile->liquid = liquidUpdate->liquidUpdate.liquidLevel();
 
     } else if (auto giveItem = as<GiveItemPacket>(packet)) {
-      tryGiveMainPlayerItem(itemDatabase->item(giveItem->item));
+      if (!m_headless) {
+        // TODO: call something on world script
+      } else {
+        tryGiveMainPlayerItem(itemDatabase->item(giveItem->item));
+      }
 
     } else if (auto stepUpdate = as<StepUpdatePacket>(packet)) {
       m_interpolationTracker.receiveTimeUpdate(stepUpdate->remoteTime);
@@ -1134,7 +1197,31 @@ List<PacketPtr> WorldClient::getOutgoingPackets() {
   return std::move(m_outgoingPackets);
 }
 
+Maybe<Json> WorldClient::receiveMessage(ConnectionId fromConnection, String const& message, JsonArray const& args) {
+  m_expiryTimer.reset();
+  if (!inWorld()) {
+    // script contexts aren't active to handle this message
+    return {};
+  }
+  Maybe<Json> result;
+  for (auto& p : m_scriptContexts) {
+    result = p.second->handleMessage(message, fromConnection == ServerConnectionId, args);
+    if (result)
+      break;
+  }
+  return result;
+}
+
+WorldClient::ScriptComponentPtr WorldClient::scriptContext(String const& contextName) {
+  if (auto context = m_scriptContexts.ptr(contextName))
+    return *context;
+  else
+    return nullptr;
+}
+
 void WorldClient::update(float dt) {
+  m_expiryTimer.tick(dt);
+  
   if (!inWorld())
     return;
 
@@ -1156,13 +1243,15 @@ void WorldClient::update(float dt) {
     }
   });
 
-  // Secret broadcasts are transmitted through DamageNotifications for vanilla server compatibility.
-  // Because DamageNotification packets are spoofable, we have to sign the data so other clients can validate that it is legitimate.
-  auto& publicKey = Curve25519::publicKey();
-  String publicKeyString((const char*)publicKey.data(), publicKey.size());
-  m_mainPlayer->setSecretProperty(SECRET_BROADCAST_PUBLIC_KEY, publicKeyString);
-  // Temporary: Backwards compatibility with StarExtensions
-  m_mainPlayer->effectsAnimator()->setGlobalTag("\0SE_VOICE_SIGNING_KEY"s, publicKeyString);
+  if (!m_headless) {
+    // Secret broadcasts are transmitted through DamageNotifications for vanilla server compatibility.
+    // Because DamageNotification packets are spoofable, we have to sign the data so other clients can validate that it is legitimate.
+    auto& publicKey = Curve25519::publicKey();
+    String publicKeyString((const char*)publicKey.data(), publicKey.size());
+    m_mainPlayer->setSecretProperty(SECRET_BROADCAST_PUBLIC_KEY, publicKeyString);
+    // Temporary: Backwards compatibility with StarExtensions
+    m_mainPlayer->effectsAnimator()->setGlobalTag("\0SE_VOICE_SIGNING_KEY"s, publicKeyString);
+  }
 
   ++m_currentStep;
   m_currentTime += dt;
@@ -1206,90 +1295,110 @@ void WorldClient::update(float dt) {
     }, [](EntityPtr const& a, EntityPtr const& b) {
       return a->entityType() < b->entityType();
     });
+  
+  if (m_headless) {
+    if (m_entityMap->size() > 0) {
+      m_expiryTimer.reset();
+    } else if (m_expiryTimer.ready()) {
+      // world has had no entities and isn't being used, destroy it
+      requestDestroy();
+    }
+  }
 
-  m_clientState.setPlayer(m_mainPlayer->entityId());
+  RectI particleRegion;
+  if (!m_headless) {
+    m_clientState.setPlayer(m_mainPlayer->entityId());
+    
+    m_sky->setAltitude(m_clientState.windowCenter()[1]);
+    
+    particleRegion = m_clientState.window().padded(m_clientConfig.getInt("particleRegionPadding"));
+
+    m_weather.setVisibleRegion(particleRegion);
+  }
+  
   m_clientState.setClientPresenceEntities(std::move(clientPresenceEntities));
+
+  for (auto& pair : m_scriptContexts)
+    pair.second->update(pair.second->updateDt(dt));
 
   m_damageManager->update(dt);
   handleDamageNotifications();
 
-  m_sky->setAltitude(m_clientState.windowCenter()[1]);
   m_sky->update(dt);
 
-  RectI particleRegion = m_clientState.window().padded(m_clientConfig.getInt("particleRegionPadding"));
-
-  m_weather.setVisibleRegion(particleRegion);
   m_weather.update(dt);
 
-  if (!m_mainPlayer->isDead()) {
-    // Clear m_requestedDrops every so often in case of entity id reuse or
-    // desyncs etc
-    if (m_currentStep % m_clientConfig.getInt("itemRequestReset") == 0)
+  if (!m_headless) {
+    if (!m_mainPlayer->isDead()) {
+      // Clear m_requestedDrops every so often in case of entity id reuse or
+      // desyncs etc
+      if (m_currentStep % m_clientConfig.getInt("itemRequestReset") == 0)
+        m_requestedDrops.clear();
+
+      Vec2F playerPos = m_mainPlayer->position();
+      auto dropList = m_entityMap->query<ItemDrop>(RectF(playerPos - Vec2F::filled(DropDist / 2), playerPos + Vec2F::filled(DropDist / 2)));
+      for (auto itemDrop : dropList) {
+        auto distSquared = m_geometry.diff(itemDrop->position(), playerPos).magnitudeSquared();
+
+        // If the drop is within DropDist and not owned, request it.
+        if (itemDrop->canTake() && !m_requestedDrops.contains(itemDrop->entityId()) && distSquared < square(DropDist)) {
+          m_requestedDrops.add(itemDrop->entityId());
+          if (m_mainPlayer->itemsCanHold(itemDrop->item()) != 0) {
+            m_startupHiddenEntities.erase(itemDrop->entityId());
+            itemDrop->takeBy(m_mainPlayer->entityId(), (float)m_latency / 1000);
+            m_outgoingPackets.append(make_shared<RequestDropPacket>(itemDrop->entityId()));
+          }
+        }
+      }
+    } else {
       m_requestedDrops.clear();
+    }
 
-    Vec2F playerPos = m_mainPlayer->position();
-    auto dropList = m_entityMap->query<ItemDrop>(RectF(playerPos - Vec2F::filled(DropDist / 2), playerPos + Vec2F::filled(DropDist / 2)));
-    for (auto itemDrop : dropList) {
-      auto distSquared = m_geometry.diff(itemDrop->position(), playerPos).magnitudeSquared();
+    sparkDamagedBlocks();
 
-      // If the drop is within DropDist and not owned, request it.
-      if (itemDrop->canTake() && !m_requestedDrops.contains(itemDrop->entityId()) && distSquared < square(DropDist)) {
-        m_requestedDrops.add(itemDrop->entityId());
-        if (m_mainPlayer->itemsCanHold(itemDrop->item()) != 0) {
-          m_startupHiddenEntities.erase(itemDrop->entityId());
-          itemDrop->takeBy(m_mainPlayer->entityId(), (float)m_latency / 1000);
-          m_outgoingPackets.append(make_shared<RequestDropPacket>(itemDrop->entityId()));
+    m_particles->addParticles(m_weather.pullNewParticles());
+    m_particles->update(dt, RectF(particleRegion), m_weather.wind());
+
+    if (auto audioSample = m_ambientSounds.updateAmbient(currentAmbientNoises(), m_sky->isDayTime()))
+      m_samples.append(audioSample);
+    if (auto audioSample = m_ambientSounds.updateWeather(currentWeatherNoises()))
+      m_samples.append(audioSample);
+
+    if (inSpace()) {
+      m_samples.appendAll(m_sky->pullSounds());
+
+      if (m_spaceSound && m_spaceSound->finished()) {
+        m_spaceSound = {};
+        m_activeSpaceSound = "";
+      }
+
+      auto skyAmbientNoise = m_sky->ambientNoise();
+      if (skyAmbientNoise != m_activeSpaceSound) {
+        if (m_spaceSound) {
+          m_spaceSound->stop(skyAmbientNoise == "" ? 3.0 : 0.0);
+        } else {
+          m_activeSpaceSound = skyAmbientNoise;
+          if (!m_activeSpaceSound.empty()) {
+            m_spaceSound = make_shared<AudioInstance>(*assets->audio(m_activeSpaceSound));
+            m_samples.append(m_spaceSound);
+          }
         }
       }
     }
-  } else {
-    m_requestedDrops.clear();
-  }
 
-  sparkDamagedBlocks();
-
-  m_particles->addParticles(m_weather.pullNewParticles());
-  m_particles->update(dt, RectF(particleRegion), m_weather.wind());
-
-  if (auto audioSample = m_ambientSounds.updateAmbient(currentAmbientNoises(), m_sky->isDayTime()))
-    m_samples.append(audioSample);
-  if (auto audioSample = m_ambientSounds.updateWeather(currentWeatherNoises()))
-    m_samples.append(audioSample);
-
-  if (inSpace()) {
-    m_samples.appendAll(m_sky->pullSounds());
-
-    if (m_spaceSound && m_spaceSound->finished()) {
-      m_spaceSound = {};
-      m_activeSpaceSound = "";
+    if (auto newAltMusic = m_mainPlayer->pullPendingAltMusic()) {
+      if (newAltMusic->first)
+        playAltMusic(newAltMusic->first->first, newAltMusic->second, newAltMusic->first->second);
+      else
+        stopAltMusic(newAltMusic->second);
     }
 
-    auto skyAmbientNoise = m_sky->ambientNoise();
-    if (skyAmbientNoise != m_activeSpaceSound) {
-      if (m_spaceSound) {
-        m_spaceSound->stop(skyAmbientNoise == "" ? 3.0 : 0.0);
-      } else {
-        m_activeSpaceSound = skyAmbientNoise;
-        if (!m_activeSpaceSound.empty()) {
-          m_spaceSound = make_shared<AudioInstance>(*assets->audio(m_activeSpaceSound));
-          m_samples.append(m_spaceSound);
-        }
-      }
-    }
+    if (auto audioSample = m_altMusicTrack.updateAmbient(currentAltMusicTrack(), true))
+      m_music.append(audioSample);
+
+    if (auto audioSample = m_musicTrack.updateAmbient(currentMusicTrack(), m_sky->isDayTime()))
+      m_music.append(audioSample);
   }
-
-  if (auto newAltMusic = m_mainPlayer->pullPendingAltMusic()) {
-    if (newAltMusic->first)
-      playAltMusic(newAltMusic->first->first, newAltMusic->second, newAltMusic->first->second);
-    else
-      stopAltMusic(newAltMusic->second);
-  }
-
-  if (auto audioSample = m_altMusicTrack.updateAmbient(currentAltMusicTrack(), true))
-    m_music.append(audioSample);
-
-  if (auto audioSample = m_musicTrack.updateAmbient(currentMusicTrack(), m_sky->isDayTime()))
-    m_music.append(audioSample);
 
   for (EntityId entityId : toRemove)
     removeEntity(entityId, true);
@@ -1301,7 +1410,7 @@ void WorldClient::update(float dt) {
     m_outgoingPackets.append(make_shared<PingPacket>(*m_pingTime));
   }
 
-  LogMap::set("client_ping", m_latency);
+  LogMap::set(strf("client_{}_ping",m_subWorldId), m_latency);
 
   // Remove active sectors that are outside of the current monitoring region
   Set<ClientTileSectorArray::Sector> neededSectors;
@@ -1322,9 +1431,9 @@ void WorldClient::update(float dt) {
   if (m_collisionDebug)
     renderCollisionDebug();
 
-  LogMap::set("client_entities", m_entityMap->size());
-  LogMap::set("client_sectors", toString(loadedSectors.size()));
-  LogMap::set("client_lua_mem", m_luaRoot->luaMemoryUsage());
+  LogMap::set(strf("client_{}_entities",m_subWorldId), m_entityMap->size());
+  LogMap::set(strf("client_{}_sectors",m_subWorldId), toString(loadedSectors.size()));
+  LogMap::set(strf("client_{}_lua_mem",m_subWorldId), m_luaRoot->luaMemoryUsage());
 }
 
 ConnectionId WorldClient::connection() const {
@@ -1566,7 +1675,13 @@ void WorldClient::handleDamageNotifications() {
       return false;
     });
 
+  if (m_headless) {
+    m_damageManager->pullPendingNotifications();
+    return;
+  }
+  
   for (auto const& damageNotification : m_damageManager->pullPendingNotifications()) {
+    
     auto damageDatabase = Root::singleton().damageDatabase();
     DamageKind const& damageKind = damageDatabase->damageKind(damageNotification.damageSourceKind);
     ElementalType const& elementalType = damageDatabase->elementalType(damageKind.elementalType);
@@ -1813,7 +1928,8 @@ void WorldClient::initWorld(WorldStartPacket const& startPacket) {
   m_entityUpdateTimer = GameTimer(m_interpolationTracker.entityUpdateDelta());
 
   m_clientId = startPacket.clientId;
-  m_mainPlayer->clientContext()->setConnectionId(startPacket.clientId);
+  if (!m_headless)
+    m_mainPlayer->clientContext()->setConnectionId(startPacket.clientId);
   auto entitySpace = connectionEntitySpace(startPacket.clientId);
   m_worldTemplate = make_shared<WorldTemplate>(startPacket.templateData);
   m_entityMap = make_shared<EntityMap>(m_worldTemplate->size(), entitySpace.first, entitySpace.second);
@@ -1865,28 +1981,60 @@ void WorldClient::initWorld(WorldStartPacket const& startPacket) {
 
   m_inWorld = true;
   
-  if (!m_mainPlayer->isDead()) {
-    m_mainPlayer->init(this, m_entityMap->reserveEntityId(), EntityMode::Master);
-    m_entityMap->addEntity(m_mainPlayer);
-  }
-  m_mainPlayer->moveTo(startPacket.playerStart);
-  if (const auto& parameters = m_worldTemplate->worldParameters())
-    m_mainPlayer->overrideTech(parameters->overrideTech);
-  else
-    m_mainPlayer->overrideTech({});
+  if (!m_headless) {
+    if (!m_mainPlayer->isDead()) {
+      m_mainPlayer->init(this, m_entityMap->reserveEntityId(), EntityMode::Master);
+      m_entityMap->addEntity(m_mainPlayer);
+    }
+    m_mainPlayer->moveTo(startPacket.playerStart);
+    if (const auto& parameters = m_worldTemplate->worldParameters())
+      m_mainPlayer->overrideTech(parameters->overrideTech);
+    else
+      m_mainPlayer->overrideTech({});
 
-  // Auto reposition the client window on the player when the main player
-  // changes position.
-  centerClientWindowOnPlayer();
+    // Auto reposition the client window on the player when the main player
+    // changes position.
+    centerClientWindowOnPlayer();
+  }
+  
+  // script contexts for both kinds of worlds
+  for (auto& p : m_clientConfig.getObject("worldScriptContexts")) {
+    auto scriptComponent = make_shared<ScriptComponent>();
+    scriptComponent->setScripts(jsonToStringList(p.second.toArray()));
+
+    m_scriptContexts.set(p.first, scriptComponent);
+    scriptComponent->init(this);
+  }
+  
+  for (auto& p : m_clientConfig.getObject(m_headless ? "subWorldScriptContexts" : "mainWorldScriptContexts")) {
+    if (m_scriptContexts.contains(p.first)) {
+      Logger::error("World script context {} is already defined!", p.first);
+      continue;
+    }
+    
+    auto scriptComponent = make_shared<ScriptComponent>();
+    scriptComponent->setScripts(jsonToStringList(p.second.toArray()));
+
+    m_scriptContexts.set(p.first, scriptComponent);
+    scriptComponent->init(this);
+  }
 }
 
 void WorldClient::clearWorld() {
+  for (auto& p : m_scriptContexts)
+    p.second->invoke("preUninit");
+  
   if (m_entityMap) {
     while (m_entityMap->size() > 0) {
       for (auto entityId : m_entityMap->entityIds())
         removeEntity(entityId, false);
     }
   }
+  
+  for (auto& p : m_scriptContexts)
+    p.second->uninit();
+
+  m_scriptContexts.clear();
 
   waitForLighting();
 
@@ -1935,6 +2083,9 @@ void WorldClient::clearWorld() {
   m_findUniqueEntityResponses = {};
 
   m_forceRegions.clear();
+  
+  m_expiryTimer.reset();
+  m_requestedDestroy = false;
 }
 
 void WorldClient::tryGiveMainPlayerItem(ItemPtr item, bool silent) {
@@ -1951,6 +2102,10 @@ void WorldClient::notifyEntityCreate(EntityPtr const& entity) {
     m_outgoingPackets.append(make_shared<EntityCreatePacket>(entity->entityType(),
       Root::singleton().entityFactory()->netStoreEntity(entity, netRules), std::move(firstNetState.first), entity->entityId()));
   }
+}
+
+List<EntityId> WorldClient::entityIds() const {
+  return m_entityMap->entityIds();
 }
 
 Vec2I WorldClient::environmentBiomeTrackPosition() const {
@@ -2318,6 +2473,17 @@ LuaRootPtr WorldClient::luaRoot() {
   return m_luaRoot;
 }
 
+bool WorldClient::pullRequestedDestroy() {
+  auto out = m_requestedDestroy;
+  m_requestedDestroy = false;
+  return out;
+}
+
+void WorldClient::requestDestroy() {
+  m_expiryTimer.reset();
+  m_requestedDestroy = true;
+}
+
 RpcPromise<Vec2F> WorldClient::findUniqueEntity(String const& uniqueId) {
   if (!inWorld())
     return RpcPromise<Vec2F>::createFailed("Not currently in a world");
@@ -2508,6 +2674,14 @@ void WorldClient::setupForceRegions() {
     bottomForceRegion.categoryFilter = regionCategoryFilter;
     m_forceRegions.append(bottomForceRegion);
   }
+}
+
+bool WorldClient::shouldExpire() {
+  if (inWorld()) {
+    return false;
+  }
+
+  return m_expiryTimer.ready();
 }
 
 }

--- a/source/game/StarWorldClient.hpp
+++ b/source/game/StarWorldClient.hpp
@@ -14,6 +14,7 @@
 #include "StarWorld.hpp"
 #include "StarGameTimers.hpp"
 #include "StarLuaRoot.hpp"
+#include "StarLuaComponents.hpp"
 #include "StarTickRateMonitor.hpp"
 
 namespace Star {
@@ -38,7 +39,11 @@ STAR_EXCEPTION(WorldClientException, StarException);
 
 class WorldClient : public World {
 public:
+  typedef LuaMessageHandlingComponent<LuaUpdatableComponent<LuaWorldComponent<LuaBaseComponent>>> ScriptComponent;
+  typedef shared_ptr<ScriptComponent> ScriptComponentPtr;
+  
   WorldClient(PlayerPtr mainPlayer, LuaRootPtr luaRoot);
+  WorldClient(ClientSubWorldId subWorldId);
   ~WorldClient();
 
   ConnectionId connection() const override;
@@ -103,6 +108,9 @@ public:
 
   // Is this WorldClient properly initialized in a world
   bool inWorld() const;
+  
+  bool isHeadless() const;
+  ClientSubWorldId subWorldId() const;
 
   bool inSpace() const;
   bool flying() const;
@@ -128,6 +136,8 @@ public:
   void overrideGravity(float gravity);
   void resetGravity();
 
+  List<EntityId> entityIds() const;
+
   // Disable normal client-side lighting algorithm, everything full brightness.
   bool fullBright() const;
   void setFullBright(bool fullBright);
@@ -148,6 +158,10 @@ public:
   void centerClientWindowOnPlayer();
   RectI clientWindow() const;
   WorldClientState& clientState();
+
+  Maybe<Json> receiveMessage(ConnectionId fromConnection, String const& message, JsonArray const& args);
+
+  ScriptComponentPtr scriptContext(String const& contextName);
 
   void update(float dt);
   // borderTiles here should extend the client window for border tile
@@ -180,8 +194,11 @@ public:
 
   typedef std::function<bool(PlayerPtr, StringView)> BroadcastCallback;
   BroadcastCallback& broadcastCallback();
-
-
+  
+  bool shouldExpire();
+  
+  bool pullRequestedDestroy();
+  void requestDestroy();
 
 private:
   static const float DropDist;
@@ -311,6 +328,11 @@ private:
   // set to true after we have entered a world *and* the first batch of updates
   // are received.
   bool m_inWorld;
+  
+  bool m_headless;
+  
+  ClientSubWorldId m_subWorldId;
+  bool m_requestedDestroy;
 
   GameTimer m_worldDimTimer;
   float m_worldDimLevel;
@@ -384,6 +406,10 @@ private:
 
   // used to keep track of already-printed stack traces caused by remote entities, so they don't clog the log
   HashSet<uint64_t> m_entityExceptionsLogged;
+  
+  StringMap<ScriptComponentPtr> m_scriptContexts;
+
+  GameTimer m_expiryTimer;
 };
 
 }

--- a/source/game/StarWorldClientThread.cpp
+++ b/source/game/StarWorldClientThread.cpp
@@ -1,0 +1,152 @@
+#include "StarWorldClientThread.hpp"
+#include "StarTickRateMonitor.hpp"
+#include "StarNpc.hpp"
+#include "StarRoot.hpp"
+#include "StarLogging.hpp"
+#include "StarAssets.hpp"
+#include "StarPlayer.hpp"
+
+namespace Star {
+
+WorldClientThread::WorldClientThread(ClientSubWorldId subWorldId)
+  : Thread("WorldClientThread: " + String(subWorldId)),
+    m_subWorldId(subWorldId),
+    m_stop(false),
+    m_errorOccurred(false),
+    m_shouldExpire(false) {
+    m_worldClient = make_shared<WorldClient>(subWorldId);
+}
+
+WorldClientThread::~WorldClientThread() {
+  m_stop = true;
+  join();
+
+  RecursiveMutexLocker locker(m_mutex);
+}
+
+ClientSubWorldId WorldClientThread::subWorldId() const {
+  return m_subWorldId;
+}
+
+void WorldClientThread::start() {
+  m_stop = false;
+  m_errorOccurred = false;
+  Thread::start();
+}
+
+void WorldClientThread::stop() {
+  m_stop = true;
+  Thread::join();
+}
+
+void WorldClientThread::setPause(shared_ptr<const atomic<bool>> pause) {
+  m_pause = pause;
+}
+
+bool WorldClientThread::errorOccurred() {
+  return m_errorOccurred;
+}
+
+bool WorldClientThread::shouldExpire() {
+  return m_shouldExpire;
+}
+
+void WorldClientThread::pushIncomingPackets(List<PacketPtr> packets) {
+  RecursiveMutexLocker queueLocker(m_queueMutex);
+  m_incomingPacketQueue.appendAll(std::move(packets));
+}
+
+List<PacketPtr> WorldClientThread::pullOutgoingPackets() {
+  RecursiveMutexLocker queueLocker(m_queueMutex);
+  return take(m_outgoingPacketQueue);
+}
+
+void WorldClientThread::executeAction(WorldClientAction action) {
+  RecursiveMutexLocker locker(m_mutex);
+  action(this, m_worldClient.get());
+}
+
+void WorldClientThread::setUpdateAction(WorldClientAction updateAction) {
+  RecursiveMutexLocker locker(m_mutex);
+  m_updateAction = updateAction;
+}
+
+void WorldClientThread::passMessage(Message&& message) {
+  RecursiveMutexLocker locker(m_messageMutex);
+  m_messages.append(std::move(message));
+}
+
+void WorldClientThread::run() {
+  try {
+    auto& root = Root::singleton();
+    double updateMeasureWindow = root.assets()->json("/client.config:subWorldUpdateMeasureWindow").toDouble();
+
+    TickRateApproacher tickApproacher(1.0f / GlobalTimestep, updateMeasureWindow);
+
+    while (!m_stop && !m_errorOccurred) {
+      LogMap::set(strf("client_{}_update", m_subWorldId), strf("{:4.2f}Hz", tickApproacher.rate()));
+
+      update();
+      tickApproacher.setTargetTickRate(1.0f / GlobalTimestep);
+      tickApproacher.tick();
+
+      double spareTime = tickApproacher.spareTime();
+
+      int64_t spareMilliseconds = floor(spareTime * 1000);
+      if (spareMilliseconds > 0)
+        Thread::sleepPrecise(spareMilliseconds);
+    }
+  } catch (std::exception const& e) {
+    Logger::error("WorldClientThread exception caught: {}", outputException(e, true));
+    m_errorOccurred = true;
+  }
+}
+
+void WorldClientThread::update() {
+  RecursiveMutexLocker locker(m_mutex);
+  RecursiveMutexLocker queueLocker(m_queueMutex);
+  auto incomingPackets = take(m_incomingPacketQueue);
+  queueLocker.unlock();
+  try {
+    m_worldClient->handleIncomingPackets(std::move(incomingPackets));
+  } catch (std::exception const& e) {
+    Logger::error("WorldClientThread exception caught handling incoming packets: {}", outputException(e, true));
+    queueLocker.lock();
+    m_outgoingPacketQueue.append({make_shared<ClientSubWorldRequest>(m_subWorldId, WorldId())});
+    queueLocker.unlock();
+    m_errorOccurred = true;
+  }
+
+  float dt = GlobalTimestep * GlobalTimescale;
+  if (dt > 0.0f && (!m_pause || *m_pause == false))
+    m_worldClient->update(dt);
+
+  List<Message> messages;
+  {
+    RecursiveMutexLocker locker(m_messageMutex);
+    messages = std::move(m_messages);
+  }
+  for (auto& message : messages) {
+    if (auto resp = m_worldClient->receiveMessage(ServerConnectionId, message.message, message.args))
+      message.promise.fulfill(*resp);
+    else
+      message.promise.fail("Message not handled by world");
+  }
+
+  auto outgoingPackets = m_worldClient->getOutgoingPackets();
+  auto shouldDestroy = m_worldClient->pullRequestedDestroy();
+  queueLocker.lock();
+  m_outgoingPacketQueue.append(make_shared<ClientSubWorldPackets>(m_subWorldId,std::move(outgoingPackets)));
+  if (shouldDestroy) {
+    Logger::info("WorldClientThread requesting destroy");
+    m_outgoingPacketQueue.append(make_shared<ClientSubWorldRequest>(m_subWorldId, WorldId()));
+  }
+  queueLocker.unlock();
+
+  m_shouldExpire = m_worldClient->shouldExpire();
+
+  if (m_updateAction)
+    m_updateAction(this, m_worldClient.get());
+}
+
+}

--- a/source/game/StarWorldClientThread.hpp
+++ b/source/game/StarWorldClientThread.hpp
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "StarWorldClient.hpp"
+#include "StarThread.hpp"
+#include "StarRpcThreadPromise.hpp"
+
+namespace Star {
+
+STAR_CLASS(WorldClientThread);
+
+// Runs a WorldThreadedClient in a separate thread.
+class WorldClientThread : public Thread {
+public:
+  struct Message {
+    String message;
+    JsonArray args;
+    RpcThreadPromiseKeeper<Json> promise;
+  };
+
+  typedef function<void(WorldClientThread*, WorldClient*)> WorldClientAction;
+
+  WorldClientThread(ClientSubWorldId subWorldId);
+  ~WorldClientThread();
+
+  ClientSubWorldId subWorldId() const;
+
+  void start();
+  // Signals the WorldClientThread to stop and then joins it
+  void stop();
+  void setPause(shared_ptr<const atomic<bool>> pause);
+
+  // An exception occurred from the actual WorldThreadedClient itself and the
+  // WorldClientThread has stopped running.
+  bool errorOccurred();
+  bool shouldExpire();
+
+  // Clients that have caused an error with incoming packets are removed from
+  // the world and no further packets are handled from them.  They are still
+  // added to this WorldClientThread, and must be removed and the final
+  // outgoing packets should be sent to them.
+
+  void pushIncomingPackets(List<PacketPtr> packets);
+  List<PacketPtr> pullOutgoingPackets();
+
+  // Executes the given action on the world in a thread safe context.  This
+  // does *not* catch exceptions thrown by the action or set the error
+  // flag.
+  void executeAction(WorldClientAction action);
+
+  // If a callback is set here, then this is called after every world update,
+  // also in a thread safe context.
+  void setUpdateAction(WorldClientAction updateAction);
+
+  // 
+  void passMessage(Message&& message);
+
+protected:
+  virtual void run();
+
+private:
+  void update();
+  void sync();
+
+  mutable RecursiveMutex m_mutex;
+
+  WorldClientPtr m_worldClient;
+  ClientSubWorldId m_subWorldId;
+  WorldClientAction m_updateAction;
+
+  mutable RecursiveMutex m_queueMutex;
+  List<PacketPtr> m_incomingPacketQueue;
+  List<PacketPtr> m_outgoingPacketQueue;
+
+  mutable RecursiveMutex m_messageMutex;
+  List<Message> m_messages;
+
+  atomic<bool> m_stop;
+  shared_ptr<const atomic<bool>> m_pause;
+  mutable atomic<bool> m_errorOccurred;
+  mutable atomic<bool> m_shouldExpire;
+};
+
+}

--- a/source/game/StarWorldServer.cpp
+++ b/source/game/StarWorldServer.cpp
@@ -223,7 +223,8 @@ bool WorldServer::spawnTargetValid(SpawnTarget const& spawnTarget) const {
   return true;
 }
 
-bool WorldServer::addClient(ConnectionId clientId, SpawnTarget const& spawnTarget, bool isLocal, bool isAdmin, NetCompatibilityRules netRules) {
+bool WorldServer::addClient(ConnectionId clientId, SpawnTarget const& spawnTarget, bool isLocal, bool isAdmin, NetCompatibilityRules netRules, ClientSubWorldId subWorldId) {
+  // if on a subworld, assumes connection id is the subworld's connectionid
   if (m_clientInfo.contains(clientId))
     return false;
 
@@ -258,6 +259,7 @@ bool WorldServer::addClient(ConnectionId clientId, SpawnTarget const& spawnTarge
   tracker.update(m_currentTime);
 
   auto& clientInfo = m_clientInfo.add(clientId, make_shared<ClientInfo>(clientId, tracker));
+  clientInfo->subWorldId = subWorldId;
   clientInfo->local = isLocal;
   clientInfo->admin = isAdmin;
   clientInfo->clientState.setNetCompatibilityRules(netRules);
@@ -315,11 +317,15 @@ List<PacketPtr> WorldServer::removeClient(ConnectionId clientId) {
   }
 
   auto packets = std::move(info->outgoingPackets);
+  auto subWorldId = info->subWorldId;
   m_clientInfo.remove(clientId);
 
   packets.append(make_shared<WorldStopPacket>("Removed"));
-
-  return packets;
+  if (subWorldId == MainClientWorldId) {
+    return packets;
+  } else {
+    return {make_shared<ClientSubWorldPackets>(subWorldId,std::move(packets))};
+  }
 }
 
 List<ConnectionId> WorldServer::clientIds() const {
@@ -342,6 +348,14 @@ PlayerPtr WorldServer::clientPlayer(ConnectionId clientId) const {
   auto i = m_clientInfo.find(clientId);
   if (i != m_clientInfo.end())
     return get<Player>(i->second->clientState.playerId());
+  else
+    return {};
+}
+
+ClientSubWorldId WorldServer::clientSubWorld(ConnectionId clientId) const {
+  auto i = m_clientInfo.find(clientId);
+  if (i != m_clientInfo.end())
+    return i->second->subWorldId;
   else
     return {};
 }
@@ -573,7 +587,11 @@ void WorldServer::handleIncomingPackets(ConnectionId clientId, List<PacketPtr> c
 
 List<PacketPtr> WorldServer::getOutgoingPackets(ConnectionId clientId) {
   auto const& clientInfo = m_clientInfo.get(clientId);
-  return std::move(clientInfo->outgoingPackets);
+  if (clientInfo->subWorldId == MainClientWorldId) {
+    return std::move(clientInfo->outgoingPackets);
+  } else {
+    return {make_shared<ClientSubWorldPackets>(clientInfo->subWorldId,std::move(clientInfo->outgoingPackets))};
+  }
 }
 
 bool WorldServer::sendPacket(ConnectionId clientId, PacketPtr const& packet) {
@@ -618,6 +636,10 @@ void WorldServer::setExpiryTime(float expiryTime) {
 
 float WorldServer::expiryTime() {
   return m_expiryTimer.timer;
+}
+
+List<EntityId> WorldServer::entityIds() const {
+  return m_entityMap->entityIds();
 }
 
 void WorldServer::update(float dt) {
@@ -2543,7 +2565,7 @@ bool WorldServer::isVisibleToPlayer(RectF const& region) const {
 }
 
 WorldServer::ClientInfo::ClientInfo(ConnectionId clientId, InterpolationTracker const trackerInit)
-  : clientId(clientId), skyNetVersion(0), weatherNetVersion(0), pendingForward(false), started(false), local(false), admin(false), interpolationTracker(trackerInit) {}
+  : clientId(clientId), subWorldId(MainClientWorldId), skyNetVersion(0), weatherNetVersion(0), pendingForward(false), started(false), local(false), admin(false), interpolationTracker(trackerInit) {}
 
 List<RectI> WorldServer::ClientInfo::monitoringRegions(EntityMapPtr const& entityMap) const {
   return clientState.monitoringRegions([entityMap](EntityId entityId) -> Maybe<RectI> {
@@ -2637,11 +2659,12 @@ void WorldServer::setTemplate(WorldTemplatePtr newTemplate) {
     bool local = info->local;
     bool isAdmin = info->admin;
     auto netRules = info->clientState.netCompatibilityRules();
+    auto subWorldId = info->subWorldId;
     SpawnTarget spawnTarget;
     if (auto player = clientPlayer(client))
       spawnTarget = SpawnTargetPosition(player->position() + player->feetOffset());
     removeClient(client);
-    addClient(client, spawnTarget, local, isAdmin, netRules);
+    addClient(client, spawnTarget, local, isAdmin, netRules, subWorldId);
   }
 }
 

--- a/source/game/StarWorldServer.cpp
+++ b/source/game/StarWorldServer.cpp
@@ -357,7 +357,7 @@ ClientSubWorldId WorldServer::clientSubWorld(ConnectionId clientId) const {
   if (i != m_clientInfo.end())
     return i->second->subWorldId;
   else
-    return {};
+    return 0;
 }
 
 List<EntityId> WorldServer::players() const {

--- a/source/game/StarWorldServer.hpp
+++ b/source/game/StarWorldServer.hpp
@@ -89,7 +89,7 @@ public:
 
   // Returns false if the client id already exists, or the spawn target is
   // invalid.
-  bool addClient(ConnectionId clientId, SpawnTarget const& spawnTarget, bool isLocal, bool isAdmin = false, NetCompatibilityRules netRules = {});
+  bool addClient(ConnectionId clientId, SpawnTarget const& spawnTarget, bool isLocal, bool isAdmin = false, NetCompatibilityRules netRules = {}, ClientSubWorldId subWorldId = MainClientWorldId);
 
   // Removes client, sends the WorldStopPacket, and returns any pending packets
   // for that client
@@ -101,6 +101,8 @@ public:
   // May return null if a Player is not available or if the client id is not
   // valid.
   PlayerPtr clientPlayer(ConnectionId clientId) const;
+  
+  ClientSubWorldId clientSubWorld(ConnectionId clientId) const;
 
   List<EntityId> players() const;
 
@@ -209,6 +211,8 @@ public:
 
   ScriptComponentPtr scriptContext(String const& contextName);
 
+  List<EntityId> entityIds() const;
+
   // Queues a microdungeon for placement
   RpcPromise<Vec2I> enqueuePlacement(List<BiomeItemDistribution> distributions, Maybe<DungeonId> id);
 
@@ -282,7 +286,6 @@ public:
   // Returns the list of weather names available in this world
   StringList weatherList() const;
 
-
   // used to notify the universe server that the celestial planet type has changed
   Maybe<pair<String, String>> pullNewPlanetType();
 
@@ -295,6 +298,7 @@ private:
     bool needsDamageNotification(RemoteDamageNotification const& rdn) const;
 
     ConnectionId clientId;
+    ClientSubWorldId subWorldId;
     uint64_t skyNetVersion;
     uint64_t weatherNetVersion;
     WorldClientState clientState;

--- a/source/game/StarWorldServerThread.cpp
+++ b/source/game/StarWorldServerThread.cpp
@@ -66,10 +66,10 @@ bool WorldServerThread::spawnTargetValid(SpawnTarget const& spawnTarget) {
   }
 }
 
-bool WorldServerThread::addClient(ConnectionId clientId, SpawnTarget const& spawnTarget, bool isLocal, bool isAdmin, NetCompatibilityRules netRules) {
+bool WorldServerThread::addClient(ConnectionId clientId, SpawnTarget const& spawnTarget, bool isLocal, bool isAdmin, NetCompatibilityRules netRules, ClientSubWorldId subWorldId) {
   try {
     RecursiveMutexLocker locker(m_mutex);
-    if (m_worldServer->addClient(clientId, spawnTarget, isLocal, isAdmin, netRules)) {
+    if (m_worldServer->addClient(clientId, spawnTarget, isLocal, isAdmin, netRules, subWorldId)) {
       m_clients.add(clientId);
       return true;
     }
@@ -125,6 +125,10 @@ bool WorldServerThread::noClients() const {
   return m_clients.empty();
 }
 
+ClientSubWorldId WorldServerThread::clientSubWorld(ConnectionId clientId) const {
+  RecursiveMutexLocker locker(m_mutex);
+  return m_worldServer->clientSubWorld(clientId);
+}
 
 List<ConnectionId> WorldServerThread::erroredClients() const {
   RecursiveMutexLocker locker(m_mutex);

--- a/source/game/StarWorldServerThread.hpp
+++ b/source/game/StarWorldServerThread.hpp
@@ -38,13 +38,14 @@ public:
 
   bool spawnTargetValid(SpawnTarget const& spawnTarget);
 
-  bool addClient(ConnectionId clientId, SpawnTarget const& spawnTarget, bool isLocal, bool isAdmin = false, NetCompatibilityRules netRules = {});
+  bool addClient(ConnectionId clientId, SpawnTarget const& spawnTarget, bool isLocal, bool isAdmin = false, NetCompatibilityRules netRules = {}, ClientSubWorldId subWorldId = MainClientWorldId);
   // Returns final outgoing packets
   List<PacketPtr> removeClient(ConnectionId clientId);
 
   List<ConnectionId> clients() const;
   bool hasClient(ConnectionId clientId) const;
   bool noClients() const;
+  ClientSubWorldId clientSubWorld(ConnectionId clientId) const;
 
   // Clients that have caused an error with incoming packets are removed from
   // the world and no further packets are handled from them.  They are still

--- a/source/game/scripting/StarLuaEntityUserdata.cpp
+++ b/source/game/scripting/StarLuaEntityUserdata.cpp
@@ -356,7 +356,7 @@ LuaMethods<EntityPtr> LuaUserDataMethods<EntityPtr>::make() {
             return actor->movementController()->liquidPercentage();
         return {};
     });
-    methods.registerMethod("liquidId", [&](EntityPtr entity) -> Maybe<float> {
+    methods.registerMethod("liquidId", [&](EntityPtr entity) -> Maybe<uint8_t> {
         if (auto actor = as<ActorEntity>(entity))
             return actor->movementController()->liquidId();
         return {};

--- a/source/game/scripting/StarUniverseClientLuaBindings.cpp
+++ b/source/game/scripting/StarUniverseClientLuaBindings.cpp
@@ -1,5 +1,6 @@
 #include "StarUniverseClientLuaBindings.hpp"
 #include "StarJsonExtra.hpp"
+#include "StarWarping.hpp"
 #include "StarLuaGameConverters.hpp"
 #include "StarUniverseClient.hpp"
 #include "StarWorldTemplate.hpp"
@@ -42,6 +43,63 @@ LuaCallbacks LuaBindings::makeUniverseClientCallbacks(UniverseClientPtr universe
     SkyParameters skyParameters = SkyParameters(worldConfig.get("skyParameters", Json()));
     auto worldTemplate = WorldTemplate(worldParameters, skyParameters, worldSeed);
     universe->createCustomWorld(name, worldTemplate.store());
+  });
+  
+  callbacks.registerCallback("clientUuid", [universe]() {
+    if (!universe->isConnected())
+      throw StarException("Universe is not connected");
+    return universe->clientContext()->playerUuid().hex();
+  });
+  
+  callbacks.registerCallback("serverOpenProtocolVersion", [universe]() {
+    return universe->connectionVersion();
+  });
+  
+  callbacks.registerCallback("playerCount", [universe]() -> Vec2U {
+    if (!universe->isConnected())
+      return Vec2U();
+    return Vec2U(universe->players(),universe->maxPlayers());
+  });
+  
+  callbacks.registerCallback("subWorldActive", [universe](String const& worldId) -> bool {
+    return universe->subWorldExistsOnWorld(parseWorldId(worldId));
+  });
+  
+  callbacks.registerCallback("loadSubWorld", [universe](String const& worldId) {
+    universe->getSubWorldOnWorld(parseWorldId(worldId));
+  });
+  
+  callbacks.registerCallback("unloadSubWorld", [universe](String const& worldId) {
+    universe->destroySubWorldOnWorld(parseWorldId(worldId));
+  });
+  
+  callbacks.registerCallback("sendSubWorldMessage", [universe](String const& worldId, String const& message, LuaVariadic<Json> args) -> RpcThreadPromise<Json> {
+    return universe->sendSubWorldOnWorldMessage(parseWorldId(worldId), message, JsonArray::from(std::move(args)));
+  });
+  
+  callbacks.registerCallback("sendMainWorldMessage", [universe](String const& message, LuaVariadic<Json> args) -> RpcPromise<Json> {
+    return universe->sendMainWorldMessage(message, JsonArray::from(std::move(args)));
+  });
+  
+  // primarily useful on the main world and other non-universe contexts, as universe is accessible everywhere on the main client thread
+  callbacks.registerCallback("callScriptContext", [universe](String const& contextName, String const& function, LuaVariadic<LuaValue> const& args) -> Maybe<LuaValue> {
+    auto context = universe->scriptContext(contextName);
+    if (!context)
+      throw StarException::format("Context {} does not exist", contextName);
+    return context->invoke(function, args);
+  });
+  
+  // primarily useful on universe contexts
+  callbacks.registerCallback("callMainWorldScriptContext", [universe](String const& contextName, String const& function, LuaVariadic<LuaValue> const& args) -> Maybe<LuaValue> {
+    if (!universe->isConnected())
+      throw StarException("Universe is not connected");
+    auto world = universe->worldClient();
+    if (!world->inWorld())
+      throw StarException("Not in a world");
+    auto context = world->scriptContext(contextName);
+    if (!context)
+      throw StarException::format("Context {} does not exist", contextName);
+    return context->invoke(function, args);
   });
 
   return callbacks;

--- a/source/game/scripting/StarUniverseServerLuaBindings.cpp
+++ b/source/game/scripting/StarUniverseServerLuaBindings.cpp
@@ -30,6 +30,10 @@ LuaCallbacks LuaBindings::makeUniverseServerCallbacks(UniverseServer* universe) 
     universe->clientWarpPlayer(clientId, parseWarpAction(action), deploy.value(false));
   });
   
+  callbacks.registerCallback("clientOpenProtocolVersion", [universe](ConnectionId clientId) {
+    return universe->clientConnectionVersion(clientId);
+  });
+  
   callbacks.registerCallback("createCustomWorld", [universe](String name, Json templateData) {
     universe->createCustomWorld(CustomWorldId(name), make_shared<WorldTemplate>(templateData));
   });

--- a/source/game/scripting/StarWorldLuaBindings.cpp
+++ b/source/game/scripting/StarWorldLuaBindings.cpp
@@ -80,6 +80,8 @@ namespace LuaBindings {
     Maybe<pair<Vec2F, float>> radiusQuery;
     if (auto radius = options.get<Maybe<float>>("radius"))
       radiusQuery = make_pair(options.get<Vec2F>("center"), *radius);
+    
+    bool globalQuery = !lineQuery && !polyQuery && !rectQuery && !radiusQuery;
 
     EntityBoundMode boundMode = EntityBoundModeNames.getLeft(options.get<Maybe<String>>("boundMode").value("CollisionArea"));
     Maybe<LuaString> order = options.get<Maybe<LuaString>>("order");
@@ -107,7 +109,9 @@ namespace LuaBindings {
       }
 
       auto position = entity->position();
-      if (boundMode == EntityBoundMode::MetaBoundBox) {
+      if (globalQuery) {
+        return true;
+      } else if (boundMode == EntityBoundMode::MetaBoundBox) {
         // If using MetaBoundBox, the regular line / box query methods already
         // enforce collision with MetaBoundBox
         if (radiusQuery)
@@ -155,6 +159,14 @@ namespace LuaBindings {
       RectF region(radiusQuery->first - Vec2F::filled(radiusQuery->second),
           radiusQuery->first + Vec2F::filled(radiusQuery->second));
       entities = world->query<EntityT>(region, innerSelector);
+    } else {
+      // global query
+      world->forAllEntities([&](EntityPtr const& entity) {
+          if (auto ofType = as<EntityT>(entity)) {
+            if (innerSelector(ofType))
+              entities.emplace_back(ofType);
+          }
+      });
     }
 
     if (order) {
@@ -385,7 +397,15 @@ namespace LuaBindings {
 
     if (auto clientWorld = as<WorldClient>(world)) {
       callbacks.registerCallback("inWorld", [clientWorld]() { return clientWorld->inWorld(); });
-      callbacks.registerCallback("mainPlayer", [clientWorld]() { return clientWorld->clientState().playerId(); });
+      callbacks.registerCallback("mainPlayer", [clientWorld]() -> Maybe<int> {
+        if (clientWorld->isHeadless()) {
+          return {};
+        } else {
+          return clientWorld->clientState().playerId(); 
+        }
+      });
+      callbacks.registerCallback("headless", [clientWorld]() { return clientWorld->isHeadless();  });
+      callbacks.registerCallback("subWorldId", [clientWorld]() { return clientWorld->subWorldId();  });
       callbacks.registerCallback("isClient", []() { return true;  });
       callbacks.registerCallback("isServer", []() { return false; });
       callbacks.registerCallback("latency", [clientWorld]() { return clientWorld->latency(); });
@@ -400,6 +420,17 @@ namespace LuaBindings {
         });
 
         return playerIds;
+      });
+      callbacks.registerCallback("callScriptContext", [clientWorld](String const& contextName, String const& function, LuaVariadic<LuaValue> const& args) -> Maybe<LuaValue> {
+        auto context = clientWorld->scriptContext(contextName);
+        if (!context)
+          throw StarException::format("Context {} does not exist", contextName);
+        return context->invoke(function, args);
+      });
+      callbacks.registerCallback("unload", [clientWorld]() {
+        if (!clientWorld->isHeadless())
+          throw StarException::format("Non-headless worlds cannot be unloaded.");
+        clientWorld->requestDestroy();
       });
       callbacks.registerCallback("template", [clientWorld]() {
         return clientWorld->currentTemplate()->store();
@@ -543,6 +574,13 @@ namespace LuaBindings {
       } else {
         return {};
       }
+    });
+    
+    callbacks.registerCallback("entities", [world](LuaEngine& engine, Maybe<LuaTable> options) {
+      if (!options) {
+        options = engine.createTable();
+      }
+      return entityQueryImpl<Entity>(world, engine, *options, {});
     });
 
     callbacks.registerCallbackWithSignature<bool, int>("entityExists", bind(WorldEntityCallbacks::entityExists, world, _1));


### PR DESCRIPTION
Allows the client to create subworlds. 

Subworlds can coexist with the main world, the client can warp around and the subworlds will remain. Subworlds disconnect when the client disconnects.
Subworlds automatically unload the world after 10 seconds of no entities or messages.
Subworld threads are automatically stopped after 10 seconds of not having any world loaded.

Subworlds initially start with no entities. It is up to worldClient script contexts (also added in this PR) to do anything with the worlds or respond to messages. The main client world is also allowed contexts and message handling.
Subworlds are functionally similar to server worlds.

`ClientPresenceMaster` entities are required to load anything on subworlds, as they have no players and no windows.
Subworlds use the second half of the ConnectionId range, with their world-specific ConnectionId being the second half of the players'. This lowers the player limit to 16k (which is still a lot for one Starbound server to handle) but allows retaining the property of every entity within a given 65k client range being considered same master.

Subworlds can be configured with the following server config values:
`disallowClientSubWorlds` (defaults false) disables the entire system.
`allowClientSubWorldsAllWorlds` (defaults true) allows creating subworlds on any world.
`allowClientSubWorldsCurrentWorld` (defaults true) only allows creating subworlds on the client's current world.
If not disallowed, subworlds can always be created on the client's own ship/custom worlds.

Additional features, useful for subworlds:
- Clients can be notified on serverside world create, invoking a callback on the client's UniverseClient script contexts. This always happens for the clients' own custom worlds and shipworld, and can optionally happen for all worlds, optionally for admins only. Configured with server config values `notifyClientsOnWorldCreate` (defaults false) and `notifyAdminsOnWorldCreate` (defaults false)
- Some additional Lua bindings

Documentation for relevant Lua bindings pending.