### PR TITLE
universe server and celestial server bindings for commandprocessor/universe server/world server scripts

### DIFF
--- a/doc/lua/openstarbound/threads.md
+++ b/doc/lua/openstarbound/threads.md
@@ -67,9 +67,13 @@ Threads have simple updateable scripts with access to only a few tables.
 They include:
  - the basic tables all scripts have access to (including `threads`)
  - `updateablescript` bindings
- - `message`
+ - `message`, for handling thread messages
  - `config`
  - `thread`
+
+They may include additional bindings depending on what script context created them.
+- `universe` on server universe/world scripts
+- `celestial` on server universe/world scripts
  
 ---
 

--- a/source/game/StarCommandProcessor.cpp
+++ b/source/game/StarCommandProcessor.cpp
@@ -35,6 +35,8 @@ CommandProcessor::CommandProcessor(UniverseServer* universe)
   m_luaRoot->tuneAutoGarbageCollection(universeConfig.getFloat("luaGcPause"), universeConfig.getFloat("luaGcStepMultiplier"));
   m_scriptComponent.addCallbacks("universe", LuaBindings::makeUniverseServerCallbacks(m_universe));
   m_scriptComponent.addCallbacks("celestial", LuaBindings::makeCelestialCallbacks(m_universe));
+  m_scriptComponent.addThreadCallbacks("universe", LuaBindings::makeUniverseServerCallbacks(m_universe));
+  m_scriptComponent.addThreadCallbacks("celestial", LuaBindings::makeCelestialCallbacks(m_universe));
   m_scriptComponent.addCallbacks("CommandProcessor", makeCommandCallbacks());
   m_scriptComponent.setScripts(jsonToStringList(universeConfig.get("commandProcessorScripts")));
   m_luaRoot->luaEngine().setNullTerminated(false);

