### PR TITLE
Make imgui object names conditional on `IMGUI_VERSION_NUM`

### DIFF
--- a/source/extern/imgui_iterator.inl
+++ b/source/extern/imgui_iterator.inl
@@ -2191,8 +2191,11 @@ MAKE_ENUM(ImGuiChildFlags_AlwaysAutoResize,AlwaysAutoResize)
 MAKE_ENUM(ImGuiChildFlags_FrameStyle,FrameStyle)
 //    ImGuiChildFlags_NavFlattened            = 1 << 8,   // [BETA] Share focus scope, allow keyboard/gamepad navigation to cross over parent border to this child or between sibling child windows.
 MAKE_ENUM(ImGuiChildFlags_NavFlattened,NavFlattened)
-// Renamed in 1.91.1 → ImGuiChildFlags_Borders. Old alias removed in imgui 1.92.0 +.
-// MAKE_ENUM(ImGuiChildFlags_Border,Border)
+#if IMGUI_VERSION_NUM < 19110
+  MAKE_ENUM(ImGuiChildFlags_Border,Border)
+#else
+  MAKE_ENUM(ImGuiChildFlags_Borders,Border)
+#endif
 END_ENUM(ChildFlags)
 //enum ImGuiItemFlags_
 
@@ -2307,10 +2310,16 @@ MAKE_ENUM(ImGuiTreeNodeFlags_LabelSpanAllColumns,LabelSpanAllColumns)
 MAKE_ENUM(ImGuiTreeNodeFlags_NavLeftJumpsBackHere,NavLeftJumpsBackHere)
 //    ImGuiTreeNodeFlags_CollapsingHeader     = ImGuiTreeNodeFlags_Framed | ImGuiTreeNodeFlags_NoTreePushOnOpen | ImGuiTreeNodeFlags_NoAutoOpenOnLog,
 MAKE_ENUM(ImGuiTreeNodeFlags_CollapsingHeader,CollapsingHeader)
-// Renamed in 1.89.7 → ImGuiTreeNodeFlags_AllowOverlap. Old alias removed in imgui 1.92.0 +.
-// MAKE_ENUM(ImGuiTreeNodeFlags_AllowItemOverlap,AllowItemOverlap)
-//    ImGuiTreeNodeFlags_SpanTextWidth        = ImGuiTreeNodeFlags_SpanLabelWidth,// Renamed in 1.90.7
-MAKE_ENUM(ImGuiTreeNodeFlags_SpanTextWidth,SpanTextWidth)
+#if IMGUI_VERSION_NUM < 18970
+  MAKE_ENUM(ImGuiTreeNodeFlags_AllowItemOverlap,AllowItemOverlap)
+#else
+  MAKE_ENUM(ImGuiTreeNodeFlags_AllowOverlap,AllowItemOverlap)
+#endif
+#if IMGUI_VERSION_NUM < 19070
+  MAKE_ENUM(ImGuiTreeNodeFlags_SpanTextWidth,SpanTextWidth)
+#else
+  MAKE_ENUM(ImGuiTreeNodeFlags_SpanLabelWidth,SpanTextWidth)
+#endif
 END_ENUM(TreeNodeFlags)
 //enum ImGuiPopupFlags_
 
@@ -2353,10 +2362,16 @@ MAKE_ENUM(ImGuiSelectableFlags_Disabled,Disabled)
 MAKE_ENUM(ImGuiSelectableFlags_AllowOverlap,AllowOverlap)
 //    ImGuiSelectableFlags_Highlight          = 1 << 5,   // Make the item be displayed as if it is hovered
 MAKE_ENUM(ImGuiSelectableFlags_Highlight,Highlight)
-//    ImGuiSelectableFlags_DontClosePopups    = ImGuiSelectableFlags_NoAutoClosePopups,   // Renamed in 1.91.0
-MAKE_ENUM(ImGuiSelectableFlags_DontClosePopups,DontClosePopups)
-// Renamed in 1.89.7 → ImGuiSelectableFlags_AllowOverlap. Old alias removed in imgui 1.92.0 +.
-// MAKE_ENUM(ImGuiSelectableFlags_AllowItemOverlap,AllowItemOverlap)
+#if IMGUI_VERSION_NUM < 19100
+  MAKE_ENUM(ImGuiSelectableFlags_DontClosePopups,DontClosePopups)
+#else
+  MAKE_ENUM(ImGuiSelectableFlags_NoAutoClosePopups,DontClosePopups)
+#endif
+#if IMGUI_VERSION_NUM < 18970
+  MAKE_ENUM(ImGuiSelectableFlags_AllowItemOverlap,AllowItemOverlap)
+#else
+  MAKE_ENUM(ImGuiSelectableFlags_AllowOverlap,AllowItemOverlap)
+#endif
 END_ENUM(SelectableFlags)
 //enum ImGuiComboFlags_
 
