### PR TITLE
don't save celestial chunks unless they're visited

### DIFF
--- a/source/game/StarCelestialDatabase.cpp
+++ b/source/game/StarCelestialDatabase.cpp
@@ -58,6 +58,8 @@ CelestialMasterDatabase::CelestialMasterDatabase(Maybe<String> databaseFile) {
   auto assets = Root::singleton().assets();
 
   auto config = assets->json("/celestial.config");
+  
+  m_chunksAlwaysPersistent = config.getBool("saveAllChunks",false);
 
   m_baseInformation.planetOrbitalLevels = config.getInt("planetOrbitalLevels");
   m_baseInformation.satelliteOrbitalLevels = config.getInt("satelliteOrbitalLevels");
@@ -359,7 +361,7 @@ void CelestialMasterDatabase::updateParameters(CelestialCoordinate const& coordi
     updated = true;
   }
 
-  if (updated && m_database.isOpen()) {
+  if (updated && chunk.persistent && m_database.isOpen()) {
     auto versioningDatabase = Root::singleton().versioningDatabase();
     auto versionedChunk = versioningDatabase->makeCurrentVersionedJson("CelestialChunk", chunk.toJson());
     DataStreamBuffer ds;
@@ -383,6 +385,26 @@ Maybe<CelestialOrbitRegion> CelestialMasterDatabase::orbitRegion(
       return region;
   }
   return {};
+}
+
+void CelestialMasterDatabase::markPersistent(CelestialCoordinate const& coordinate) {
+  RecursiveMutexLocker locker(m_mutex);
+
+  auto chunkIndex = chunkIndexFor(coordinate);
+  auto chunk = getChunk(chunkIndex);
+  if (chunk.persistent) {
+    // chunk is already considered persistent and is in the database
+    return;
+  }
+  if (m_database.isOpen()) {
+    auto versioningDatabase = Root::singleton().versioningDatabase();
+    auto versionedChunk = versioningDatabase->makeCurrentVersionedJson("CelestialChunk", chunk.toJson());
+    DataStreamBuffer ds;
+    ds.write(versionedChunk);
+    VersionedJson::writeSubVersioning(ds, versionedChunk);
+    m_database.insert(DataStreamBuffer::serialize(chunkIndex), compressData(ds.data()));
+    chunk.persistent = true;
+  }
 }
 
 CelestialChunk const& CelestialMasterDatabase::getChunk(Vec2I const& chunkIndex, UnlockDuringFunction unlockDuring) {
@@ -409,12 +431,16 @@ CelestialChunk const& CelestialMasterDatabase::getChunk(Vec2I const& chunkIndex,
         unlockDuring(producer);
       else
         producer();
-      if (m_database.isOpen()) {
-        auto versionedChunk = versioningDatabase->makeCurrentVersionedJson("CelestialChunk", newChunk.toJson());
-        DataStreamBuffer ds;
-        ds.write(versionedChunk);
-        VersionedJson::writeSubVersioning(ds, versionedChunk);
-        m_database.insert(DataStreamBuffer::serialize(chunkIndex), compressData(ds.data()));
+    
+      if (m_chunksAlwaysPersistent) {
+        if (m_database.isOpen()) {
+          auto versionedChunk = versioningDatabase->makeCurrentVersionedJson("CelestialChunk", newChunk.toJson());
+          DataStreamBuffer ds;
+          ds.write(versionedChunk);
+          VersionedJson::writeSubVersioning(ds, versionedChunk);
+          m_database.insert(DataStreamBuffer::serialize(chunkIndex), compressData(ds.data()));
+          newChunk.persistent = true;
+        }
       }
 
       return newChunk;

--- a/source/game/StarCelestialDatabase.hpp
+++ b/source/game/StarCelestialDatabase.hpp
@@ -106,6 +106,8 @@ public:
 
   // overwrite the celestial parameters for the world at the given celestial coordinate
   void updateParameters(CelestialCoordinate const& coordinate, CelestialParameters const& parameters);
+  
+  void markPersistent(CelestialCoordinate const& coordinate);
 
 protected:
   struct SatelliteType {
@@ -171,6 +173,8 @@ protected:
       RandomSource& random, List<Vec2I> const& constellationCandidates) const;
 
   GenerationInformation m_generationInformation;
+  
+  bool m_chunksAlwaysPersistent = false;
 
   mutable RecursiveMutex m_mutex;
 

--- a/source/game/StarCelestialTypes.cpp
+++ b/source/game/StarCelestialTypes.cpp
@@ -43,6 +43,8 @@ DataStream& operator<<(DataStream& ds, CelestialSystemObjects const& systemObjec
 CelestialChunk::CelestialChunk() {}
 
 CelestialChunk::CelestialChunk(Json const& store) {
+  persistent = true;
+  
   chunkIndex = jsonToVec2I(store.get("chunkIndex"));
 
   for (auto const& lines : store.getArray("constellations")) {

--- a/source/game/StarCelestialTypes.hpp
+++ b/source/game/StarCelestialTypes.hpp
@@ -49,6 +49,9 @@ struct CelestialChunk {
   // can be two phases of loading, one for basic system-level parameters for an
   // entire chunk the other for each set of sub objects for each system.
   HashMap<Vec3I, HashMap<int, CelestialPlanet>> systemObjects;
+  
+  // only persistent chunks are saved to storage
+  bool persistent = false;
 };
 DataStream& operator>>(DataStream& ds, CelestialChunk& chunk);
 DataStream& operator<<(DataStream& ds, CelestialChunk const& chunk);

--- a/source/game/StarUniverseServer.cpp
+++ b/source/game/StarUniverseServer.cpp
@@ -2610,6 +2610,7 @@ Maybe<UniverseServer::WorldServerPromise> UniverseServer::celestialWorldPromise(
       Logger::info("UniverseServer: Creating celestial world {}", celestialWorldId);
       auto worldTemplate = make_shared<WorldTemplate>(celestialWorldId, celestialDatabase);
       worldServer = make_shared<WorldServer>(worldTemplate, File::open(storageFile, IOMode::ReadWrite | IOMode::Truncate));
+      m_celestialDatabase->markPersistent(celestialWorldId);
     }
 
     worldServer->setUniverseSettings(m_universeSettings);
@@ -2937,6 +2938,7 @@ SystemWorldServerThreadPtr UniverseServer::createSystemWorld(Vec3I const& locati
     if (!loadedFromStorage) {
       Logger::info("UniverseServer: Creating new system world at location {}", location);
       systemWorld = make_shared<SystemWorldServer>(location, m_universeClock, m_celestialDatabase);
+      m_celestialDatabase->markPersistent(CelestialCoordinate(location));
     }
 
     auto systemThread = make_shared<SystemWorldServerThread>(location, systemWorld, storageFile);


### PR DESCRIPTION
this significantly reduces the rate that universe.chunks grows in size, at the cost of stars being a bit slow to reload later

also means you don't have to search as far to find modded stars/planets after adding a mod that adds stars/planets

this does not fix the size of an existing universe.chunks as those chunks are already saved