### PR TITLE
Increase LUA_IDSIZE from 60 to 256

### DIFF
--- a/source/extern/luaconf.h
+++ b/source/extern/luaconf.h
@@ -747,7 +747,7 @@
 @@ of a function in debug information.
 ** CHANGE it if you want a different size.
 */
-#define LUA_IDSIZE	60
+#define LUA_IDSIZE	256
 
 
 /*


### PR DESCRIPTION
This is so annoying when you trying to find out where is the error and stacktrace goes like this  <img width="1007" height="52" alt="image" src="https://github.com/user-attachments/assets/8c3060fd-3648-49cd-9342-4dba32c72eac" /> Its just folded!