@@ -2517,8 +2532,11 @@ MAKE_ENUM(ImGuiDragDropFlags_AcceptNoDrawDefaultRect,AcceptNoDrawDefaultRect)
 MAKE_ENUM(ImGuiDragDropFlags_AcceptNoPreviewTooltip,AcceptNoPreviewTooltip)
 //    ImGuiDragDropFlags_AcceptPeekOnly               = ImGuiDragDropFlags_AcceptBeforeDelivery | ImGuiDragDropFlags_AcceptNoDrawDefaultRect, // For peeking ahead and inspecting the payload before delivery.
 MAKE_ENUM(ImGuiDragDropFlags_AcceptPeekOnly,AcceptPeekOnly)
-//    ImGuiDragDropFlags_SourceAutoExpirePayload = ImGuiDragDropFlags_PayloadAutoExpire, // Renamed in 1.90.9
-MAKE_ENUM(ImGuiDragDropFlags_SourceAutoExpirePayload,SourceAutoExpirePayload)
+#if IMGUI_VERSION_NUM < 19090
+  MAKE_ENUM(ImGuiDragDropFlags_SourceAutoExpirePayload,SourceAutoExpirePayload)
+#else
+  MAKE_ENUM(ImGuiDragDropFlags_PayloadAutoExpire,SourceAutoExpirePayload)
+#endif
 END_ENUM(DragDropFlags)
 //enum ImGuiDataType_
 
@@ -2602,9 +2620,15 @@ MAKE_ENUM(ImGuiConfigFlags_IsSRGB,IsSRGB)
 //    ImGuiConfigFlags_IsTouchScreen          = 1 << 21,  // Application is using a touch screen instead of a mouse.
 MAKE_ENUM(ImGuiConfigFlags_IsTouchScreen,IsTouchScreen)
 //    ImGuiConfigFlags_NavEnableSetMousePos   = 1 << 2,   // [moved/renamed in 1.91.4] -> use bool io.ConfigNavMoveSetMousePos
-MAKE_ENUM(ImGuiConfigFlags_NavEnableSetMousePos,NavEnableSetMousePos)
+// FIXME: not sure how to set this up right for newer versions
+#if IMGUI_VERSION_NUM < 19140
+  MAKE_ENUM(ImGuiConfigFlags_NavEnableSetMousePos,NavEnableSetMousePos)
+#endif
 //    ImGuiConfigFlags_NavNoCaptureKeyboard   = 1 << 3,   // [moved/renamed in 1.91.4] -> use bool io.ConfigNavCaptureKeyboard
-MAKE_ENUM(ImGuiConfigFlags_NavNoCaptureKeyboard,NavNoCaptureKeyboard)
+// FIXME: not sure how to set this up right for newer versions
+#if IMGUI_VERSION_NUM < 19140
+  MAKE_ENUM(ImGuiConfigFlags_NavNoCaptureKeyboard,NavNoCaptureKeyboard)
+#endif
 END_ENUM(ConfigFlags)
 //enum ImGuiBackendFlags_
 
@@ -2739,14 +2763,20 @@ MAKE_ENUM(ImGuiCol_NavWindowingDimBg,NavWindowingDimBg)
 MAKE_ENUM(ImGuiCol_ModalWindowDimBg,ModalWindowDimBg)
 //    ImGuiCol_COUNT,
 MAKE_ENUM(ImGuiCol_COUNT,COUNT)
-//    ImGuiCol_TabActive = ImGuiCol_TabSelected,                  // [renamed in 1.90.9]
-MAKE_ENUM(ImGuiCol_TabActive,TabActive)
-//    ImGuiCol_TabUnfocused = ImGuiCol_TabDimmed,                 // [renamed in 1.90.9]
-MAKE_ENUM(ImGuiCol_TabUnfocused,TabUnfocused)
-//    ImGuiCol_TabUnfocusedActive = ImGuiCol_TabDimmedSelected,   // [renamed in 1.90.9]
-MAKE_ENUM(ImGuiCol_TabUnfocusedActive,TabUnfocusedActive)
-//    ImGuiCol_NavHighlight = ImGuiCol_NavCursor,                 // [renamed in 1.91.4]
-MAKE_ENUM(ImGuiCol_NavHighlight,NavHighlight)
+#if IMGUI_VERSION_NUM < 19090
+  MAKE_ENUM(ImGuiCol_TabActive,TabActive)
+  MAKE_ENUM(ImGuiCol_TabUnfocused,TabUnfocused)
+  MAKE_ENUM(ImGuiCol_TabUnfocusedActive,TabUnfocusedActive)
+#else
+  MAKE_ENUM(ImGuiCol_TabSelected,TabActive)
+  MAKE_ENUM(ImGuiCol_TabDimmed,TabUnfocused)
+  MAKE_ENUM(ImGuiCol_TabDimmedSelected,TabUnfocusedActive)
+#endif
+#if IMGUI_VERSION_NUM < 19140
+  MAKE_ENUM(ImGuiCol_NavHighlight,NavHighlight)
+#else
+  MAKE_ENUM(ImGuiCol_NavCursor,NavHighlight)
+#endif
 END_ENUM(Col)
 //enum ImGuiStyleVar_
 


### PR DESCRIPTION
This will fix #588 and make builds work against imgui 1.92.9b (the current stable release) while preserving things on older versions.

There's a couple of FIXMEs in here that I'm not enough of a C++ person to figure out; builds work with them being like this or just unconditionally there *for now* but a proper fix for newer imgui versions should probably be in place for when imgui removes the old names.