### PR TITLE
Windows: improve EXE manifest and resource setup

### DIFF
--- a/source/client/CMakeLists.txt
+++ b/source/client/CMakeLists.txt
@@ -23,6 +23,7 @@ SET (star_client_SOURCES
 IF (STAR_SYSTEM_WINDOWS)
   SET (star_client_RESOURCES
       starbound.rc
+      starbound.exe.manifest
     )
 ENDIF ()
 

--- a/source/client/starbound.exe.manifest
+++ b/source/client/starbound.exe.manifest
@@ -6,13 +6,28 @@
               <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
           </requestedPrivileges>
       </security>
-  </trustInfo>
-  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1"> 
-    <application> 
-      <!--Windows 7--> 
-      <supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}"/> 
-      <!--Windows Vista--> 
-      <supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}"/> 
-    </application> 
-  </compatibility>     
+  </trustInfo>   
+<application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+        <printerDriverIsolation xmlns="http://schemas.microsoft.com/SMI/2011/WindowsSettings">true</printerDriverIsolation>
+        <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+        <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
+
+        <!-- SDL handles DPI stuff for us but nice to have a fallback here anyways -->
+        <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+        <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+    </windowsSettings>
+</application>
+<dependency>
+    <dependentAssembly>
+        <assemblyIdentity
+            type="win32"
+            name="Microsoft.Windows.Common-Controls"
+            version="6.0.0.0"
+            processorArchitecture="*"
+            publicKeyToken="6595b64144ccf1df"
+            language="*"
+        />
+    </dependentAssembly>
+</dependency>
 </assembly>

--- a/source/client/starbound.rc
+++ b/source/client/starbound.rc
@@ -13,7 +13,7 @@ BEGIN
       VALUE "LegalCopyright", "Chucklefish LTD"
       VALUE "OriginalFilename", "starbound.exe"
       VALUE "ProductName", "OpenStarbound"
-      VALUE "ProductVersion", "1.0"
+      VALUE "ProductVersion", "1.4.4"
     END
   END
 
@@ -23,3 +23,4 @@ BEGIN
   END
 END
 icon ICON "openstarbound.ico"
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "starbound.exe.manifest"

--- a/source/server/CMakeLists.txt
+++ b/source/server/CMakeLists.txt
@@ -22,6 +22,7 @@ SET (star_server_SOURCES
 IF (STAR_SYSTEM_WINDOWS)
   SET (star_server_RESOURCES
       starbound_server.rc
+      starbound_server.exe.manifest
     )
 ENDIF ()
 

--- a/source/server/starbound_server.exe.manifest
+++ b/source/server/starbound_server.exe.manifest
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
+      <security>
+          <requestedPrivileges>
+              <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+          </requestedPrivileges>
+      </security>
+  </trustInfo>   
+<application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+        <printerDriverIsolation xmlns="http://schemas.microsoft.com/SMI/2011/WindowsSettings">true</printerDriverIsolation>
+        <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+        <heapType xmlns="http://schemas.microsoft.com/SMI/2020/WindowsSettings">SegmentHeap</heapType>
+
+        <!-- SDL handles DPI stuff for us but nice to have a fallback here anyways -->
+        <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+        <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
+    </windowsSettings>
+</application>
+<dependency>
+    <dependentAssembly>
+        <assemblyIdentity
+            type="win32"
+            name="Microsoft.Windows.Common-Controls"
+            version="6.0.0.0"
+            processorArchitecture="*"
+            publicKeyToken="6595b64144ccf1df"
+            language="*"
+        />
+    </dependentAssembly>
+</dependency>
+</assembly>

--- a/source/server/starbound_server.rc
+++ b/source/server/starbound_server.rc
@@ -13,7 +13,7 @@ BEGIN
       VALUE "LegalCopyright", "Chucklefish LTD"
       VALUE "OriginalFilename", "starbound_server.exe"
       VALUE "ProductName", "OpenStarbound Server"
-      VALUE "ProductVersion", "1.0"
+      VALUE "ProductVersion", "1.4.4"
     END
   END
 
@@ -23,3 +23,4 @@ BEGIN
   END
 END
 icon ICON "openstarbound_server.ico"
+CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "starbound_server.exe.manifest"


### PR DESCRIPTION
- Fix custom provided manifest going unused (both CMake and standalone rc usage).
- Add manifest for server binary.
- Long path awareness so the game can handle it instead of getting a crash/error when given one (as long as the user has Windows opted-in).
- use Segment Heaps when available instead of NT Heaps (kinda superfluous since Starbound does not allocate using the Windows heap system).
- DPI awareness fallback for if either somehow SDL doesn't do it's job or gets replaced in the future.
- Update product version string from "1.0" to "1.4.4".
- use Common Control(s) V6 so that the operating system provided popup windows/errors use modern theming.
- Printer Driver Isolation so in that the 0.02% chance the game/engine is ever instructed through whatever means to print then a unstable printer driver can't cause the game to crash (this is pretty much a useless change but it's harmless so why not).
- Removed unneeded "compatibility" info from manifest (it was outdated anyways).



To be clear all of this was directly tested (for the client at least though some of these are server relevant such as long path awareness) with the sole exception being "Printer Driver Isolation" (since the game doesn't send commands to physical printers ofc), however this is fine since I have confirmed in multiple unrelated applications that such a thing does indeed function when relevant without causing issues.