### PR TITLE
Fast fix for layered weather system related dungeon npc generation crash

### DIFF
--- a/source/game/StarWorldServer.cpp
+++ b/source/game/StarWorldServer.cpp
@@ -1512,6 +1512,11 @@ void WorldServer::init(bool firstTime) {
 
   m_sky = make_shared<Sky>(m_worldTemplate->skyParameters(), false);
 
+  // Entity scripts can query weather while initial dungeons and regions are
+  // still being generated, before the configured weather domains are set up.
+  // Keep a valid weatherless fallback available throughout initialization.
+  m_emptyWeather = make_shared<ServerWeather>();
+
   m_lightIntensityCalculator.setParameters(assets->json("/lighting.config:intensity"));
 
   m_entityMessageResponses = {};


### PR DESCRIPTION
Basically, since layered weather initialises slightly later in world gen, during dungeon generation, some NPCs that query weather find that it does not exist, causing a crash. This quick fix creates a temporary empty weather object for the NPCs and other items that require it to query so dungeon gen doesn't crash while we wait for layered weather to get generated. Bandaid fix while I look for a better solution.