### PR TITLE
scriptable threads improvements

### DIFF
--- a/doc/lua/openstarbound/threads.md
+++ b/doc/lua/openstarbound/threads.md
@@ -13,15 +13,16 @@ Creates a thread using the given parameters, and returns the thread's name.
 Here's an example that uses all available parameters:
 ```lua
 threads.create({
-    name="example", -- this is the thread name you'll use to index the thread
+    name="example", -- This is the thread name you'll use to index the thread. If unspecified, uses a random UUID as the thread name.
     scripts={
-        main={"/scripts/examplethread.lua"}, -- a list of scripts for each context, similarly to how other scripts work
-        other={"/scripts/examplesecondthreadscript.lua"}, -- threads can have multiple contexts
+        main={"/scripts/examplethread.lua"}, -- A list of scripts for each context, similarly to how other scripts work.
+        other={"/scripts/examplesecondthreadscript.lua"}, -- Threads can have multiple contexts.
     },
-    instructionLimit=100000000, -- optional, threads are allowed to change their own instruction limit (as they have nothing else to block if stuck)
-    tickRate=60, -- optional, how many ticks per second the thread runs at, defaults to 60 but can be any number
-    updateMeasureWindow=0.5, -- optional, defaults to 0.5, changing this is unnecessary unless you really care about an accurate tickrate for some reason
-    someParameter="scungus" -- parameters for the scripts, all parameters are accessible using config.getParameter in the scripts
+    instructionLimit=100000000, -- Optional, threads are allowed to change their own instruction limit (as they have nothing else to block if stuck).
+    tickRate=60, -- Optional, how many ticks per second the thread runs at, defaults to 60 but can be any number.
+    updateMeasureWindow=0.5, -- Optional, defaults to 0.5, changing this is unnecessary unless you really care about an accurate tickrate for some reason.
+    logMapped=true, -- Optional, defaults to true. If false, thread's lua memory and update rate won't be included in debug log map.
+    someParameter="scungus" -- Parameters for the scripts, all parameters are accessible using config.getParameter in the script contexts.
 }),
 ```
 
@@ -39,9 +40,26 @@ Stops and destroys a thread.
 
 ---
 
-#### `RpcPromise<Json>` threads.sendMessage(`String` threadName, `String` messageName, [`LuaValue` args...])
+#### `RpcThreadPromise<Json>` threads.sendMessage(`String` threadName, `String` messageName, [`LuaValue` args...])
 
 Sends a message to the given thread. Note that the return value from this is currently the only way to get data from the thread.
+
+---
+
+The following callback is only accessible on updateable scripts.
+This means everything **except** the following:
+- Command processor scripts, both server and client
+- Item aging scripts
+- Augment application scripts
+- Fireable item scripts
+
+---
+
+#### `void` threads.setMessageHandler(`String` messageName, `LuaFunction` handler)
+
+Messages of the specified message type sent by any thread will call the specified function.
+The function is passed the following arguments:
+    (`String` threadName, `String` message, `Json` args...)
 
 ---
 
@@ -55,9 +73,14 @@ They include:
  
 ---
 
-The `thread` table has only a single function.
+The `thread` table is accessible only in scriptable threads.
 
 #### `void` thread.stop()
 
 Stops the thread.
-This does not destroy the thread; the parent script still has to stop the thread itself to destroy it, so avoid using this too much as it can cause memory leaks.
+
+---
+
+#### `RpcThreadPromise<Json>` thread.sendParentMessage(`String` messageName, [`LuaValue` args...])
+
+Sends a message to the parent context.

--- a/source/base/StarWorldGeometry.hpp
+++ b/source/base/StarWorldGeometry.hpp
@@ -17,7 +17,7 @@ public:
   WorldGeometry(unsigned width, unsigned height);
   WorldGeometry(Vec2U const& size);
 
-  bool isNull();
+  bool isNull() const;
 
   bool operator==(WorldGeometry const& other) const;
   bool operator!=(WorldGeometry const& other) const;
@@ -130,7 +130,7 @@ inline WorldGeometry::WorldGeometry(unsigned width, unsigned height)
 inline WorldGeometry::WorldGeometry(Vec2U const& size)
   : m_size(size) {}
 