--- a/source/game/StarUniverseServer.cpp
+++ b/source/game/StarUniverseServer.cpp
@@ -2982,6 +2982,8 @@ void UniverseServer::startLuaScripts() {
     scriptComponent->setLuaRoot(m_luaRoot);
     scriptComponent->addCallbacks("universe", LuaBindings::makeUniverseServerCallbacks(this));
     scriptComponent->addCallbacks("celestial", LuaBindings::makeCelestialCallbacks(this));
+    scriptComponent->addThreadCallbacks("universe", LuaBindings::makeUniverseServerCallbacks(this));
+    scriptComponent->addThreadCallbacks("celestial", LuaBindings::makeCelestialCallbacks(this));
     scriptComponent->setScripts(jsonToStringList(p.second.toArray()));
 
     m_scriptContexts.set(p.first, scriptComponent);

--- a/source/game/StarWorldServer.cpp
+++ b/source/game/StarWorldServer.cpp
@@ -169,6 +169,8 @@ void WorldServer::initLua(UniverseServer* universe) {
   for (auto& p : assets->json("/worldserver.config:scriptContexts").toObject()) {
     auto scriptComponent = make_shared<ScriptComponent>();
     scriptComponent->setScripts(jsonToStringList(p.second.toArray()));
+    scriptComponent->addThreadCallbacks("universe", LuaBindings::makeUniverseServerCallbacks(universe));
+    scriptComponent->addThreadCallbacks("celestial", LuaBindings::makeCelestialCallbacks(universe));
 
     m_scriptContexts.set(p.first, scriptComponent);
     scriptComponent->init(this);

--- a/source/game/scripting/StarLuaComponents.cpp
+++ b/source/game/scripting/StarLuaComponents.cpp
@@ -47,6 +47,25 @@ bool LuaBaseComponent::removeCallbacks(String const& groupName) {
   return false;
 }
 
+void LuaBaseComponent::addThreadCallbacks(String groupName, LuaCallbacks callbacks) {
+  if (!m_threadCallbacks.insert(groupName, callbacks).second)
+    throw LuaComponentException::format("Duplicate thread callbacks named '{}' in LuaBaseComponent", groupName);
+
+  for (auto const& p : m_threads) {
+    p.second->addCallbacks(groupName,callbacks);
+  }
+}
+
+bool LuaBaseComponent::removeThreadCallbacks(String const& groupName) {
+  if (m_threadCallbacks.remove(groupName)) {
+    for (auto const& p : m_threads) {
+      p.second->removeCallbacks(groupName);
+    }
+    return true;
+  }
+  return false;
+}
+
 bool LuaBaseComponent::autoReInit() const {
   return (bool)m_reloadTracker;
 }
@@ -181,6 +200,10 @@ LuaCallbacks LuaBaseComponent::makeThreadsCallbacks() {
       m_threads.remove(name);
     }
     auto thread = make_shared<ScriptableThread>(parameters.set("name",name), this);
+    
+    for (auto const& callbackPair : m_threadCallbacks)
+      thread->addCallbacks(callbackPair.first, callbackPair.second);
+    
     thread->setPause(false);
     thread->start();
     m_threads.set(name,thread);

--- a/source/game/scripting/StarLuaComponents.hpp
+++ b/source/game/scripting/StarLuaComponents.hpp
@@ -52,6 +52,10 @@ public:
 
   void addCallbacks(String groupName, LuaCallbacks callbacks);
   bool removeCallbacks(String const& groupName);
+  
+  // Allows adding callbacks that are also accessible to threads made by this context. The callbacks must be thread safe.
+  void addThreadCallbacks(String groupName, LuaCallbacks callbacks);
+  bool removeThreadCallbacks(String const& groupName);
 
   // If true, component will automatically uninit and re-init when root is
   // reloaded.
@@ -106,6 +110,7 @@ private:
   
   StringList m_scripts;
   StringMap<LuaCallbacks> m_callbacks;
+  StringMap<LuaCallbacks> m_threadCallbacks;
   LuaRootPtr m_luaRoot;
   TrackerListenerPtr m_reloadTracker;
   Maybe<LuaContext> m_context;

--- a/source/game/scripting/StarScriptableThread.cpp
+++ b/source/game/scripting/StarScriptableThread.cpp
@@ -32,15 +32,6 @@ ScriptableThread::ScriptableThread(Json parameters, LuaBaseComponent* parent)
       m_luaRoot->addCallbacks("thread", makeThreadCallbacks());
       m_luaRoot->addCallbacks(
           "config", LuaBindings::makeConfigCallbacks(bind(&ScriptableThread::configValue, this, _1, _2)));
-      
-      for (auto& p : m_parameters.getObject("scripts")) {
-        auto scriptComponent = make_shared<ScriptComponent>();
-        scriptComponent->setLuaRoot(m_luaRoot);
-        scriptComponent->setScripts(jsonToStringList(p.second.toArray()));
-
-        m_scriptContexts.set(p.first, scriptComponent);
-        scriptComponent->init();
-      }
 }
 
 ScriptableThread::~ScriptableThread() {
@@ -49,6 +40,23 @@ ScriptableThread::~ScriptableThread() {
   m_scriptContexts.clear();
   
   join();
+}
+
+void ScriptableThread::addCallbacks(String const& groupName, LuaCallbacks const& callbacks) {
+  if (m_threadCallbacks.insert(groupName, callbacks).second) {
+    for (auto const& p : m_scriptContexts) {
+      p.second->addCallbacks(groupName,callbacks);
+      p.second->addThreadCallbacks(groupName,callbacks);
+    }
+  }
+}
+void ScriptableThread::removeCallbacks(String const& groupName) {
+  if (m_threadCallbacks.remove(groupName)) {
+    for (auto const& p : m_scriptContexts) {
+      p.second->removeCallbacks(groupName);
+      p.second->removeThreadCallbacks(groupName);
+    }
+  }
 }
 
 void ScriptableThread::start() {
@@ -81,6 +89,20 @@ void ScriptableThread::passMessage(Message&& message) {
 
 void ScriptableThread::run() {
   try {
+    for (auto& p : m_parameters.getObject("scripts")) {
+      auto scriptComponent = make_shared<ScriptComponent>();
+      scriptComponent->setLuaRoot(m_luaRoot);
+      scriptComponent->setScripts(jsonToStringList(p.second.toArray()));
+      
+      for (auto const& callbackPair : m_threadCallbacks) {
+        scriptComponent->addCallbacks(callbackPair.first, callbackPair.second);
+        scriptComponent->addThreadCallbacks(callbackPair.first, callbackPair.second);
+      }
+
+      m_scriptContexts.set(p.first, scriptComponent);
+      scriptComponent->init();
+    }
+    
     double updateMeasureWindow = m_parameters.getDouble("updateMeasureWindow",0.5);
     TickRateApproacher tickApproacher(1.0f / m_timestep, updateMeasureWindow);
 

--- a/source/game/scripting/StarScriptableThread.hpp
+++ b/source/game/scripting/StarScriptableThread.hpp
@@ -38,6 +38,10 @@ public:
 
   // 
   void passMessage(Message&& message);
+  
+  // expected to be run before the thread is started or after it is stopped!
+  void addCallbacks(String const& groupName, LuaCallbacks const& callbacks);
+  void removeCallbacks(String const& groupName);
 
 protected:
   virtual void run();
@@ -67,6 +71,8 @@ private:
   mutable atomic<bool> m_shouldExpire;
   
   LuaBaseComponent* m_parent;
+  
+  StringMap<LuaCallbacks> m_threadCallbacks;
   
   LuaCallbacks makeThreadCallbacks();
   Json configValue(String const& name, Json def) const;


### PR DESCRIPTION
This allows scriptable threads made in those contexts to access `universe` and `celestial`. This is recursive, so threads made by those threads can also access these tables.

The `addThreadCallbacks` method on Lua components is what handles this. It should only be used with thread safe callbacks like the aforementioned `universe` and `celestial`.

I'll probably make thread safe versions of more tables later.