### PR TITLE
Add rarity border override

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Note: Mods that use StarExtensions features often work with OpenStarbound, StarE
 * Musical instruments have their own volume slider in the options menu.
 * Players can use items while lounging
 * Mods can change which scriptPane the Matter Manipulator/Collections sidebar button opens, in [interface.config.patch](https://github.com/OpenStarbound/OpenStarbound/blob/main/assets/opensb/interface.config.patch).
+* Items can change their rarity border. [Documentation](https://github.com/SilverSokolova/OpenStarbound/blob/SilverSokolova-RB/doc/json/openstarbound/items.md)
 
 * Client-side tile placement prediction (rewrite from StarExtensions)
   * You can also resize the placement area of tiles on the fly.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Note: Mods that use StarExtensions features often work with OpenStarbound, StarE
 * Musical instruments have their own volume slider in the options menu.
 * Players can use items while lounging
 * Mods can change which scriptPane the Matter Manipulator/Collections sidebar button opens, in [interface.config.patch](https://github.com/OpenStarbound/OpenStarbound/blob/main/assets/opensb/interface.config.patch).
-* Items can change their rarity border. [Documentation](https://github.com/SilverSokolova/OpenStarbound/blob/SilverSokolova-RB/doc/json/openstarbound/items.md)
+* Items can change their rarity border. [Documentation](https://github.com/OpenStarbound/OpenStarbound/blob/main/doc/json/openstarbound/items.md)
 
 * Client-side tile placement prediction (rewrite from StarExtensions)
   * You can also resize the placement area of tiles on the fly.

--- a/doc/json/openstarbound/items.md
+++ b/doc/json/openstarbound/items.md
@@ -1,0 +1,5 @@
+Not to be confused with generic items (items with the `.item` extension). This is for parameters shared amongst most or all item types.
+
+## `String` rarityBorder (All item types)
+Overrides the rarity border image. If an absolute path is not provided, the file at `/interface/inventory/itemborder<rarityBorder>.png` is used. Cosmetic only; the item's actual `rarity` is unchanged.
+Note that the rarity name shown in tooltips can be changed via the `rarityLabel` of an item's `tooltipFields`.

--- a/source/windowing/StarGuiTypes.cpp
+++ b/source/windowing/StarGuiTypes.cpp
@@ -23,7 +23,7 @@ EnumMap<GuiDirection> const GuiDirectionNames{
 };
 
 String rarityBorder(String border) {
-  return strf("/interface/inventory/itemborder{}.png", border.toLower());
+  return (border.beginsWith("/") ? border.toLower() : strf("/interface/inventory/itemborder{}.png", border.toLower()));
 }
 
 }

--- a/source/windowing/StarGuiTypes.cpp
+++ b/source/windowing/StarGuiTypes.cpp
@@ -22,8 +22,8 @@ EnumMap<GuiDirection> const GuiDirectionNames{
     {GuiDirection::Horizontal, "horizontal"}, {GuiDirection::Vertical, "vertical"},
 };
 
-String rarityBorder(Rarity rarity) {
-  return strf("/interface/inventory/itemborder{}.png", RarityNames.getRight(rarity).toLower());
+String rarityBorder(String border) {
+  return strf("/interface/inventory/itemborder{}.png", border);
 }
 
 }

--- a/source/windowing/StarGuiTypes.cpp
+++ b/source/windowing/StarGuiTypes.cpp
@@ -22,8 +22,8 @@ EnumMap<GuiDirection> const GuiDirectionNames{
     {GuiDirection::Horizontal, "horizontal"}, {GuiDirection::Vertical, "vertical"},
 };
 
-String rarityBorder(String border) {
-  return (border.beginsWith("/") ? border.toLower() : strf("/interface/inventory/itemborder{}.png", border.toLower()));
+String rarityBorder(String rarity) {
+  return (rarity.beginsWith("/") ? rarity : strf("/interface/inventory/itemborder{}.png", rarity)).toLower();
 }
 
 }

--- a/source/windowing/StarGuiTypes.cpp
+++ b/source/windowing/StarGuiTypes.cpp
@@ -23,7 +23,7 @@ EnumMap<GuiDirection> const GuiDirectionNames{
 };
 
 String rarityBorder(String border) {
-  return strf("/interface/inventory/itemborder{}.png", border);
+  return strf("/interface/inventory/itemborder{}.png", border.toLower());
 }
 
 }

--- a/source/windowing/StarGuiTypes.hpp
+++ b/source/windowing/StarGuiTypes.hpp
@@ -33,7 +33,7 @@ GuiDirection otherDirection(GuiDirection direction);
 template <typename T>
 T directionalValueFromVector(GuiDirection direction, Vector<T, 2> const& vec);
 
-String rarityBorder(Rarity rarity);
+String rarityBorder(String border);
 
 template <typename T>
 T& directionalValueFromVector(GuiDirection direction, Vector<T, 2> const& vec) {

--- a/source/windowing/StarItemSlotWidget.cpp
+++ b/source/windowing/StarItemSlotWidget.cpp
@@ -203,7 +203,7 @@ void ItemSlotWidget::renderImpl() {
     List<Drawable> iconDrawables = m_showSecondaryIcon ? m_item->secondaryDrawables().value(m_item->iconDrawables()) : m_item->iconDrawables();
 
     if (m_showRarity) {
-      String border = rarityBorder(m_item->instanceValue("rarityBorder", m_item->rarity()).toString());
+      String border = rarityBorder(m_item->instanceValue("rarityBorder", m_item->rarity().toString()).toString()); //This is stupid
       context()->drawInterfaceQuad(border, Vec2F(screenPosition()));
     }
 

--- a/source/windowing/StarItemSlotWidget.cpp
+++ b/source/windowing/StarItemSlotWidget.cpp
@@ -203,7 +203,7 @@ void ItemSlotWidget::renderImpl() {
     List<Drawable> iconDrawables = m_showSecondaryIcon ? m_item->secondaryDrawables().value(m_item->iconDrawables()) : m_item->iconDrawables();
 
     if (m_showRarity) {
-      String border = rarityBorder(m_item->instanceValue("rarityBorder", RarityNames.getLeft(m_item->rarity().toString())));
+      String border = rarityBorder(m_item->instanceValue("rarityBorder", m_item->rarity()));
       context()->drawInterfaceQuad(border, Vec2F(screenPosition()));
     }
 

--- a/source/windowing/StarItemSlotWidget.cpp
+++ b/source/windowing/StarItemSlotWidget.cpp
@@ -203,7 +203,7 @@ void ItemSlotWidget::renderImpl() {
     List<Drawable> iconDrawables = m_showSecondaryIcon ? m_item->secondaryDrawables().value(m_item->iconDrawables()) : m_item->iconDrawables();
 
     if (m_showRarity) {
-      String border = rarityBorder(m_item->instanceValue("rarityBorder", m_item->rarity()));
+      String border = rarityBorder(m_item->instanceValue("rarityBorder", "rarity"));
       context()->drawInterfaceQuad(border, Vec2F(screenPosition()));
     }
 

--- a/source/windowing/StarItemSlotWidget.cpp
+++ b/source/windowing/StarItemSlotWidget.cpp
@@ -203,7 +203,7 @@ void ItemSlotWidget::renderImpl() {
     List<Drawable> iconDrawables = m_showSecondaryIcon ? m_item->secondaryDrawables().value(m_item->iconDrawables()) : m_item->iconDrawables();
 
     if (m_showRarity) {
-      String border = rarityBorder(m_item->instanceValue("rarityBorder", RarityNames.getRight(m_item->rarity())).toLower());
+      String border = rarityBorder(m_item->instanceValue("rarityBorder", RarityNames.getRight(m_item->rarity())));
       context()->drawInterfaceQuad(border, Vec2F(screenPosition()));
     }
 

--- a/source/windowing/StarItemSlotWidget.cpp
+++ b/source/windowing/StarItemSlotWidget.cpp
@@ -203,7 +203,7 @@ void ItemSlotWidget::renderImpl() {
     List<Drawable> iconDrawables = m_showSecondaryIcon ? m_item->secondaryDrawables().value(m_item->iconDrawables()) : m_item->iconDrawables();
 
     if (m_showRarity) {
-      String border = rarityBorder(m_item->instanceValue("rarityBorder", m_item->rarity()));
+      String border = rarityBorder(m_item->instanceValue("rarityBorder", RarityNames.getRight(m_item->rarity())).toLower());
       context()->drawInterfaceQuad(border, Vec2F(screenPosition()));
     }
 

--- a/source/windowing/StarItemSlotWidget.cpp
+++ b/source/windowing/StarItemSlotWidget.cpp
@@ -203,7 +203,7 @@ void ItemSlotWidget::renderImpl() {
     List<Drawable> iconDrawables = m_showSecondaryIcon ? m_item->secondaryDrawables().value(m_item->iconDrawables()) : m_item->iconDrawables();
 
     if (m_showRarity) {
-      String border = rarityBorder(m_item->rarity());
+      String border = rarityBorder(m_item->instanceValue("rarityBorder", m_item->rarity()));
       context()->drawInterfaceQuad(border, Vec2F(screenPosition()));
     }
 

--- a/source/windowing/StarItemSlotWidget.cpp
+++ b/source/windowing/StarItemSlotWidget.cpp
@@ -203,7 +203,7 @@ void ItemSlotWidget::renderImpl() {
     List<Drawable> iconDrawables = m_showSecondaryIcon ? m_item->secondaryDrawables().value(m_item->iconDrawables()) : m_item->iconDrawables();
 
     if (m_showRarity) {
-      String border = rarityBorder(m_item->instanceValue("rarityBorder", m_item->instanceValue("rarity")).toString());
+      String border = rarityBorder(m_item->instanceValue("rarityBorder", m_item->rarity()).toString());
       context()->drawInterfaceQuad(border, Vec2F(screenPosition()));
     }
 

--- a/source/windowing/StarItemSlotWidget.cpp
+++ b/source/windowing/StarItemSlotWidget.cpp
@@ -203,7 +203,7 @@ void ItemSlotWidget::renderImpl() {
     List<Drawable> iconDrawables = m_showSecondaryIcon ? m_item->secondaryDrawables().value(m_item->iconDrawables()) : m_item->iconDrawables();
 
     if (m_showRarity) {
-      String border = rarityBorder(m_item->instanceValue("rarityBorder", "rarity").toString());
+      String border = rarityBorder(m_item->instanceValue("rarityBorder", m_item->instanceValue("rarity")).toString());
       context()->drawInterfaceQuad(border, Vec2F(screenPosition()));
     }
 

--- a/source/windowing/StarItemSlotWidget.cpp
+++ b/source/windowing/StarItemSlotWidget.cpp
@@ -203,7 +203,7 @@ void ItemSlotWidget::renderImpl() {
     List<Drawable> iconDrawables = m_showSecondaryIcon ? m_item->secondaryDrawables().value(m_item->iconDrawables()) : m_item->iconDrawables();
 
     if (m_showRarity) {
-      String border = rarityBorder(m_item->instanceValue("rarityBorder", RarityNames.getRight(m_item->rarity())));
+      String border = rarityBorder(m_item->instanceValue("rarityBorder", RarityNames.getLeft(m_item->rarity().toString())));
       context()->drawInterfaceQuad(border, Vec2F(screenPosition()));
     }
 

--- a/source/windowing/StarItemSlotWidget.cpp
+++ b/source/windowing/StarItemSlotWidget.cpp
@@ -203,7 +203,7 @@ void ItemSlotWidget::renderImpl() {
     List<Drawable> iconDrawables = m_showSecondaryIcon ? m_item->secondaryDrawables().value(m_item->iconDrawables()) : m_item->iconDrawables();
 
     if (m_showRarity) {
-      String border = rarityBorder(m_item->instanceValue("rarityBorder", m_item->rarity().toString()).toString()); //This is stupid
+      String border = rarityBorder(m_item->instanceValue("rarityBorder", RarityNames.getRight(m_item->rarity()).toString()).toString()); //This is stupid
       context()->drawInterfaceQuad(border, Vec2F(screenPosition()));
     }
 

--- a/source/windowing/StarItemSlotWidget.cpp
+++ b/source/windowing/StarItemSlotWidget.cpp
@@ -203,7 +203,7 @@ void ItemSlotWidget::renderImpl() {
     List<Drawable> iconDrawables = m_showSecondaryIcon ? m_item->secondaryDrawables().value(m_item->iconDrawables()) : m_item->iconDrawables();
 
     if (m_showRarity) {
-      String border = rarityBorder(m_item->instanceValue("rarityBorder", "rarity"));
+      String border = rarityBorder(m_item->instanceValue("rarityBorder", "rarity").toString());
       context()->drawInterfaceQuad(border, Vec2F(screenPosition()));
     }
 

--- a/source/windowing/StarItemSlotWidget.cpp
+++ b/source/windowing/StarItemSlotWidget.cpp
@@ -203,7 +203,7 @@ void ItemSlotWidget::renderImpl() {
     List<Drawable> iconDrawables = m_showSecondaryIcon ? m_item->secondaryDrawables().value(m_item->iconDrawables()) : m_item->iconDrawables();
 
     if (m_showRarity) {
-      String border = rarityBorder(m_item->instanceValue("rarityBorder", RarityNames.getRight(m_item->rarity()).toString()).toString()); //This is stupid
+      String border = rarityBorder(m_item->instanceValue("rarityBorder", RarityNames.getRight(m_item->rarity())).toString());
       context()->drawInterfaceQuad(border, Vec2F(screenPosition()));
     }
 


### PR DESCRIPTION
Add cosmetic option to override rarity border in item icons via `rarityBorder`. Optional. Accepts absolute path or path relative to "/interface/inventory/itemborder<rarityBorder>.png"

Does not affect actual rarity values