### PR TITLE
Lua: apply Loop Overflow Bug Fix patch

### DIFF
--- a/source/extern/lua/lvm.c
+++ b/source/extern/lua/lvm.c
@@ -796,6 +796,11 @@ void luaV_finishOp (lua_State *L) {
     Protect(luaV_finishset(L,t,k,v,slot)); }
 
 
+/* to check step magnitude edge case in floating point for loops */
+#define forstepcheck(ns,ni,nl)  \
+          (luai_numeq(ni, luai_numadd(L, ni, ns)) ||  \
+           luai_numeq(nl, luai_numsub(L, nl, ns)))
+
 
 void luaV_execute (lua_State *L) {
   CallInfo *ci = L->ci;
@@ -1207,21 +1212,25 @@ void luaV_execute (lua_State *L) {
       vmcase(OP_FORLOOP) {
         if (ttisinteger(ra)) {  /* integer loop? */
           lua_Integer step = ivalue(ra + 2);
-          lua_Integer idx = intop(+, ivalue(ra), step); /* increment index */
+          lua_Integer idx = ivalue(ra);
           lua_Integer limit = ivalue(ra + 1);
-          if ((0 < step) ? (idx <= limit) : (limit <= idx)) {
+          if (0 < step ? l_castS2U( step) <= uintop(-, limit, idx)
+                       : l_castS2U(-step) <= uintop(-, idx, limit)) {
             ci->u.l.savedpc += GETARG_sBx(i);  /* jump back */
+            idx = intop(+, idx, step);  /* increment index */
             chgivalue(ra, idx);  /* update internal index... */
             setivalue(ra + 3, idx);  /* ...and external index */
           }
         }
         else {  /* floating loop */
           lua_Number step = fltvalue(ra + 2);
-          lua_Number idx = luai_numadd(L, fltvalue(ra), step); /* inc. index */
+          lua_Number idx = fltvalue(ra);
           lua_Number limit = fltvalue(ra + 1);
-          if (luai_numlt(0, step) ? luai_numle(idx, limit)
-                                  : luai_numle(limit, idx)) {
+          if (luai_numlt(0, step)
+                ? luai_numle( step, luai_numsub(L, limit, idx))
+                : luai_numle(-step, luai_numsub(L, idx, limit))) {
             ci->u.l.savedpc += GETARG_sBx(i);  /* jump back */
+            idx = luai_numadd(L, idx, step);  /* increment index */
             chgfltvalue(ra, idx);  /* update internal index... */
             setfltvalue(ra + 3, idx);  /* ...and external index */
           }
@@ -1232,14 +1241,19 @@ void luaV_execute (lua_State *L) {
         TValue *init = ra;
         TValue *plimit = ra + 1;
         TValue *pstep = ra + 2;
+        TValue *xinit = ra + 3;
         lua_Integer ilimit;
-        int stopnow;
+        int stopnow = 0;
         if (ttisinteger(init) && ttisinteger(pstep) &&
             forlimit(plimit, &ilimit, ivalue(pstep), &stopnow)) {
           /* all values are integer */
-          lua_Integer initv = (stopnow ? 0 : ivalue(init));
+          lua_Integer initv = ivalue(init);
+          lua_Integer istep = ivalue(pstep);
           setivalue(plimit, ilimit);
-          setivalue(init, intop(-, initv, ivalue(pstep)));
+          setivalue(init, initv);
+          setivalue(xinit, initv);
+          stopnow = (stopnow || (0 < istep ? ilimit < initv
+                                           : initv < ilimit));
         }
         else {  /* try making all values floats */
           lua_Number ninit; lua_Number nlimit; lua_Number nstep;
@@ -1251,9 +1265,17 @@ void luaV_execute (lua_State *L) {
           setfltvalue(pstep, nstep);
           if (!tonumber(init, &ninit))
             luaG_runerror(L, "'for' initial value must be a number");
-          setfltvalue(init, luai_numsub(L, ninit, nstep));
+          if (0 < nstep ? forstepcheck( nstep, ninit, nlimit)
+                        : forstepcheck(-nstep, nlimit, ninit))
+            luaG_runerror(L, "'for' step magnitude too small");
+          setfltvalue(init, ninit);
+          setfltvalue(xinit, ninit);
+          stopnow = (stopnow || (luai_numlt(0, nstep)
+                                   ? luai_numlt(nlimit, ninit)
+                                   : luai_numlt(ninit, nlimit)));
         }
-        ci->u.l.savedpc += GETARG_sBx(i);
+        if (stopnow)
+          ci->u.l.savedpc += GETARG_sBx(i) + 1;  /* no iterations; skip loop */
         vmbreak;
       }
       vmcase(OP_TFORCALL) {

--- a/source/extern/lua/lvm.h
+++ b/source/extern/lua/lvm.h
@@ -43,7 +43,8 @@
 #define tointeger(o,i) \
     (ttisinteger(o) ? (*(i) = ivalue(o), 1) : luaV_tointeger(o,i,LUA_FLOORN2I))
 
-#define intop(op,v1,v2) l_castU2S(l_castS2U(v1) op l_castS2U(v2))
+#define uintop(op,v1,v2) (l_castS2U(v1) op l_castS2U(v2))
+#define intop(op,v1,v2) l_castU2S(uintop(op,v1,v2))
 
 #define luaV_rawequalobj(t1,t2)		luaV_equalobj(NULL,t1,t2)
 


### PR DESCRIPTION
directly from http://lua-users.org/lists/lua-l/2017-11/msg00082.html

This fixes quite few edge cases of overflows of large integers with loops (which which could cause code to run for an absurdly long time and chew memory) and also prevents allowing some floating point based infinite loops.
newer versions of PUC Lua have some of these issues partially fixed already (some of the code even directly matches this patch) however we are using PUC Lua 5.3 (first major version of Lua with native integers) which has pretty much none of these cases handled without this patch.


(tested standalone outside of the game to be clear) Results of the `"loopfix-test.lua"`:
- Vanilla Lua 5.3.6 gets stuck at the first part of the test continuously growing gigabytes upon gigabytes of memory for a long time (test had to be stopped due to running out of system memory).
- Patched Lua 5.3.6 (this PR) passes all the tests almost instantly.
- Lua 5.5.1 passes a little under half the tests then gets stuck for around 14 minutes using quite a few gigabytes of memory before giving a table overflow exception.

[lua-loopfix-test.zip](https://github.com/user-attachments/files/31903537/lua-loopfix-test.zip) (compressed copy of "`loopfix-test.lua`" in case it isn't accessible from the mailing list link. for standalone testing.)
<details>
<summary>Lua 5.5.1 results for anyone wondering</summary>

```
A1D: 3 = 3
A1F: 3 = 3
A2D: 5 = 5
A2F: 5 = 5
A3F: 5 = 5
A4D: 1 = 1
A5D: 1 = 1
A6D: 11 = 11
A6F: lua: loopfix-test.lua:11: table overflow
stack traceback:
        loopfix-test.lua:11: in upvalue 'testloop'
        loopfix-test.lua:23: in local 'testboth'
        loopfix-test.lua:41: in main chunk
        [C]: in ?
```

</details>



One other detail to point out is that this patch slows down loops by a pretty negligible amount which seems like a fine tradeoff.