### PR TITLE
universe messages, expose some thread-safe universe client methods to other threads

### DIFF
--- a/doc/lua/openstarbound/universe.md
+++ b/doc/lua/openstarbound/universe.md
@@ -2,6 +2,24 @@
 
 Server-side and client-side scripts gain access to a `universe` table that exposes helpers for worlds, as well as administrative helpers for connected clients on server-side scripts.
 
+---
+
+#### `ConnectionId` universe.connectionId()
+
+Returns the universe's connection id. For server universes this is always 0.
+
+---
+
+#### `RpcPromise<Json>` universe.sendUniverseMessage(`ConnectionId` connection, `String` messageName, [`Json` args ...])
+
+Sends a message to the given connectionId's universe.
+
+---
+
+#### `RpcPromise<Json>` universe.sendOwnUniverseMessage(`String` messageName, [`Json` args ...])
+
+Sends a message to the main UniverseClient on clientside or UniverseServer on serverside. Useful for threads communicating with the primary universe thread.
+
 --- 
 
 The following callbacks are only available in contexts that run on the server (such as world scripts or the command
@@ -145,7 +163,13 @@ Otherwise, functionally similar to `universe.createCustomWorld`.
 
 ---
 
-The following functions are available on all scripts on the client main thread.
+The following functions are available on all scripts on the client main thread, all scripts in subworlds, and all scriptable threads made by world contexts and universe client contexts.
+
+---
+
+#### `RpcPromise<Json>` universe.sendServerUniverseMessage(`String` messageName, [`Json` args ...])
+
+Sends a message to the server universe.
 
 ---
 
@@ -178,6 +202,10 @@ Returns the OpenProtocolVersion used for networking with the server.
 #### `Vec2U` universe.playerCount()
 
 Returns the server's current player count and maximum players.
+
+---
+
+The following callbacks are only available on the client main thread.
 
 ---
 

--- a/source/client/StarClientApplication.cpp
+++ b/source/client/StarClientApplication.cpp
@@ -670,7 +670,7 @@ void ClientApplication::changeState(MainAppState newState) {
     m_statistics = make_shared<Statistics>(m_root->toStoragePath("player"), app->statisticsService());
     m_universeClient = make_shared<UniverseClient>(m_playerStorage, m_statistics, m_root->toStoragePath("universeclient"));
 
-    m_universeClient->setLuaCallbacks("universe", LuaBindings::makeUniverseClientCallbacks(m_universeClient));
+    m_universeClient->setLuaCallbacks("universe", LuaBindings::makeUniverseClientCallbacks(m_universeClient.get()));
     m_universeClient->setLuaCallbacks("input", LuaBindings::makeInputCallbacks());
     m_universeClient->setLuaCallbacks("voice", LuaBindings::makeVoiceCallbacks());
     m_universeClient->setLuaCallbacks("camera", LuaBindings::makeCameraCallbacks(&m_worldPainter->camera()));

--- a/source/core/StarDataStream.cpp
+++ b/source/core/StarDataStream.cpp
@@ -6,7 +6,7 @@
 
 namespace Star {
 
-unsigned const CurrentStreamVersion = 17; // update OpenProtocolVersion too!
+unsigned const CurrentStreamVersion = 18; // update OpenProtocolVersion too!
 
 DataStream::DataStream()
   : m_byteOrder(ByteOrder::BigEndian),

--- a/source/core/StarNetCompatibility.cpp
+++ b/source/core/StarNetCompatibility.cpp
@@ -2,6 +2,6 @@
 
 namespace Star {
 
-VersionNumber const OpenProtocolVersion = 17; // update StreamCompatibilityVersion too!
+VersionNumber const OpenProtocolVersion = 18; // update StreamCompatibilityVersion too!
 
 }

--- a/source/game/StarNetPackets.cpp
+++ b/source/game/StarNetPackets.cpp
@@ -86,7 +86,9 @@ EnumMap<PacketType> const PacketTypeNames{
   {PacketType::ClientSubWorldRequest, "ClientSubWorldRequest"},
   {PacketType::ClientSubWorldReject, "ClientSubWorldReject"},
   {PacketType::NotifyWorldLoad, "NotifyWorldLoad"},
-  {PacketType::LogMapUpdate, "LogMapUpdate"}
+  {PacketType::LogMapUpdate, "LogMapUpdate"},
+  {PacketType::UniverseMessage, "UniverseMessage"},
+  {PacketType::UniverseMessageResponse, "UniverseMessageResponse"}
 };
 
 EnumMap<NetCompressionMode> const NetCompressionModeNames {
@@ -188,6 +190,8 @@ PacketPtr createPacket(PacketType type) {
     case PacketType::ClientSubWorldReject: return make_shared<ClientSubWorldReject>();
     case PacketType::NotifyWorldLoad: return make_shared<NotifyWorldLoad>();
     case PacketType::LogMapUpdate: return make_shared<LogMapUpdate>();
+    case PacketType::UniverseMessage: return make_shared<UniverseMessage>();
+    case PacketType::UniverseMessageResponse: return make_shared<UniverseMessageResponse>();
     default:
       throw StarPacketException(strf("Unrecognized packet type {}", (unsigned int)type));
   }
@@ -1577,6 +1581,60 @@ void LogMapUpdate::read(DataStream& ds) {
 
 void LogMapUpdate::write(DataStream& ds) const {
   ds.write(map);
+}
+
+UniverseMessage::UniverseMessage() {}
+
+UniverseMessage::UniverseMessage(ConnectionId connection, String message, JsonArray args, Uuid uuid, ConnectionId fromConnection)
+  : connection(connection), message(std::move(message)), args(std::move(args)), uuid(uuid), fromConnection(fromConnection) {}
+
+void UniverseMessage::read(DataStream& ds) {
+  ds.read(connection);
+  ds.read(message);
+  ds.read(args);
+  ds.read(uuid);
+  ds.read(fromConnection);
+}
+
+void UniverseMessage::write(DataStream& ds) const {
+  ds.write(connection);
+  ds.write(message);
+  ds.write(args);
+  ds.write(uuid);
+  ds.write(fromConnection);
+}
+
+void UniverseMessage::readJson(Json const& json) {
+  connection = json.getUInt("connection");
+  message = json.getString("message");
+  args = json.getArray("args");
+  uuid = Uuid(json.getString("uuid"));
+  fromConnection = json.getUInt("fromConnection");
+}
+
+Json UniverseMessage::writeJson() const {
+  return JsonObject{
+    {"connection", connection},
+    {"message", message},
+    {"args", args},
+    {"uuid", uuid.hex()},
+    {"fromConnection", fromConnection}
+  };
+}
+
+UniverseMessageResponse::UniverseMessageResponse() {}
+
+UniverseMessageResponse::UniverseMessageResponse(Either<String, Json> response, Uuid uuid)
+  : response(std::move(response)), uuid(uuid) {}
+
+void UniverseMessageResponse::read(DataStream& ds) {
+  ds.read(response);
+  ds.read(uuid);
+}
+
+void UniverseMessageResponse::write(DataStream& ds) const {
+  ds.write(response);
+  ds.write(uuid);
 }
 
 }

--- a/source/game/StarNetPackets.hpp
+++ b/source/game/StarNetPackets.hpp
@@ -128,7 +128,10 @@ enum class PacketType : uint8_t {
   ClientSubWorldReject,
   NotifyWorldLoad,
   
-  LogMapUpdate
+  LogMapUpdate,
+  
+  UniverseMessage,
+  UniverseMessageResponse
 };
 extern EnumMap<PacketType> const PacketTypeNames;
 
@@ -1076,5 +1079,33 @@ struct LogMapUpdate : PacketBase<PacketType::LogMapUpdate> {
   void write(DataStream& ds) const override;
 
   Map<String,String> map;
+};
+
+struct UniverseMessage : PacketBase<PacketType::UniverseMessage> {
+  UniverseMessage();
+  UniverseMessage(ConnectionId connection, String message, JsonArray args, Uuid uuid, ConnectionId fromConnection = ServerConnectionId);
+
+  void read(DataStream& ds) override;
+  void write(DataStream& ds) const override;
+
+  void readJson(Json const& json) override;
+  Json writeJson() const override;
+
+  ConnectionId connection;
+  String message;
+  JsonArray args;
+  Uuid uuid;
+  ConnectionId fromConnection;
+};
+
+struct UniverseMessageResponse : PacketBase<PacketType::UniverseMessageResponse> {
+  UniverseMessageResponse();
+  UniverseMessageResponse(Either<String,Json> response, Uuid uuid);
+
+  void read(DataStream& ds) override;
+  void write(DataStream& ds) const override;
+
+  Either<String, Json> response;
+  Uuid uuid;
 };
 }

--- a/source/game/StarUniverseClient.cpp
+++ b/source/game/StarUniverseClient.cpp
@@ -24,6 +24,8 @@
 #include "StarPlayerUniverseMap.hpp"
 #include "StarWorldTemplate.hpp"
 
+#include "StarUniverseClientLuaBindings.hpp"
+
 namespace Star {
 
 UniverseClient::UniverseClient(PlayerStoragePtr playerStorage, StatisticsPtr statistics, String const& customWorldStorageDir) {
@@ -158,7 +160,7 @@ Maybe<String> UniverseClient::connect(UniverseConnection connection, bool allowA
     m_teamClient = make_shared<TeamClient>(m_mainPlayer, m_clientContext);
     m_mainPlayer->setClientContext(m_clientContext);
     m_mainPlayer->setStatistics(m_statistics);
-    m_worldClient = make_shared<WorldClient>(m_mainPlayer, m_luaRoot);
+    m_worldClient = make_shared<WorldClient>(m_mainPlayer, m_luaRoot, this);
     m_worldClient->clientState().setNetCompatibilityRules(compatibilityRules);
     m_worldClient->setAsyncLighting(true);
 
@@ -305,6 +307,32 @@ void UniverseClient::update(float dt) {
     for (auto& p : m_subWorldThreads) {
       m_connection->push(p.second->pullOutgoingPackets());
     }
+  }
+  
+  for (auto const& uuid : m_universeMessagePromises.keys()) {
+    if (m_universeMessagePromises[uuid].finished()) {
+      if (m_universeMessagePromises[uuid].succeeded()) {
+        m_connection->pushSingle(make_shared<UniverseMessageResponse>(makeRight(*m_universeMessagePromises[uuid].result()), uuid));
+      } else {
+        m_connection->pushSingle(make_shared<UniverseMessageResponse>(makeLeft(*m_universeMessagePromises[uuid].error()), uuid));
+      }
+      m_universeMessagePromises.remove(uuid);
+    }
+  }
+  
+  RecursiveMutexLocker messageLocker(m_messageMutex);
+  List<Message> messages = std::move(m_universeMessages);
+  messageLocker.unlock();
+  
+  for (auto& message : messages) {
+    auto keeper = message.keeper.get<RpcPromiseKeeper<Json>>();
+    if (auto resp = receiveMessage(message.message, true, message.args))
+      if (resp->is<RpcPromise<Json>>())
+        keeper.chain(resp->get<RpcPromise<Json>>());
+      else
+        keeper.fulfill(resp->get<Json>());
+    else
+      keeper.fail("Message not handled by universe");
   }
 
   if (!*m_pause)
@@ -592,6 +620,8 @@ void UniverseClient::startLuaScripts() {
     auto scriptComponent = make_shared<ScriptComponent>();
     scriptComponent->setLuaRoot(m_luaRoot);
     scriptComponent->setScripts(jsonToStringList(p.second.toArray()));
+    
+    scriptComponent->addThreadCallbacks("universe",LuaBindings::makeUniverseClientThreadCallbacks(this));
 
     m_scriptContexts.set(p.first, scriptComponent);
     scriptComponent->init();
@@ -758,7 +788,7 @@ void UniverseClient::createCustomWorld(String const& name, Json templateData) {
 
 ClientSubWorldId UniverseClient::createSubWorld() {
   auto swid = m_subWorldThreads.nextId();
-  auto thread = make_shared<WorldClientThread>(swid);
+  auto thread = make_shared<WorldClientThread>(swid,this);
   thread->setPause(m_pause);
   thread->start();
   m_subWorldThreads.add(swid,thread);
@@ -1013,6 +1043,27 @@ void UniverseClient::handlePackets(List<PacketPtr> const& packets) {
         for (auto& p : logMapUpdate->map) {
           LogMap::setValue(p.first,p.second);
         }
+      } else if (auto universeMessage = as<UniverseMessage>(packet)) {
+        if (auto response = receiveMessage(universeMessage->message, false, universeMessage->args)) {
+          if (response->is<Json>()) {
+            m_connection->pushSingle(make_shared<UniverseMessageResponse>(makeRight(response->get<Json>()), universeMessage->uuid));
+          } else {
+            // delay the response until this promise is done
+            m_universeMessagePromises[universeMessage->uuid] = response->get<RpcPromise<Json>>();
+          } 
+        } else
+          m_connection->pushSingle(make_shared<UniverseMessageResponse>(makeLeft("Message not handled by universe"), universeMessage->uuid));
+      } else if (auto universeMessageResponse = as<UniverseMessageResponse>(packet)) {
+        RecursiveMutexLocker messageLocker(m_messageMutex);
+        if (!m_universeMessageResponses.contains(universeMessageResponse->uuid))
+          Logger::warn("UniverseClient: UniverseMessageResponse received for unknown context [{}]!", universeMessageResponse->uuid.hex());
+        else {
+          auto response = m_universeMessageResponses.take(universeMessageResponse->uuid);
+          if (universeMessageResponse->response.isRight())
+            response.fulfill(universeMessageResponse->response.right());
+          else
+            response.fail(universeMessageResponse->response.left());
+        }
       } else if (!m_systemWorldClient->handleIncomingPacket(packet)) {
         // see if the system world will handle it, otherwise pass it along to the world client
         m_worldClient->handleIncomingPackets({packet});
@@ -1049,6 +1100,45 @@ void UniverseClient::reset() {
     m_playerStorage->savePlayer(m_mainPlayer);
 
   m_connection.reset();
+  
+  RecursiveMutexLocker messageLocker(m_messageMutex);
+  m_universeMessageResponses = {};
+  m_universeMessagePromises = {};
+  messageLocker.unlock();
+}
+
+void UniverseClient::passMessage(Universe::Message&& message) {
+  RecursiveMutexLocker locker(m_messageMutex);
+  m_universeMessages.append(std::move(message));
+}
+
+RpcPromise<Json> UniverseClient::sendUniverseMessage(ConnectionId const& connectionId, String const& message, JsonArray const& args) {
+  if (connectionId == m_clientContext->connectionId()) {
+    auto pair = RpcPromise<Json>::createPair();
+    passMessage({message,args,pair.second});
+    return pair.first;
+  } else {
+    if (connectionVersion() < 18) {
+      return RpcPromise<Json>::createFailed("Server is not new enough");
+    }
+    auto pair = RpcPromise<Json>::createPair();
+    Uuid uuid;
+    RecursiveMutexLocker messageLocker(m_messageMutex);
+    m_universeMessageResponses[uuid] = pair.second;
+    messageLocker.unlock();
+    m_connection->pushSingle(make_shared<UniverseMessage>(connectionId, message, args, uuid));
+    return pair.first;
+  }
+}
+
+Maybe<ChainableJsonMessageResponse> UniverseClient::receiveMessage(String const& message, bool const& local, JsonArray const& args) {
+  Maybe<ChainableJsonMessageResponse> result;
+  for (auto& p : m_scriptContexts) {
+    result = p.second->handleMessage(message, local, args);
+    if (result)
+      break;
+  }
+  return result;
 }
 
 }

--- a/source/game/StarUniverseClient.hpp
+++ b/source/game/StarUniverseClient.hpp
@@ -13,6 +13,8 @@
 #include "StarLuaComponents.hpp"
 #include "StarUniverse.hpp"
 
+// TODO: make this more thread safe
+
 namespace Star {
 
 STAR_CLASS(WorldTemplate);
@@ -36,7 +38,7 @@ STAR_CLASS(LuaRoot);
 
 class UniverseClient : public Universe {
 public:
-  typedef LuaUpdatableComponent<LuaBaseComponent> ScriptComponent;
+  typedef LuaMessageHandlingComponent<LuaUpdatableComponent<LuaBaseComponent>> ScriptComponent;
   typedef shared_ptr<ScriptComponent> ScriptComponentPtr;
   
   UniverseClient(PlayerStoragePtr playerStorage, StatisticsPtr statistics, String const& customWorldStorageDir);
@@ -132,6 +134,11 @@ public:
   RpcPromise<Json> sendMainWorldMessage(String const& message, JsonArray const& args = {});
 
   bool paused() const;
+  
+  void passMessage(Universe::Message&& message) override;
+  RpcPromise<Json> sendUniverseMessage(ConnectionId const& connectionId, String const& message, JsonArray const& args = {}) override;
+  
+  Maybe<ChainableJsonMessageResponse> receiveMessage(String const& message, bool const& local, JsonArray const& args) override;
 
 private:
   struct ServerInfo {
@@ -189,6 +196,12 @@ private:
 
   ReloadPlayerCallback m_playerReloadPreCallback;
   ReloadPlayerCallback m_playerReloadCallback;
+
+  mutable RecursiveMutex m_messageMutex;
+  List<Universe::Message> m_universeMessages;
+  
+  HashMap<Uuid, RpcPromiseKeeper<Json>> m_universeMessageResponses;
+  HashMap<Uuid, RpcPromise<Json>> m_universeMessagePromises;
 };
 
 }

--- a/source/game/StarUniverseServer.cpp
+++ b/source/game/StarUniverseServer.cpp
@@ -628,6 +628,7 @@ void UniverseServer::run() {
       respondToCelestialRequests();
       clearBrokenWorlds();
       handleWorldMessages();
+      handleUniverseMessages();
       shutdownInactiveWorlds();
       doTriggeredStorage();
     } catch (std::exception const& e) {
@@ -1336,6 +1337,57 @@ void UniverseServer::handleWorldMessages() {
   }
 }
 
+void UniverseServer::handleUniverseMessages() {
+  
+  ReadLocker clientsLocker(m_clientsLock, false);
+  for (auto const& uuid : m_universeMessagePromises.keys()) {
+    auto clientId = m_universeMessagePromises[uuid].first;
+    clientsLocker.lock();
+    if (auto clientContext = m_clients.value(clientId)) {
+      clientsLocker.unlock();
+      if (m_universeMessagePromises[uuid].second.finished()) {
+        if (m_universeMessagePromises[uuid].second.succeeded()) {
+          m_connectionServer->sendPackets(clientId, {make_shared<UniverseMessageResponse>(makeRight(*m_universeMessagePromises[uuid].second.result()), uuid)});
+        } else {
+          m_connectionServer->sendPackets(clientId, {make_shared<UniverseMessageResponse>(makeLeft(*m_universeMessagePromises[uuid].second.error()), uuid)});
+        }
+        m_universeMessagePromises.remove(uuid);
+      }
+    } else {
+      clientsLocker.unlock();
+      m_universeMessagePromises.remove(uuid);
+    }
+  }
+  
+  RecursiveMutexLocker locker(m_messageLock);
+  List<Message> messages = std::move(m_universeMessages);
+  locker.unlock();
+  
+  for (auto& message : messages) {
+    if (message.keeper.is<pair<Uuid,ConnectionId>>()) {
+      auto p = message.keeper.get<pair<Uuid,ConnectionId>>();
+      auto uuid = p.first;
+      auto clientId = p.second;
+      if (auto resp = receiveMessage(message.message, false, message.args))
+        if (resp->is<RpcPromise<Json>>()) {
+          m_universeMessagePromises[uuid] = make_pair(clientId, resp->get<RpcPromise<Json>>());
+        } else
+          m_connectionServer->sendPackets(clientId, {make_shared<UniverseMessageResponse>(makeRight(resp->get<Json>()), uuid)});
+      else
+        m_connectionServer->sendPackets(clientId, {make_shared<UniverseMessageResponse>(makeLeft("Message not handled by universe"), uuid)});
+    } else {
+      auto keeper = message.keeper.get<RpcPromiseKeeper<Json>>();
+      if (auto resp = receiveMessage(message.message, true, message.args))
+        if (resp->is<RpcPromise<Json>>())
+          keeper.chain(resp->get<RpcPromise<Json>>());
+        else
+          keeper.fulfill(resp->get<Json>());
+      else
+        keeper.fail("Message not handled by universe");
+    }
+  }
+}
+
 void UniverseServer::shutdownInactiveWorlds() {
   RecursiveMutexLocker locker(m_mainLock);
   ReadLocker clientsLocker(m_clientsLock);
@@ -1926,6 +1978,45 @@ void UniverseServer::packetsReceived(UniverseConnectionServer*, ConnectionId cli
       } else if (auto cwtPackets = as<ClientSubWorldPackets>(packet)) {
         if (auto currentWorld = clientContext->subWorld(cwtPackets->subWorldId))
           currentWorld->pushIncomingPackets(mainToSubWorldConnectionId(clientId), std::move(cwtPackets->packets));
+      } else if (auto universeMessage = as<UniverseMessage>(packet)) {
+        if (universeMessage->connection == ServerConnectionId) {
+          passMessage({universeMessage->message,universeMessage->args,make_pair(universeMessage->uuid,clientId)});
+        } else {
+          clientsLocker.lock();
+          if (auto& client = m_clients.get(universeMessage->connection)) {
+            clientsLocker.unlock();
+            if (client->netRules().version() < 18) {
+              m_connectionServer->sendPackets(clientId, {make_shared<UniverseMessageResponse>(makeLeft("Client is not new enough"), universeMessage->uuid)});
+            } else {
+              RecursiveMutexLocker messageLocker(m_messageLock);
+              m_universeMessageResponses[universeMessage->uuid] = {universeMessage->connection, clientId};
+              messageLocker.unlock();
+              universeMessage->fromConnection = clientId;
+              m_connectionServer->sendPackets(universeMessage->connection,{std::move(universeMessage)});
+            }
+          } else {
+            m_connectionServer->sendPackets(clientId, {make_shared<UniverseMessageResponse>(makeLeft("Client does not exist"), universeMessage->uuid)});
+          }
+        }
+      } else if (auto universeMessageResponse = as<UniverseMessageResponse>(packet)) {
+        RecursiveMutexLocker messageLocker(m_messageLock);
+        if (!m_universeMessageResponses.contains(universeMessageResponse->uuid))
+          Logger::warn("UniverseServer: UniverseMessageResponse received for unknown context [{}]!", universeMessageResponse->uuid.hex());
+        else {
+          auto response = m_universeMessageResponses.take(universeMessageResponse->uuid).second;
+          messageLocker.unlock();
+          if (response.is<ConnectionId>()) {
+            clientsLocker.lock();
+            if (auto client = m_clients.get(response.get<ConnectionId>()))
+              m_connectionServer->sendPackets(response.get<ConnectionId>(),{std::move(universeMessageResponse)});
+            clientsLocker.unlock();
+          } else {
+            if (universeMessageResponse->response.isRight())
+              response.get<RpcPromiseKeeper<Json>>().fulfill(universeMessageResponse->response.right());
+            else
+              response.get<RpcPromiseKeeper<Json>>().fail(universeMessageResponse->response.left());
+          }
+        }
       } else if (is<SystemObjectSpawnPacket>(packet)) {
         if (auto currentSystem = clientContext->systemWorld())
           currentSystem->pushIncomingPacket(clientId, std::move(packet));
@@ -3003,4 +3094,42 @@ void UniverseServer::stopLua() {
   m_scriptContexts.clear();
 }
 
+void UniverseServer::passMessage(Universe::Message&& message) {
+  RecursiveMutexLocker locker(m_messageLock);
+  m_universeMessages.append(std::move(message));
+}
+
+RpcPromise<Json> UniverseServer::sendUniverseMessage(ConnectionId const& connectionId, String const& message, JsonArray const& args) {
+  if (connectionId == ServerConnectionId) {
+    auto pair = RpcPromise<Json>::createPair();
+    passMessage({message,args,pair.second});
+    return pair.first;
+  } else {
+    ReadLocker clientsLocker(m_clientsLock);
+    if (auto& client = m_clients.get(connectionId)) {
+      clientsLocker.unlock();
+      if (client->netRules().version() < 18) {
+        return RpcPromise<Json>::createFailed("Client is not new enough");
+      }
+      auto pair = RpcPromise<Json>::createPair();
+      Uuid uuid;
+      RecursiveMutexLocker messageLocker(m_messageLock);
+      m_universeMessageResponses[uuid] = {connectionId, pair.second};
+      messageLocker.unlock();
+      m_connectionServer->sendPackets(connectionId, {make_shared<UniverseMessage>(connectionId, message, args, uuid)});
+      return pair.first;
+    }
+    return RpcPromise<Json>::createFailed("Client does not exist");
+  }
+}
+
+Maybe<ChainableJsonMessageResponse> UniverseServer::receiveMessage(String const& message, bool const& local, JsonArray const& args) {
+  Maybe<ChainableJsonMessageResponse> result;
+  for (auto& p : m_scriptContexts) {
+    result = p.second->handleMessage(message, local, args);
+    if (result)
+      break;
+  }
+  return result;
+}
 }// namespace Star

--- a/source/game/StarUniverseServer.hpp
+++ b/source/game/StarUniverseServer.hpp
@@ -118,6 +118,12 @@ public:
   void createCustomWorld(CustomWorldId const& customWorld, WorldTemplatePtr worldTemplate);
 
   bool sendPacket(ConnectionId clientId, PacketPtr packet);
+  
+  void passMessage(Universe::Message&& message) override;
+  
+  RpcPromise<Json> sendUniverseMessage(ConnectionId const& connectionId, String const& message, JsonArray const& args = {}) override;
+  
+  Maybe<ChainableJsonMessageResponse> receiveMessage(String const& message, bool const& local, JsonArray const& args) override;
 
 protected:
   virtual void run() override;
@@ -164,6 +170,7 @@ private:
   void processChat();
   void clearBrokenWorlds();
   void handleWorldMessages();
+  void handleUniverseMessages();
   void shutdownInactiveWorlds();
   void doTriggeredStorage();
 
@@ -298,9 +305,15 @@ private:
 
   LuaRootPtr m_luaRoot;
 
-  typedef LuaUpdatableComponent<LuaBaseComponent> ScriptComponent;
+  typedef LuaMessageHandlingComponent<LuaUpdatableComponent<LuaBaseComponent>> ScriptComponent;
   typedef shared_ptr<ScriptComponent> ScriptComponentPtr;
   StringMap<ScriptComponentPtr> m_scriptContexts;
+
+  mutable RecursiveMutex m_messageLock;
+  List<Universe::Message> m_universeMessages;
+  
+  HashMap<Uuid, pair<ConnectionId, MVariant<ConnectionId, RpcPromiseKeeper<Json>>>> m_universeMessageResponses;
+  HashMap<Uuid, pair<ConnectionId, RpcPromise<Json>>> m_universeMessagePromises;
 };
 
 }

--- a/source/game/StarWorldClient.cpp
+++ b/source/game/StarWorldClient.cpp
@@ -21,7 +21,10 @@
 #include "StarWorldTemplate.hpp"
 #include "StarStoredFunctions.hpp"
 #include "StarInspectableEntity.hpp"
+#include "StarUniverseClient.hpp"
 #include "StarCurve25519.hpp"
+
+#include "StarUniverseClientLuaBindings.hpp"
 
 namespace Star {
 
@@ -29,10 +32,12 @@ const std::string SECRET_BROADCAST_PUBLIC_KEY = "SecretBroadcastPublicKey";
 const std::string SECRET_BROADCAST_PREFIX = "\0Broadcast\0"s;
 
 const float WorldClient::DropDist = 6.0f;
-WorldClient::WorldClient(PlayerPtr mainPlayer, LuaRootPtr luaRoot) {
+WorldClient::WorldClient(PlayerPtr mainPlayer, LuaRootPtr luaRoot, UniverseClient* universe) {
   // main client world, set up to render
   auto& root = Root::singleton();
   auto assets = root.assets();
+  
+  m_universe = universe;
 
   m_clientConfig = assets->json("/client.config");
   
@@ -102,10 +107,12 @@ WorldClient::WorldClient(PlayerPtr mainPlayer, LuaRootPtr luaRoot) {
   clearWorld();
 }
 
-WorldClient::WorldClient(ClientSubWorldId subWorldId) {
+WorldClient::WorldClient(ClientSubWorldId subWorldId, UniverseClient* universe) {
   // client subworld, doesn't render
   auto& root = Root::singleton();
   auto assets = root.assets();
+  
+  m_universe = universe;
 
   m_clientConfig = assets->json("/client.config");
   
@@ -122,6 +129,7 @@ WorldClient::WorldClient(ClientSubWorldId subWorldId) {
   m_luaRoot = make_shared<LuaRoot>();
   m_luaRoot->luaEngine().setNullTerminated(false);
   m_luaRoot->tuneAutoGarbageCollection(m_clientConfig.getFloat("luaGcPause"), m_clientConfig.getFloat("luaGcStepMultiplier"));
+  m_luaRoot->addCallbacks("universe",LuaBindings::makeUniverseClientThreadCallbacks(universe));
 
   m_collisionGenerator.init([this](int x, int y) {
     if (!m_predictedTiles.empty()) {
@@ -2104,6 +2112,8 @@ void WorldClient::initWorld(WorldStartPacket const& startPacket) {
   for (auto& p : m_clientConfig.getObject("worldScriptContexts")) {
     auto scriptComponent = make_shared<ScriptComponent>();
     scriptComponent->setScripts(jsonToStringList(p.second.toArray()));
+    
+    scriptComponent->addThreadCallbacks("universe",LuaBindings::makeUniverseClientThreadCallbacks(m_universe));
 
     m_scriptContexts.set(p.first, scriptComponent);
     scriptComponent->init(this);

--- a/source/game/StarWorldClient.hpp
+++ b/source/game/StarWorldClient.hpp
@@ -28,6 +28,7 @@ STAR_CLASS(DamageManager);
 STAR_CLASS(EntityMap);
 STAR_CLASS(ParticleManager);
 STAR_CLASS(WorldClient);
+STAR_CLASS(UniverseClient);
 STAR_CLASS(Player);
 STAR_CLASS(Item);
 STAR_CLASS(CelestialLog);
@@ -42,8 +43,8 @@ public:
   typedef LuaMessageHandlingComponent<LuaUpdatableComponent<LuaWorldComponent<LuaBaseComponent>>> ScriptComponent;
   typedef shared_ptr<ScriptComponent> ScriptComponentPtr;
   
-  WorldClient(PlayerPtr mainPlayer, LuaRootPtr luaRoot);
-  WorldClient(ClientSubWorldId subWorldId);
+  WorldClient(PlayerPtr mainPlayer, LuaRootPtr luaRoot, UniverseClient* universe);
+  WorldClient(ClientSubWorldId subWorldId, UniverseClient* universe);
   ~WorldClient();
 
   ConnectionId connection() const override;
@@ -420,6 +421,8 @@ private:
   StringMap<ScriptComponentPtr> m_scriptContexts;
 
   GameTimer m_expiryTimer;
+  
+  UniverseClient* m_universe;
 };
 
 }

--- a/source/game/StarWorldClientThread.cpp
+++ b/source/game/StarWorldClientThread.cpp
@@ -8,13 +8,13 @@
 
 namespace Star {
 
-WorldClientThread::WorldClientThread(ClientSubWorldId subWorldId)
+WorldClientThread::WorldClientThread(ClientSubWorldId subWorldId, UniverseClient* universe)
   : Thread("WorldClientThread: " + String(subWorldId)),
     m_subWorldId(subWorldId),
     m_stop(false),
     m_errorOccurred(false),
     m_shouldExpire(false) {
-    m_worldClient = make_shared<WorldClient>(subWorldId);
+    m_worldClient = make_shared<WorldClient>(subWorldId,universe);
 }
 
 WorldClientThread::~WorldClientThread() {

--- a/source/game/StarWorldClientThread.hpp
+++ b/source/game/StarWorldClientThread.hpp
@@ -7,6 +7,7 @@
 namespace Star {
 
 STAR_CLASS(WorldClientThread);
+STAR_CLASS(UniverseClient);
 
 // Runs a WorldThreadedClient in a separate thread.
 class WorldClientThread : public Thread {
@@ -19,7 +20,7 @@ public:
 
   typedef function<void(WorldClientThread*, WorldClient*)> WorldClientAction;
 
-  WorldClientThread(ClientSubWorldId subWorldId);
+  WorldClientThread(ClientSubWorldId subWorldId, UniverseClient* universe);
   ~WorldClientThread();
 
   ClientSubWorldId subWorldId() const;

--- a/source/game/interfaces/StarUniverse.hpp
+++ b/source/game/interfaces/StarUniverse.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "StarConfig.hpp"
+#include "StarGameTypes.hpp"
+#include "StarUuid.hpp"
 
 namespace Star {
 
@@ -10,7 +12,19 @@ STAR_CLASS(CelestialDatabase);
 // Shared base class for UniverseClient and UniverseServer
 class Universe {
 public:
+  struct Message {
+    String message;
+    JsonArray args;
+    Variant<pair<Uuid,ConnectionId>,RpcPromiseKeeper<Json>> keeper;
+  };
+  
   virtual CelestialDatabasePtr celestialDatabase() = 0;
+  
+  virtual void passMessage(Message&& message) = 0;
+  // Sends a universe message to the target universe's main universe script context.
+  virtual RpcPromise<Json> sendUniverseMessage(ConnectionId const& connectionId, String const& message, JsonArray const& args = {}) = 0;
+  
+  virtual Maybe<ChainableJsonMessageResponse> receiveMessage(String const& message, bool const& local, JsonArray const& args) = 0;
 };
 
 }

--- a/source/game/scripting/StarUniverseClientLuaBindings.cpp
+++ b/source/game/scripting/StarUniverseClientLuaBindings.cpp
@@ -7,8 +7,20 @@
 
 namespace Star {
 
-LuaCallbacks LuaBindings::makeUniverseClientCallbacks(UniverseClientPtr universe) {
+LuaCallbacks LuaBindings::makeUniverseClientThreadCallbacks(UniverseClient* universe) {
   LuaCallbacks callbacks;
+  
+  callbacks.registerCallback("sendOwnUniverseMessage", [universe](String const& message, LuaVariadic<Json> args) -> RpcPromise<Json> {
+    auto pair = RpcPromise<Json>::createPair();
+    universe->passMessage({message,JsonArray::from(std::move(args)),pair.second});
+    return pair.first;
+  });
+  callbacks.registerCallback("sendUniverseMessage", [universe](ConnectionId const& connection, String const& message, LuaVariadic<Json> args) -> RpcPromise<Json> {
+    return universe->sendUniverseMessage(connection,message,JsonArray::from(std::move(args)));
+  });
+  callbacks.registerCallback("sendServerUniverseMessage", [universe](String const& message, LuaVariadic<Json> args) -> RpcPromise<Json> {
+    return universe->sendUniverseMessage(ServerConnectionId,message,JsonArray::from(std::move(args)));
+  });
   
   callbacks.registerCallback("createClientCustomWorld", [universe](String name, Json templateData) {
     universe->createCustomWorld(name, templateData);
@@ -45,6 +57,12 @@ LuaCallbacks LuaBindings::makeUniverseClientCallbacks(UniverseClientPtr universe
     universe->createCustomWorld(name, worldTemplate.store());
   });
   
+  callbacks.registerCallback("connectionId", [universe]() {
+    if (!universe->isConnected())
+      throw StarException("Universe is not connected");
+    return universe->clientContext()->connectionId();
+  });
+  
   callbacks.registerCallback("clientUuid", [universe]() {
     if (!universe->isConnected())
       throw StarException("Universe is not connected");
@@ -60,6 +78,12 @@ LuaCallbacks LuaBindings::makeUniverseClientCallbacks(UniverseClientPtr universe
       return Vec2U();
     return Vec2U(universe->players(),universe->maxPlayers());
   });
+  
+  return callbacks;
+}
+
+LuaCallbacks LuaBindings::makeUniverseClientCallbacks(UniverseClient* universe) {
+  LuaCallbacks callbacks = makeUniverseClientThreadCallbacks(universe);
   
   callbacks.registerCallback("subWorldActive", [universe](String const& worldId) -> bool {
     return universe->subWorldExistsOnWorld(parseWorldId(worldId));

--- a/source/game/scripting/StarUniverseClientLuaBindings.hpp
+++ b/source/game/scripting/StarUniverseClientLuaBindings.hpp
@@ -9,7 +9,8 @@ namespace Star {
 STAR_CLASS(UniverseClient);
 
 namespace LuaBindings {
-  LuaCallbacks makeUniverseClientCallbacks(UniverseClientPtr universe);
+  LuaCallbacks makeUniverseClientThreadCallbacks(UniverseClient* universe); // thread-safe callbacks
+  LuaCallbacks makeUniverseClientCallbacks(UniverseClient* universe); // non-thread-safe callbacks
 
   namespace UniverseClientCallbacks {
   }

--- a/source/game/scripting/StarUniverseServerLuaBindings.cpp
+++ b/source/game/scripting/StarUniverseServerLuaBindings.cpp
@@ -68,6 +68,17 @@ LuaCallbacks LuaBindings::makeUniverseServerCallbacks(UniverseServer* universe) 
     Json worldProperties = worldConfig.get("worldProperties", JsonObject{});
     universe->createCustomWorld(CustomWorldId(name), worldTemplate);
   });
+  
+  callbacks.registerCallback("sendOwnUniverseMessage", [universe](String const& message, LuaVariadic<Json> args) -> RpcPromise<Json> {
+    return universe->sendUniverseMessage(ServerConnectionId,message,JsonArray::from(std::move(args)));
+  });
+  callbacks.registerCallback("sendUniverseMessage", [universe](ConnectionId const& connection, String const& message, LuaVariadic<Json> args) -> RpcPromise<Json> {
+    return universe->sendUniverseMessage(connection,message,JsonArray::from(std::move(args)));
+  });
+  
+  callbacks.registerCallback("connectionId", [universe]() {
+    return ServerConnectionId;
+  });
 
   return callbacks;
 }


### PR DESCRIPTION
docs pending
scriptable threads under WorldClient script contexts and UniverseClient script contexts now have access to a smaller version of `universe`

universe script contexts can now be sent messages via universe callbacks