### PR TITLE
serverside celestial bindings

### DIFF
--- a/source/game/CMakeLists.txt
+++ b/source/game/CMakeLists.txt
@@ -211,6 +211,7 @@ SET (star_game_HEADERS
     interfaces/StarWarpTargetEntity.hpp
     interfaces/StarWireEntity.hpp
     interfaces/StarWorld.hpp
+    interfaces/StarUniverse.hpp
 
     items/StarActiveItem.hpp
     items/StarArmors.hpp

--- a/source/game/StarCommandProcessor.cpp
+++ b/source/game/StarCommandProcessor.cpp
@@ -21,6 +21,7 @@
 #include "StarAssets.hpp"
 #include "StarWorldLuaBindings.hpp"
 #include "StarUniverseServerLuaBindings.hpp"
+#include "StarCelestialLuaBindings.hpp"
 #include "StarString.hpp"
 
 namespace Star {
@@ -29,6 +30,7 @@ CommandProcessor::CommandProcessor(UniverseServer* universe, LuaRootPtr luaRoot)
   : m_universe(universe) {
   auto assets = Root::singleton().assets();
   m_scriptComponent.addCallbacks("universe", LuaBindings::makeUniverseServerCallbacks(m_universe));
+  m_scriptComponent.addCallbacks("celestial", LuaBindings::makeCelestialCallbacks(m_universe));
   m_scriptComponent.addCallbacks("CommandProcessor", makeCommandCallbacks());
   m_scriptComponent.setScripts(jsonToStringList(assets->json("/universe_server.config:commandProcessorScripts")));
   luaRoot->luaEngine().setNullTerminated(false);
@@ -184,11 +186,11 @@ String CommandProcessor::warpRandom(ConnectionId connectionId, String const& typ
     return *errorMsg;
 
 	Vec2I size = {2, 2};
-	auto& celestialDatabase = m_universe->celestialDatabase();
+	auto celestialDatabase = m_universe->celestialDatabase();
 	Maybe<CelestialCoordinate> target = {};
 
-	auto validPlanet = [&celestialDatabase, &typeName](CelestialCoordinate const& p) {
-			if (auto celestialParams = celestialDatabase.parameters(p)) {
+	auto validPlanet = [celestialDatabase, &typeName](CelestialCoordinate const& p) {
+			if (auto celestialParams = celestialDatabase->parameters(p)) {
 				if (auto visitableParams = celestialParams->visitableParameters()) {
 					if (visitableParams->typeName == typeName)
 						return true;
@@ -200,16 +202,16 @@ String CommandProcessor::warpRandom(ConnectionId connectionId, String const& typ
 	while (target.isNothing()) {
 		RectI region = RectI::withSize(Vec2I(Random::randi32(), Random::randi32()), size);
 
-		while (!celestialDatabase.scanRegionFullyLoaded(region)) {
-			celestialDatabase.scanSystems(region);
+		while (!celestialDatabase->scanRegionFullyLoaded(region)) {
+			celestialDatabase->scanSystems(region);
 		}
-		auto systems = celestialDatabase.scanSystems(region);
+		auto systems = celestialDatabase->scanSystems(region);
 		for (auto s : systems) {
-			for (auto planet : celestialDatabase.children(s)) {
+			for (auto planet : celestialDatabase->children(s)) {
 				if (validPlanet(planet))
 					target = planet;
 				if (target.isNothing()) {
-					for (auto moon : celestialDatabase.children(planet)) {
+					for (auto moon : celestialDatabase->children(planet)) {
 						if (validPlanet(moon)) {
 							target = moon;
 							break;

--- a/source/game/StarPlayer.cpp
+++ b/source/game/StarPlayer.cpp
@@ -40,6 +40,7 @@
 #include "StarScriptedAnimatorLuaBindings.hpp"
 #include "StarEntityLuaBindings.hpp"
 #include "StarDanceDatabase.hpp"
+#include "StarUniverseClient.hpp"
 
 namespace Star {
 

--- a/source/game/StarQuests.cpp
+++ b/source/game/StarQuests.cpp
@@ -22,6 +22,7 @@
 #include "StarClientContext.hpp"
 #include "StarUuid.hpp"
 #include "StarCelestialLuaBindings.hpp"
+#include "StarUniverseClient.hpp"
 
 namespace Star {
 

--- a/source/game/StarUniverseClient.cpp
+++ b/source/game/StarUniverseClient.cpp
@@ -507,7 +507,7 @@ void UniverseClient::flyShip(Vec3I const& system, SystemLocation const& destinat
   m_connection->pushSingle(make_shared<FlyShipPacket>(system, destination, settings));
 }
 
-CelestialDatabasePtr UniverseClient::celestialDatabase() const {
+CelestialDatabasePtr UniverseClient::celestialDatabase() {
   return m_celestialDatabase;
 }
 

--- a/source/game/StarUniverseClient.hpp
+++ b/source/game/StarUniverseClient.hpp
@@ -11,6 +11,7 @@
 #include "StarUniverseConnection.hpp"
 #include "StarWorldClientThread.hpp"
 #include "StarLuaComponents.hpp"
+#include "StarUniverse.hpp"
 
 namespace Star {
 
@@ -33,7 +34,7 @@ STAR_CLASS(QuestManager);
 STAR_CLASS(UniverseClient);
 STAR_CLASS(LuaRoot);
 
-class UniverseClient {
+class UniverseClient : public Universe {
 public:
   typedef LuaUpdatableComponent<LuaBaseComponent> ScriptComponent;
   typedef shared_ptr<ScriptComponent> ScriptComponentPtr;
@@ -69,7 +70,7 @@ public:
   void warpPlayer(WarpAction const& warpAction, bool animate = true, String const& animationType = "default", bool deploy = false);
   void flyShip(Vec3I const& system, SystemLocation const& destination, Json const& settings = {});
 
-  CelestialDatabasePtr celestialDatabase() const;
+  CelestialDatabasePtr celestialDatabase() override;
 
   CelestialCoordinate shipCoordinate() const;
 

--- a/source/game/StarUniverseServer.cpp
+++ b/source/game/StarUniverseServer.cpp
@@ -17,6 +17,7 @@
 #include "StarTcp.hpp"
 #include "StarTeamManager.hpp"
 #include "StarUniverseServerLuaBindings.hpp"
+#include "StarCelestialLuaBindings.hpp"
 #include "StarVersioningDatabase.hpp"
 
 namespace Star {
@@ -47,10 +48,6 @@ UniverseServer::UniverseServer(String const& storageDir, bool const& isLocal)
   }
 
   startLuaScripts();
-
-  m_commandProcessor = make_shared<CommandProcessor>(this, m_luaRoot);
-  m_chatProcessor = make_shared<ChatProcessor>();
-  m_chatProcessor->setCommandHandler(bind(&CommandProcessor::userCommand, m_commandProcessor.get(), _1, _2, _3));
 
   Logger::info("UniverseServer: Acquiring universe lock file");
 
@@ -86,6 +83,10 @@ UniverseServer::UniverseServer(String const& storageDir, bool const& isLocal)
 
   m_teamManager = make_shared<TeamManager>();
   m_workerPool.start(universeConfig.getUInt("workerPoolThreads"));
+
+  m_commandProcessor = make_shared<CommandProcessor>(this, m_luaRoot);
+  m_chatProcessor = make_shared<ChatProcessor>();
+  m_chatProcessor->setCommandHandler(bind(&CommandProcessor::userCommand, m_commandProcessor.get(), _1, _2, _3));
 
   size_t networkWorkerThreads = universeConfig.optUInt("networkWorkerThreads").value(0);
   m_connectionServer = make_shared<UniverseConnectionServer>(
@@ -393,8 +394,8 @@ UniverseSettingsPtr UniverseServer::universeSettings() const {
   return m_universeSettings;
 }
 
-CelestialDatabase& UniverseServer::celestialDatabase() {
-  return *m_celestialDatabase;
+CelestialDatabasePtr UniverseServer::celestialDatabase() {
+  return m_celestialDatabase;
 }
 
 bool UniverseServer::executeForClient(ConnectionId clientId, function<void(WorldServer*, PlayerPtr)> action) {
@@ -2976,6 +2977,7 @@ void UniverseServer::startLuaScripts() {
     auto scriptComponent = make_shared<ScriptComponent>();
     scriptComponent->setLuaRoot(m_luaRoot);
     scriptComponent->addCallbacks("universe", LuaBindings::makeUniverseServerCallbacks(this));
+    scriptComponent->addCallbacks("celestial", LuaBindings::makeCelestialCallbacks(this));
     scriptComponent->setScripts(jsonToStringList(p.second.toArray()));
 
     m_scriptContexts.set(p.first, scriptComponent);

--- a/source/game/StarUniverseServer.hpp
+++ b/source/game/StarUniverseServer.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "StarUniverse.hpp"
 #include "StarLockFile.hpp"
 #include "StarIdMap.hpp"
 #include "StarWorkerPool.hpp"
@@ -30,7 +31,7 @@ STAR_EXCEPTION(UniverseServerException, StarException);
 // Manages all running worlds, listens for new client connections and marshalls
 // between all the different worlds and all the different client connections
 // and routes packets between them.
-class UniverseServer : public Thread {
+class UniverseServer : public Universe, public Thread {
 public:
   UniverseServer(String const& storageDir, bool const& isLocal = false);
   ~UniverseServer();
@@ -96,7 +97,7 @@ public:
   ClockPtr universeClock() const;
   UniverseSettingsPtr universeSettings() const;
 
-  CelestialDatabase& celestialDatabase();
+  CelestialDatabasePtr celestialDatabase() override;
 
   // If the client exists and is in a valid connection state, executes the
   // given function on the client world and player object in a thread safe way.
@@ -119,7 +120,7 @@ public:
   bool sendPacket(ConnectionId clientId, PacketPtr packet);
 
 protected:
-  virtual void run();
+  virtual void run() override;
 
 private:
   struct TimeoutBan {

--- a/source/game/StarWorldServer.cpp
+++ b/source/game/StarWorldServer.cpp
@@ -23,7 +23,9 @@
 #include "StarFallingBlocksAgent.hpp"
 #include "StarWarpTargetEntity.hpp"
 #include "StarUniverseSettings.hpp"
+#include "StarUniverseServer.hpp"
 #include "StarUniverseServerLuaBindings.hpp"
+#include "StarCelestialLuaBindings.hpp"
 
 namespace Star {
 
@@ -112,6 +114,7 @@ void WorldServer::setPause(bool pause) {
 
 void WorldServer::initLua(UniverseServer* universe) {
   m_luaRoot->addCallbacks("universe", LuaBindings::makeUniverseServerCallbacks(universe));
+  m_luaRoot->addCallbacks("celestial", LuaBindings::makeCelestialCallbacks(universe));
   auto assets = Root::singleton().assets();
   for (auto& p : assets->json("/worldserver.config:scriptContexts").toObject()) {
     auto scriptComponent = make_shared<ScriptComponent>();

--- a/source/game/interfaces/StarUniverse.hpp
+++ b/source/game/interfaces/StarUniverse.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "StarConfig.hpp"
+
+namespace Star {
+
+STAR_CLASS(Universe);
+STAR_CLASS(CelestialDatabase);
+
+// Shared base class for UniverseClient and UniverseServer
+class Universe {
+public:
+  virtual CelestialDatabasePtr celestialDatabase() = 0;
+};
+
+}

--- a/source/game/scripting/StarCelestialLuaBindings.cpp
+++ b/source/game/scripting/StarCelestialLuaBindings.cpp
@@ -8,54 +8,11 @@
 
 namespace Star {
 
-LuaCallbacks LuaBindings::makeCelestialCallbacks(UniverseClient* client) {
+LuaCallbacks LuaBindings::makeCelestialCallbacks(Universe* universe) {
   LuaCallbacks callbacks;
 
-  auto systemWorld = client->systemWorldClient();
-  auto celestialDatabase = client->celestialDatabase();
-
-  callbacks.registerCallback("skyFlying", [client]() {
-      return client->currentSky()->flying();
-    });
-  callbacks.registerCallback("skyFlyingType", [client]() -> String {
-      return FlyingTypeNames.getRight(client->currentSky()->flyingType());
-    });
-  callbacks.registerCallback("skyWarpPhase", [client]() -> String {
-      return WarpPhaseNames.getRight(client->currentSky()->warpPhase());
-    });
-  callbacks.registerCallback("skyWarpProgress", [client]() -> float {
-      return client->currentSky()->warpProgress();
-    });
-  callbacks.registerCallback("skyInHyperspace", [client]() -> bool {
-      return client->currentSky()->inHyperspace();
-    });
-
-  callbacks.registerCallback("flyShip", [client,systemWorld](Vec3I const& system, Json const& destination, Json const& settings) {
-      auto location = jsonToSystemLocation(destination);
-      client->flyShip(system, location, settings);
-    });
-  callbacks.registerCallback("flying", [systemWorld]() {
-      return systemWorld->flying();
-    });
-  callbacks.registerCallback("shipSystemPosition", [systemWorld]() -> Maybe<Vec2F> {
-      return systemWorld->shipPosition();
-    });
-  callbacks.registerCallback("shipDestination", [systemWorld]() -> Json {
-      return jsonFromSystemLocation(systemWorld->shipDestination());
-    });
-  callbacks.registerCallback("shipLocation", [systemWorld]() -> Json {
-      return jsonFromSystemLocation(systemWorld->shipLocation());
-    });
-  callbacks.registerCallback("currentSystem", [systemWorld]() -> Json {
-      return systemWorld->currentSystem().toJson();
-    });
-
-  callbacks.registerCallback("planetSize", [systemWorld](Json const& coords) -> float {
-      return systemWorld->planetSize(CelestialCoordinate(coords));
-    });
-  callbacks.registerCallback("planetPosition", [systemWorld](Json const& coords) -> Vec2F {
-      return systemWorld->planetPosition(CelestialCoordinate(coords));
-    });
+  auto celestialDatabase = universe->celestialDatabase();
+  
   callbacks.registerCallback("planetParameters", [celestialDatabase](Json const& coords) -> Json {
       CelestialCoordinate coordinate = CelestialCoordinate(coords);
       if (auto celestialParameters = celestialDatabase->parameters(coordinate))
@@ -81,9 +38,6 @@ LuaCallbacks LuaBindings::makeCelestialCallbacks(UniverseClient* client) {
       if (auto parameters = celestialDatabase->parameters(coordinate))
         return parameters->seed();
       return {};
-    });
-  callbacks.registerCallback("clusterSize", [systemWorld](Json const& coords) -> float {
-      return systemWorld->clusterSize(CelestialCoordinate(coords));
     });
   callbacks.registerCallback("planetOres", [celestialDatabase](Json const& coords, float threatLevel) -> List<String> {
       CelestialCoordinate coordinate = CelestialCoordinate(coords);
@@ -113,66 +67,6 @@ LuaCallbacks LuaBindings::makeCelestialCallbacks(UniverseClient* client) {
       }
 
       return planetOres.values();
-    });
-
-  callbacks.registerCallback("systemPosition", [systemWorld](Json const& l) -> Maybe<Vec2F> {
-      auto location = jsonToSystemLocation(l);
-      return systemWorld->systemLocationPosition(location);
-    });
-  callbacks.registerCallback("orbitPosition", [systemWorld](Json const& orbit) -> Vec2F {
-      return systemWorld->orbitPosition(CelestialOrbit::fromJson(orbit));
-    });
-
-  callbacks.registerCallback("systemObjects", [systemWorld]() -> List<String> {
-      return systemWorld->objects().transformed([](SystemObjectPtr object) { return object->uuid().hex(); });
-    });
-  callbacks.registerCallback("objectType", [systemWorld](String const& uuid) -> Maybe<String> {
-      if (auto object = systemWorld->getObject(Uuid(uuid)))
-        return object->name();
-      else
-        return {};
-    });
-  callbacks.registerCallback("objectParameters", [systemWorld](String const& uuid) -> Json {
-      if (auto object = systemWorld->getObject(Uuid(uuid)))
-        return object->parameters();
-      else
-        return {};
-    });
-  callbacks.registerCallback("objectWarpActionWorld", [systemWorld](String const& uuid) -> Maybe<String> {
-      if (Maybe<WarpAction> action = systemWorld->objectWarpAction((Uuid(uuid)))) {
-        return action.get().maybe<WarpToWorld>().apply([](WarpToWorld const& warp) { return printWorldId(warp.world); });
-      } else {
-        return {};
-      }
-    });
-  callbacks.registerCallback("objectOrbit", [systemWorld](String const& uuid) -> Json {
-      if (auto object = systemWorld->getObject(Uuid(uuid)))
-        return jsonFromMaybe<CelestialOrbit>(object->orbit(), [](CelestialOrbit const& orbit) { return orbit.toJson(); });
-      else
-        return {};
-    });
-  callbacks.registerCallback("objectPosition", [systemWorld](String const& uuid) -> Maybe<Vec2F> {
-      if (auto object = systemWorld->getObject(Uuid(uuid)))
-        return object->position();
-      else
-        return {};
-    });
-  callbacks.registerCallback("objectTypeConfig", [](String const& typeName) -> Json {
-      return SystemWorld::systemObjectTypeConfig(typeName);
-    });
-  callbacks.registerCallback("systemSpawnObject", [systemWorld](String const& typeName, Maybe<Vec2F> const& position, Maybe<String> uuidHex, Maybe<JsonObject> parameters) -> String {
-      Maybe<Uuid> uuid = uuidHex.apply([](auto const& u) { return Uuid(u); });
-      return systemWorld->spawnObject(typeName, position, uuid, parameters.value({})).hex();
-    });
-
-  callbacks.registerCallback("playerShips", [systemWorld]() -> List<String> {
-      return systemWorld->ships().transformed([](SystemClientShipPtr ship) { return ship->uuid().hex(); });
-    });
-  callbacks.registerCallback("playerShipPosition", [systemWorld](String const& uuid) -> Maybe<Vec2F> {
-      if (auto ship = systemWorld->getShip(Uuid(uuid)))
-        return ship->position();
-      else
-        return {};
     });
 
   callbacks.registerCallback("hasChildren", [celestialDatabase](Json const& coords) -> Maybe<bool> {
@@ -212,6 +106,116 @@ LuaCallbacks LuaBindings::makeCelestialCallbacks(UniverseClient* client) {
       CelestialCoordinate coordinate = CelestialCoordinate(coords);
       return CelestialGraphics::drawSystemTwinkle(celestialDatabase, coordinate, twinkleTime);
     });
+  
+  if (auto client = as<UniverseClient>(universe)) {
+    auto systemWorld = client->systemWorldClient();
+
+    callbacks.registerCallback("skyFlying", [client]() {
+        return client->currentSky()->flying();
+      });
+    callbacks.registerCallback("skyFlyingType", [client]() -> String {
+        return FlyingTypeNames.getRight(client->currentSky()->flyingType());
+      });
+    callbacks.registerCallback("skyWarpPhase", [client]() -> String {
+        return WarpPhaseNames.getRight(client->currentSky()->warpPhase());
+      });
+    callbacks.registerCallback("skyWarpProgress", [client]() -> float {
+        return client->currentSky()->warpProgress();
+      });
+    callbacks.registerCallback("skyInHyperspace", [client]() -> bool {
+        return client->currentSky()->inHyperspace();
+      });
+
+    callbacks.registerCallback("flyShip", [client,systemWorld](Vec3I const& system, Json const& destination, Json const& settings) {
+        auto location = jsonToSystemLocation(destination);
+        client->flyShip(system, location, settings);
+      });
+    callbacks.registerCallback("flying", [systemWorld]() {
+        return systemWorld->flying();
+      });
+    callbacks.registerCallback("shipSystemPosition", [systemWorld]() -> Maybe<Vec2F> {
+        return systemWorld->shipPosition();
+      });
+    callbacks.registerCallback("shipDestination", [systemWorld]() -> Json {
+        return jsonFromSystemLocation(systemWorld->shipDestination());
+      });
+    callbacks.registerCallback("shipLocation", [systemWorld]() -> Json {
+        return jsonFromSystemLocation(systemWorld->shipLocation());
+      });
+    callbacks.registerCallback("currentSystem", [systemWorld]() -> Json {
+        return systemWorld->currentSystem().toJson();
+      });
+
+    callbacks.registerCallback("planetSize", [systemWorld](Json const& coords) -> float {
+        return systemWorld->planetSize(CelestialCoordinate(coords));
+      });
+    callbacks.registerCallback("planetPosition", [systemWorld](Json const& coords) -> Vec2F {
+        return systemWorld->planetPosition(CelestialCoordinate(coords));
+      });
+    callbacks.registerCallback("clusterSize", [systemWorld](Json const& coords) -> float {
+        return systemWorld->clusterSize(CelestialCoordinate(coords));
+      });
+
+    callbacks.registerCallback("systemPosition", [systemWorld](Json const& l) -> Maybe<Vec2F> {
+        auto location = jsonToSystemLocation(l);
+        return systemWorld->systemLocationPosition(location);
+      });
+    callbacks.registerCallback("orbitPosition", [systemWorld](Json const& orbit) -> Vec2F {
+        return systemWorld->orbitPosition(CelestialOrbit::fromJson(orbit));
+      });
+
+    callbacks.registerCallback("systemObjects", [systemWorld]() -> List<String> {
+        return systemWorld->objects().transformed([](SystemObjectPtr object) { return object->uuid().hex(); });
+      });
+    callbacks.registerCallback("objectType", [systemWorld](String const& uuid) -> Maybe<String> {
+        if (auto object = systemWorld->getObject(Uuid(uuid)))
+          return object->name();
+        else
+          return {};
+      });
+    callbacks.registerCallback("objectParameters", [systemWorld](String const& uuid) -> Json {
+        if (auto object = systemWorld->getObject(Uuid(uuid)))
+          return object->parameters();
+        else
+          return {};
+      });
+    callbacks.registerCallback("objectWarpActionWorld", [systemWorld](String const& uuid) -> Maybe<String> {
+        if (Maybe<WarpAction> action = systemWorld->objectWarpAction((Uuid(uuid)))) {
+          return action.get().maybe<WarpToWorld>().apply([](WarpToWorld const& warp) { return printWorldId(warp.world); });
+        } else {
+          return {};
+        }
+      });
+    callbacks.registerCallback("objectOrbit", [systemWorld](String const& uuid) -> Json {
+        if (auto object = systemWorld->getObject(Uuid(uuid)))
+          return jsonFromMaybe<CelestialOrbit>(object->orbit(), [](CelestialOrbit const& orbit) { return orbit.toJson(); });
+        else
+          return {};
+      });
+    callbacks.registerCallback("objectPosition", [systemWorld](String const& uuid) -> Maybe<Vec2F> {
+        if (auto object = systemWorld->getObject(Uuid(uuid)))
+          return object->position();
+        else
+          return {};
+      });
+    callbacks.registerCallback("objectTypeConfig", [](String const& typeName) -> Json {
+        return SystemWorld::systemObjectTypeConfig(typeName);
+      });
+    callbacks.registerCallback("systemSpawnObject", [systemWorld](String const& typeName, Maybe<Vec2F> const& position, Maybe<String> uuidHex, Maybe<JsonObject> parameters) -> String {
+        Maybe<Uuid> uuid = uuidHex.apply([](auto const& u) { return Uuid(u); });
+        return systemWorld->spawnObject(typeName, position, uuid, parameters.value({})).hex();
+      });
+
+    callbacks.registerCallback("playerShips", [systemWorld]() -> List<String> {
+        return systemWorld->ships().transformed([](SystemClientShipPtr ship) { return ship->uuid().hex(); });
+      });
+    callbacks.registerCallback("playerShipPosition", [systemWorld](String const& uuid) -> Maybe<Vec2F> {
+        if (auto ship = systemWorld->getShip(Uuid(uuid)))
+          return ship->position();
+        else
+          return {};
+      });
+  }
 
   return callbacks;
 }

--- a/source/game/scripting/StarCelestialLuaBindings.hpp
+++ b/source/game/scripting/StarCelestialLuaBindings.hpp
@@ -5,9 +5,9 @@
 namespace Star {
 
 STAR_CLASS(Root);
-STAR_CLASS(UniverseClient);
+STAR_CLASS(Universe);
 
 namespace LuaBindings {
-  LuaCallbacks makeCelestialCallbacks(UniverseClient* client);
+  LuaCallbacks makeCelestialCallbacks(Universe* universe);
 }
 }


### PR DESCRIPTION
adds a shared Universe interface, currently only used for a unified CelestialDatabase getter

adds `celestial` callbacks to world server scripts, universe server scripts, and command processor scripts
contains many of the same functions as client `celestial` but excludes anything from SystemWorldClient and anything about player ships

bindings for SystemWorldServer and accessing player ships might be something to add in the future, either to `celestial` or to `universe`