### PR TITLE
add 3.1 to supported OpenGL context

### DIFF
--- a/assets/opensb/rendering/effects/basic.vert
+++ b/assets/opensb/rendering/effects/basic.vert
@@ -1,4 +1,4 @@
-#version 150
+#version 140
 
 in vec2 vertexPosition;
 

--- a/assets/opensb/rendering/effects/interface.frag
+++ b/assets/opensb/rendering/effects/interface.frag
@@ -1,4 +1,4 @@
-#version 150
+#version 140
 
 uniform sampler2D texture0;
 uniform sampler2D texture1;

--- a/assets/opensb/rendering/effects/interface.vert
+++ b/assets/opensb/rendering/effects/interface.vert
@@ -1,4 +1,4 @@
-#version 150
+#version 140
 
 uniform vec2 textureSize0;
 uniform vec2 textureSize1;

--- a/assets/opensb/rendering/effects/world.frag
+++ b/assets/opensb/rendering/effects/world.frag
@@ -1,4 +1,4 @@
-#version 150
+#version 140
 
 uniform sampler2D texture0;
 uniform sampler2D texture1;

--- a/assets/opensb/rendering/effects/world.vert
+++ b/assets/opensb/rendering/effects/world.vert
@@ -1,4 +1,4 @@
-#version 150
+#version 140
 
 uniform vec2 textureSize0;
 uniform vec2 textureSize1;

--- a/source/application/StarMainApplication_sdl.cpp
+++ b/source/application/StarMainApplication_sdl.cpp
@@ -579,7 +579,7 @@ public:
 #endif
 
     Logger::info("Application: Creating SDL OpenGL context");
-    static const std::pair<int,int> versions[] = {{4,6},{4,5},{4,4},{4,3},{4,2},{4,1},{4,0},{3,3},{3,2}};
+    static const std::pair<int,int> versions[] = {{4,6},{4,5},{4,4},{4,3},{4,2},{4,1},{4,0},{3,3},{3,2},{3,1}};
     for (auto& [majorVersion, minorVersion] : versions) {
       SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG);
       SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);

--- a/source/application/StarRenderer_opengl.cpp
+++ b/source/application/StarRenderer_opengl.cpp
@@ -8,7 +8,7 @@ namespace Star {
 size_t const MultiTextureCount = 4;
 
 char const* DefaultVertexShader = R"SHADER(
-#version 150
+#version 140
 
 uniform vec2 textureSize0;
 uniform vec2 textureSize1;
@@ -49,7 +49,7 @@ void main() {
 )SHADER";
 
 char const* DefaultFragmentShader = R"SHADER(
-#version 150
+#version 140
 
 uniform sampler2D texture0;
 uniform sampler2D texture1;
@@ -107,9 +107,6 @@ OpenGlRenderer::OpenGlRenderer() {
   auto glewResult = glewInit();
   if (glewResult != GLEW_OK && glewResult != GLEW_ERROR_NO_GLX_DISPLAY)
     throw RendererException::format("Could not initialize GLEW: {}", (char*)glewGetErrorString(glewResult));
-
-  if (!GLEW_VERSION_3_2)
-    throw RendererException("OpenGL 3.2 not available!");
 
   Logger::info("OpenGL version: '{}' vendor: '{}' renderer: '{}' shader: '{}'",
       (const char*)glGetString(GL_VERSION),


### PR DESCRIPTION
So, as in the title, this adds GL 3.1 to the supported context. As it is the first version with GLSL 140.

The GLSL version was updated to 150 in the past due to a misunderstanding of why 140 was used, which is why I reverted this mistake I made with this PR.

This might help with #597 because it seems like it at a maximum supports 3.1

Also, I removed the OpenGL version check in the OpenGL renderer. The only reason this code was ever there is because the original code didn't set a context, so the system chose one, and therefore the renderer needed to check what it got.