-inline bool WorldGeometry::isNull() {
+inline bool WorldGeometry::isNull() const {
   return m_size == Vec2U();
 }
 

--- a/source/game/scripting/StarLuaComponents.cpp
+++ b/source/game/scripting/StarLuaComponents.cpp
@@ -2,7 +2,6 @@
 #include "StarUtilityLuaBindings.hpp"
 #include "StarRootLuaBindings.hpp"
 #include "StarScriptableThread.hpp"
-#include "StarRpcThreadPromise.hpp"
 #include "StarLuaGameConverters.hpp"
 
 namespace Star {
@@ -10,7 +9,6 @@ namespace Star {
 LuaBaseComponent::LuaBaseComponent() {
   addCallbacks("sb", LuaBindings::makeUtilityCallbacks());
   addCallbacks("root", LuaBindings::makeRootCallbacks());
-  addCallbacks("threads", makeThreadsCallbacks());
   setAutoReInit(true);
 }
 
@@ -141,6 +139,10 @@ Maybe<LuaContext>& LuaBaseComponent::context() {
 void LuaBaseComponent::contextSetup() {
   m_context->setPath("self", m_context->createTable());
 
+  // set up here instead
+  if (!m_callbacks.contains("threads"))
+    addCallbacks("threads", makeThreadsCallbacks());
+  
   for (auto const& p : m_callbacks)
     m_context->setCallbacks(p.first, p.second);
 }
@@ -161,36 +163,62 @@ bool LuaBaseComponent::checkInitialization() {
   return initialized();
 }
 
+void LuaBaseComponent::cleanThreads() {
+  for (auto const& p : m_threads) {
+    if (p.second->shouldExpire()) {
+      m_threads.remove(p.first);
+    }
+  }
+}
+
 LuaCallbacks LuaBaseComponent::makeThreadsCallbacks() {
   LuaCallbacks callbacks;
   
   callbacks.registerCallback("create", [this](Json parameters) {
-    auto name = parameters.getString("name");
+    cleanThreads();
+    auto name = parameters.getString("name",Uuid().hex());
     if (m_threads.contains(name)) {
       m_threads.get(name)->stop();
       m_threads.remove(name);
     }
-    auto thread = make_shared<ScriptableThread>(parameters);
+    auto thread = make_shared<ScriptableThread>(parameters.set("name",name), this);
     thread->setPause(false);
     thread->start();
     m_threads.set(name,thread);
     return name;
   });
   callbacks.registerCallback("setPause", [this](String const& threadName, bool paused) {
+    if (m_threads.contains(threadName))
       m_threads.get(threadName)->setPause(paused);
   });
   callbacks.registerCallback("stop", [this](String const& threadName) {
+    if (m_threads.contains(threadName)) {
       m_threads.get(threadName)->stop();
       m_threads.remove(threadName);
+    }
+    cleanThreads();
   });
-  callbacks.registerCallback("sendMessage", [this](String const& threadName, String const& message, LuaVariadic<Json> args) {
+  callbacks.registerCallback("sendMessage", [this](String const& threadName, String const& message, LuaVariadic<Json> args) -> RpcThreadPromise<Json> {
+    if (!m_threads.contains(threadName))
+      return RpcThreadPromise<Json>::createFailed("Thread does not exist");
+    
+    auto thread = m_threads.get(threadName);
+    if (thread->shouldExpire())
+      return RpcThreadPromise<Json>::createFailed("Thread is stopped");
+    
     auto pair = RpcThreadPromise<Json>::createPair();
-    RecursiveMutexLocker locker(m_threadLock);
-    m_threads.get(threadName)->passMessage({ message, args, pair.second });
+    thread->passMessage({ message, JsonArray::from(std::move(args)), pair.second });
     return pair.first;
   });
   
   return callbacks;
+}
+
+RpcThreadPromise<Json> LuaBaseComponent::threadPassMessage(String const& thread, String const& message, JsonArray const& args) {
+  _unused(thread);
+  _unused(message);
+  _unused(args);
+  return RpcThreadPromise<Json>::createFailed("Lua component cannot handle messages");
 }
 
 }

--- a/source/game/scripting/StarLuaComponents.hpp
+++ b/source/game/scripting/StarLuaComponents.hpp
@@ -5,6 +5,7 @@
 #include "StarListener.hpp"
 #include "StarWorld.hpp"
 #include "StarWorldLuaBindings.hpp"
+#include "StarRpcThreadPromise.hpp"
 
 namespace Star {
 
@@ -84,6 +85,8 @@ public:
 
   Maybe<LuaContext> const& context() const;
   Maybe<LuaContext>& context();
+  
+  virtual RpcThreadPromise<Json> threadPassMessage(String const& thread, String const& message, JsonArray const& args);
 
 protected:
   virtual void contextSetup();
@@ -94,9 +97,11 @@ protected:
   // Checks the initialization state of the script, while also reloading the
   // script and clearing the error state if a root reload has occurred.
   bool checkInitialization();
-
+  
+  virtual LuaCallbacks makeThreadsCallbacks();
+  
+  void cleanThreads();
 private:
-  LuaCallbacks makeThreadsCallbacks();
   
   StringList m_scripts;
   StringMap<LuaCallbacks> m_callbacks;
@@ -105,8 +110,7 @@ private:
   Maybe<LuaContext> m_context;
   Maybe<String> m_error;
   
-  StringMap<shared_ptr<ScriptableThread>> m_threads;
-  mutable RecursiveMutex m_threadLock;
+  StringMap<ScriptableThreadPtr> m_threads;
 };
 
 // Wraps a basic lua component to add a persistent storage table translated
@@ -129,9 +133,19 @@ private:
 // rate.  Every call to 'update' here will only call the internal script
 // 'update' at the configured delta.  Adds a update tick controls under the
 // 'script' callback table.
+
+// Also allows scriptable threads to send messages back to parent context where they will be handled on update.
+
 template <typename Base>
 class LuaUpdatableComponent : public Base {
 public:
+  struct ThreadMessage {
+    String originThread;
+    String message;
+    JsonArray args;
+    RpcThreadPromiseKeeper<Json> promise;
+  };
+  
   LuaUpdatableComponent();
 
   unsigned updateDelta() const;
@@ -145,10 +159,26 @@ public:
 
   template <typename Ret = LuaValue, typename... V>
   Maybe<Ret> update(V&&... args);
+  
+  RpcThreadPromise<Json> threadPassMessage(String const& thread, String const& message, JsonArray const& args) override;
 
+protected:
+  virtual LuaCallbacks makeThreadsCallbacks() override;
 private:
+  Maybe<Json> handleThreadMessage(ThreadMessage const& message);
+  
   Periodic m_updatePeriodic;
   mutable float m_lastDt;
+  
+  List<ThreadMessage> m_threadMessages;
+  mutable RecursiveMutex m_threadMessageMutex;
+  
+  struct ThreadMessageHandler {
+    Maybe<LuaFunction> function;
+    String name;
+  };
+
+  StringMap<ThreadMessageHandler> m_threadMessageHandlers;
 };
 
 // Wraps a basic lua component so that world callbacks are added on init, and
@@ -290,11 +320,68 @@ bool LuaUpdatableComponent<Base>::updateReady() const {
 }
 
 template <typename Base>
-template <typename Ret, typename... V>
-Maybe<Ret> LuaUpdatableComponent<Base>::update(V&&... args) {
-  if (!m_updatePeriodic.tick())
+RpcThreadPromise<Json> LuaUpdatableComponent<Base>::threadPassMessage(String const& thread, String const& message, JsonArray const& args) {
+  auto pair = RpcThreadPromise<Json>::createPair();
+  RecursiveMutexLocker locker(m_threadMessageMutex);
+  m_threadMessages.append({thread,message,args,pair.second});
+  return pair.first;
+}
+
+template <typename Base>
+Maybe<Json> LuaUpdatableComponent<Base>::handleThreadMessage(ThreadMessage const& message) {
+  if (!Base::initialized())
     return {};
 
+  if (auto handler = m_threadMessageHandlers.ptr(message.message)) {
+    try {
+      return handler->function->template invoke<Json>(message.originThread, message.message, luaUnpack(message.args));
+    } catch (LuaException const& e) {
+      Logger::error(
+          "Exception while invoking lua thread message handler for message '{}'. {}", message.message, outputException(e, true));
+      Base::setError(String(printException(e, false)));
+    }
+  }
+  return {};
+}
+
+template <typename Base>
+LuaCallbacks LuaUpdatableComponent<Base>::makeThreadsCallbacks() {
+  auto callbacks = Base::makeThreadsCallbacks();
+  
+  callbacks.registerCallback("setMessageHandler", [this](String message, Maybe<LuaFunction> handler) {
+    if (handler) {
+      ThreadMessageHandler handlerInfo = {};
+      handlerInfo.name = message;
+      handlerInfo.function.emplace(handler.take());
+      m_threadMessageHandlers.set(handlerInfo.name, handlerInfo);
+    }
+    else
+      m_threadMessageHandlers.remove(message);
+  });
+  
+  return callbacks;
+}
+
+template <typename Base>
+template <typename Ret, typename... V>
+Maybe<Ret> LuaUpdatableComponent<Base>::update(V&&... args) {
+  List<ThreadMessage> messages;
+  {
+    RecursiveMutexLocker locker(m_threadMessageMutex);
+    messages = std::move(m_threadMessages);
+  }
+  for (auto& message : messages) {
+    if (auto resp = handleThreadMessage(message))
+      message.promise.fulfill(*resp);
+    else
+      message.promise.fail("Message not handled");
+  }
+  
+  if (!m_updatePeriodic.tick())
+    return {};
+  
+  Base::cleanThreads();
+  
   return Base::template invoke<Ret>("update", std::forward<V>(args)...);
 }
 

--- a/source/game/scripting/StarScriptableThread.cpp
+++ b/source/game/scripting/StarScriptableThread.cpp
@@ -1,6 +1,5 @@
 #include "StarScriptableThread.hpp"
 #include "StarLuaRoot.hpp"
-#include "StarLuaComponents.hpp"
 #include "StarConfigLuaBindings.hpp"
 #include "StarTickRateMonitor.hpp"
 #include "StarNpc.hpp"
@@ -11,16 +10,18 @@
 
 namespace Star {
 
-ScriptableThread::ScriptableThread(Json parameters)
+ScriptableThread::ScriptableThread(Json parameters, LuaBaseComponent* parent)
   : Thread("ScriptableThread: " + parameters.getString("name")),
     m_parameters(std::move(parameters)),
     m_stop(false),
     m_errorOccurred(false),
-    m_shouldExpire(true) {
+    m_shouldExpire(false),
+    m_parent(parent) {
       m_luaRoot = make_shared<LuaRoot>();
       m_luaRoot->luaEngine().setNullTerminated(false);
       m_luaRoot->tuneAutoGarbageCollection(m_parameters.getFloat("luaGcPause",1.2), m_parameters.getFloat("luaGcStepMultiplier",1.2));
       m_name = m_parameters.getString("name");
+      m_logMapped = m_parameters.getBool("logMapped",true);
       
       m_timestep = 1.0f / m_parameters.getFloat("tickRate",60.0f);
       
@@ -84,7 +85,8 @@ void ScriptableThread::run() {
     TickRateApproacher tickApproacher(1.0f / m_timestep, updateMeasureWindow);
 
     while (!m_stop && !m_errorOccurred) {
-      LogMap::set(strf("lua_{}_update", m_name), strf("{:4.2f}Hz", tickApproacher.rate()));
+      if (m_logMapped)
+        LogMap::set(strf("lua_{}_update", m_name), strf("{:4.2f}Hz", tickApproacher.rate()));
 
       update();
       tickApproacher.setTargetTickRate(1.0f / m_timestep);
@@ -134,7 +136,8 @@ void ScriptableThread::update() {
     else
       message.promise.fail("Message not handled by thread");
   }
-  LogMap::set(strf("lua_{}_lua_mem", m_name), m_luaRoot->luaMemoryUsage());
+  if (m_logMapped)
+    LogMap::set(strf("lua_{}_lua_mem", m_name), m_luaRoot->luaMemoryUsage());
 }
 
 LuaCallbacks ScriptableThread::makeThreadCallbacks() {
@@ -142,6 +145,11 @@ LuaCallbacks ScriptableThread::makeThreadCallbacks() {
 
   callbacks.registerCallback("stop", [this]() {
       m_stop = true;
+      m_shouldExpire = true;
+    });
+
+  callbacks.registerCallback("sendParentMessage", [this](String const& message, LuaVariadic<Json> args) {
+      return m_parent->threadPassMessage(m_name, message, JsonArray::from(std::move(args)));
     });
 
   return callbacks;

--- a/source/game/scripting/StarScriptableThread.hpp
+++ b/source/game/scripting/StarScriptableThread.hpp
@@ -23,7 +23,7 @@ public:
   typedef LuaMessageHandlingComponent<LuaUpdatableComponent<LuaBaseComponent>> ScriptComponent;
   typedef shared_ptr<ScriptComponent> ScriptComponentPtr;
 
-  ScriptableThread(Json parameters);
+  ScriptableThread(Json parameters, LuaBaseComponent* parent);
   ~ScriptableThread();
 
   void start();
@@ -53,6 +53,8 @@ private:
   
   Json m_parameters;
   String m_name;
+  // log mapping can be disabled on scriptable threads to reduce debug clutter
+  bool m_logMapped;
   
   float m_timestep;
 
@@ -63,6 +65,8 @@ private:
   atomic<bool> m_pause;
   mutable atomic<bool> m_errorOccurred;
   mutable atomic<bool> m_shouldExpire;
+  
+  LuaBaseComponent* m_parent;
   
   LuaCallbacks makeThreadCallbacks();
   Json configValue(String const& name, Json def) const;


### PR DESCRIPTION
adds `threads.setMessageHandler` for updateable scripts and `thread.sendParentMessage` for scriptable threads
this allows threads to send messages back to their parent thread

also includes some other minor internal improvements