### PR TITLE
openGl context creation changes

### DIFF
--- a/source/application/StarMainApplication_sdl.cpp
+++ b/source/application/StarMainApplication_sdl.cpp
@@ -578,24 +578,16 @@ public:
     SDL_SetHint(SDL_HINT_AUDIO_DEVICE_APP_ICON_NAME, "openstarbound");
 #endif
 
-#if defined(__APPLE__)
-    // GL 3.2 Core + GLSL 150
-    const char* glsl_version = "#version 150";
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG); // Always required on Mac
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
-#else
-    // GL 3.2 Core + GLSL 150
-    const char* glsl_version = "#version 150";
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, 0);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 2);
-#endif
-
     Logger::info("Application: Creating SDL OpenGL context");
-    m_sdlGlContext = SDL_GL_CreateContext(m_sdlWindow);
+    static const std::pair<int,int> versions[] = {{4,6},{4,5},{4,4},{4,3},{4,2},{4,1},{4,0},{3,3},{3,2}};
+    for (auto& [majorVersion, minorVersion] : versions) {
+      SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG);
+      SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+      SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, majorVersion);
+      SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, minorVersion);
+      m_sdlGlContext = SDL_GL_CreateContext(m_sdlWindow);
+      if (m_sdlGlContext) break;
+    }
     if (!m_sdlGlContext)
       throw ApplicationException::format("Application: Could not create OpenGL context: {}", SDL_GetError());
 
@@ -647,7 +639,7 @@ public:
     style.ScaleAllSizes(main_scale);
 
     ImGui_ImplSDL3_InitForOpenGL(m_sdlWindow, m_sdlGlContext);
-    ImGui_ImplOpenGL3_Init(glsl_version);
+    ImGui_ImplOpenGL3_Init(nullptr);
 
   }
 


### PR DESCRIPTION
So this tries to fix the SSAA crash that was happening by replacing our old context creation with one that iterates through a list to find the highest possible available OpenGL version. I also changed `ImGui_ImplOpenGL3_Init` to use `nullptr`, as that enables its auto-detection based on the OpenGL context.

As for why the crash was happening: the line `multisample = GLEW_VERSION_4_0 ? config.getUInt("multisample", 0) : 0;` worked fine in most cases, but GLEW effectively asks the system rather than the context. So, the system was saying "yes, I support 4.0," while the context did not actually support it.

This issue shouldn't happen with this implementation because we now use the highest possible version instead of 3.2, so GLEW version checks and the context should no longer disagree.

It might be good if others test this as well, as I know my system will always use OpenGL 4.6.