### PR TITLE
weather bindings, more bindings for threads

### DIFF
--- a/doc/lua/openstarbound/world.md
+++ b/doc/lua/openstarbound/world.md
@@ -47,6 +47,27 @@ Holding an Entity instance in Lua will keep the entity present in memory even af
 
 ---
 
+#### `List<String>` world.weatherStatusEffects(`Vec2F` position)
+
+Returns a list of the weather status effects at the specified position.
+
+---
+
+#### `bool` world.exposedToWeather(`Vec2F` position)
+
+Returns whether the given position is considered exposed to weather.
+
+---
+
+#### `Maybe<String>` world.activeWeather(`Vec2F` position)
+
+Returns the current weather for the given position. This is `nil` if the weather pool at that position has no options.
+If an area has weather, it will always return the current weather. Note that `"clear"` is a weather type.
+
+For client worlds, only one weather domain is networked at a time, so the output is based on the player position instead.
+
+---
+
 The following additional world bindings are available only for scripts running on the client.
 
 ---

--- a/source/game/StarWeather.cpp
+++ b/source/game/StarWeather.cpp
@@ -129,6 +129,13 @@ List<ProjectilePtr> ServerWeather::pullNewProjectiles() {
   return take(m_newProjectiles);
 }
 
+Maybe<String> ServerWeather::activeWeather() const {
+  if (m_currentWeatherIndex == NPos)
+    return {};
+  else
+    return m_weatherPool.item(m_currentWeatherIndex);
+}
+
 StringList ServerWeather::weatherList() const {
   StringList weatherList;
   for (size_t i = 0; i < m_weatherPool.size(); ++i)
@@ -174,11 +181,11 @@ void ServerWeather::setWeatherIndex(size_t weatherIndex, bool force) {
   setNetStates();
   }
 
-  void ServerWeather::forceWeather(bool force) {
+void ServerWeather::forceWeather(bool force) {
   m_forceWeather = force;
   if (force)
     m_nextWeatherChangeTime = INFINITY;
-  }
+}
 
 void ServerWeather::setNetStates() {
   m_weatherPoolNetState.set(DataStreamBuffer::serializeContainer(m_weatherPool.items()));
@@ -373,6 +380,13 @@ StringList ClientWeather::statusEffects() const {
 
 List<Particle> ClientWeather::pullNewParticles() {
   return take(m_particles);
+}
+
+Maybe<String> ClientWeather::activeWeather() const {
+  if (m_currentWeatherIndex == NPos)
+    return {};
+  else
+    return m_weatherPool.item(m_currentWeatherIndex);
 }
 
 StringList ClientWeather::weatherTrackOptions() const {

--- a/source/game/StarWeather.hpp
+++ b/source/game/StarWeather.hpp
@@ -53,6 +53,8 @@ public:
   StringList statusEffects() const;
 
   List<ProjectilePtr> pullNewProjectiles();
+  
+  Maybe<String> activeWeather() const;
 
 private:
   void setNetStates();
@@ -112,6 +114,8 @@ public:
   List<Particle> pullNewParticles();
   StringList weatherTrackOptions() const;
   Maybe<String> weatherParallax() const;
+  
+  Maybe<String> activeWeather() const;
 
 private:
   void getNetStates();

--- a/source/game/StarWorldClient.cpp
+++ b/source/game/StarWorldClient.cpp
@@ -25,6 +25,7 @@
 #include "StarCurve25519.hpp"
 
 #include "StarUniverseClientLuaBindings.hpp"
+#include "StarCelestialLuaBindings.hpp"
 
 namespace Star {
 
@@ -61,6 +62,8 @@ WorldClient::WorldClient(PlayerPtr mainPlayer, LuaRootPtr luaRoot, UniverseClien
   m_inWorld = false;
 
   m_luaRoot = luaRoot;
+  m_luaThreadCallbacks["universe"] = LuaBindings::makeUniverseClientThreadCallbacks(universe);
+  m_luaThreadCallbacks["celestial"] = LuaBindings::makeCelestialCallbacks(universe->celestialDatabase());
 
   m_mainPlayer = mainPlayer;
 
@@ -129,7 +132,10 @@ WorldClient::WorldClient(ClientSubWorldId subWorldId, UniverseClient* universe) 
   m_luaRoot = make_shared<LuaRoot>();
   m_luaRoot->luaEngine().setNullTerminated(false);
   m_luaRoot->tuneAutoGarbageCollection(m_clientConfig.getFloat("luaGcPause"), m_clientConfig.getFloat("luaGcStepMultiplier"));
-  m_luaRoot->addCallbacks("universe",LuaBindings::makeUniverseClientThreadCallbacks(universe));
+  m_luaThreadCallbacks["universe"] = LuaBindings::makeUniverseClientThreadCallbacks(universe);
+  m_luaThreadCallbacks["celestial"] = LuaBindings::makeCelestialCallbacks(universe->celestialDatabase());
+  m_luaRoot->addCallbacks("universe",m_luaThreadCallbacks["universe"]);
+  m_luaRoot->addCallbacks("celestial",m_luaThreadCallbacks["celestial"]);
 
   m_collisionGenerator.init([this](int x, int y) {
     if (!m_predictedTiles.empty()) {
@@ -2112,8 +2118,6 @@ void WorldClient::initWorld(WorldStartPacket const& startPacket) {
   for (auto& p : m_clientConfig.getObject("worldScriptContexts")) {
     auto scriptComponent = make_shared<ScriptComponent>();
     scriptComponent->setScripts(jsonToStringList(p.second.toArray()));
-    
-    scriptComponent->addThreadCallbacks("universe",LuaBindings::makeUniverseClientThreadCallbacks(m_universe));
 
     m_scriptContexts.set(p.first, scriptComponent);
     scriptComponent->init(this);
@@ -2478,6 +2482,12 @@ bool WorldClient::exposedToWeather(Vec2F const& pos) const {
   return false;
 }
 
+Maybe<String> WorldClient::activeWeather(Vec2F const& pos) const {
+  if (!inWorld())
+    return {};
+  return m_weather.activeWeather();
+}
+
 bool WorldClient::isUnderground(Vec2F const& pos) const {
   if (!inWorld())
     return true;
@@ -2612,6 +2622,10 @@ float WorldClient::timeOfDay() const {
 
 LuaRootPtr WorldClient::luaRoot() {
   return m_luaRoot;
+}
+
+StringMap<LuaCallbacks> WorldClient::luaThreadCallbacks() const {
+  return m_luaThreadCallbacks;
 }
 
 bool WorldClient::pullRequestedDestroy() {

--- a/source/game/StarWorldClient.hpp
+++ b/source/game/StarWorldClient.hpp
@@ -92,6 +92,7 @@ public:
   StringList environmentStatusEffects(Vec2F const& pos) const override;
   StringList weatherStatusEffects(Vec2F const& pos) const override;
   bool exposedToWeather(Vec2F const& pos) const override;
+  Maybe<String> activeWeather(Vec2F const& pos) const override;
   bool isUnderground(Vec2F const& pos) const override;
   bool disableDeathDrops() const override;
   List<PhysicsForceRegion> forceRegions() const override;
@@ -106,6 +107,7 @@ public:
   RpcPromise<Vec2F> findUniqueEntity(String const& uniqueId) override;
   RpcPromise<Json> sendEntityMessage(Variant<EntityId, String> const& entity, String const& message, JsonArray const& args = {}) override;
   bool isTileProtected(Vec2I const& pos) const override;
+  StringMap<LuaCallbacks> luaThreadCallbacks() const override;
 
   // Is this WorldClient properly initialized in a world
   bool inWorld() const;
@@ -423,6 +425,8 @@ private:
   GameTimer m_expiryTimer;
   
   UniverseClient* m_universe;
+  
+  StringMap<LuaCallbacks> m_luaThreadCallbacks;
 };
 
 }

--- a/source/game/StarWorldServer.cpp
+++ b/source/game/StarWorldServer.cpp
@@ -163,14 +163,14 @@ void WorldServer::setPause(bool pause) {
 }
 
 void WorldServer::initLua(UniverseServer* universe) {
-  m_luaRoot->addCallbacks("universe", LuaBindings::makeUniverseServerCallbacks(universe));
-  m_luaRoot->addCallbacks("celestial", LuaBindings::makeCelestialCallbacks(universe));
+  m_luaThreadCallbacks["universe"] = LuaBindings::makeUniverseServerCallbacks(universe);
+  m_luaThreadCallbacks["celestial"] = LuaBindings::makeCelestialCallbacks(universe);
+  m_luaRoot->addCallbacks("universe",m_luaThreadCallbacks["universe"]);
+  m_luaRoot->addCallbacks("celestial",m_luaThreadCallbacks["celestial"]);
   auto assets = Root::singleton().assets();
   for (auto& p : assets->json("/worldserver.config:scriptContexts").toObject()) {
     auto scriptComponent = make_shared<ScriptComponent>();
     scriptComponent->setScripts(jsonToStringList(p.second.toArray()));
-    scriptComponent->addThreadCallbacks("universe", LuaBindings::makeUniverseServerCallbacks(universe));
-    scriptComponent->addThreadCallbacks("celestial", LuaBindings::makeCelestialCallbacks(universe));
 
     m_scriptContexts.set(p.first, scriptComponent);
     scriptComponent->init(this);
@@ -2427,6 +2427,11 @@ bool WorldServer::exposedToWeather(Vec2F const& pos) const {
   return false;
 }
 
+Maybe<String> WorldServer::activeWeather(Vec2F const& pos) const {
+  auto weather = weatherAt(pos);
+  return weather->activeWeather();
+}
+
 bool WorldServer::isUnderground(Vec2F const& pos) const {
   return m_worldTemplate->undergroundLevel() >= pos[1];
 }
@@ -2500,6 +2505,10 @@ float WorldServer::timeOfDay() const {
 
 LuaRootPtr WorldServer::luaRoot() {
   return m_luaRoot;
+}
+
+StringMap<LuaCallbacks> WorldServer::luaThreadCallbacks() const {
+  return m_luaThreadCallbacks;
 }
 
 RpcPromise<Vec2F> WorldServer::findUniqueEntity(String const& uniqueId) {

--- a/source/game/StarWorldServer.hpp
+++ b/source/game/StarWorldServer.hpp
@@ -173,6 +173,7 @@ public:
   StringList environmentStatusEffects(Vec2F const& pos) const override;
   StringList weatherStatusEffects(Vec2F const& pos) const override;
   bool exposedToWeather(Vec2F const& pos) const override;
+  Maybe<String> activeWeather(Vec2F const& pos) const override;
   bool isUnderground(Vec2F const& pos) const override;
   bool disableDeathDrops() const override;
   List<PhysicsForceRegion> forceRegions() const override;
@@ -187,6 +188,9 @@ public:
   RpcPromise<Vec2F> findUniqueEntity(String const& uniqueId) override;
   RpcPromise<Json> sendEntityMessage(Variant<EntityId, String> const& entity, String const& message, JsonArray const& args = {}) override;
   bool isTileProtected(Vec2I const& pos) const override;
+  
+  StringMap<LuaCallbacks> luaThreadCallbacks() const override;
+  
   void wire(Vec2I const& outputPosition, size_t outputIndex, Vec2I const& inputPosition, size_t inputIndex);
 
   bool getTileProtection(DungeonId dungeonId) const;
@@ -446,6 +450,8 @@ private:
   String m_worldId;
 
   GameTimer m_expiryTimer;
+  
+  StringMap<LuaCallbacks> m_luaThreadCallbacks;
 };
 
 }

--- a/source/game/interfaces/StarWorld.hpp
+++ b/source/game/interfaces/StarWorld.hpp
@@ -127,6 +127,7 @@ public:
   virtual StringList environmentStatusEffects(Vec2F const& pos) const = 0;
   virtual StringList weatherStatusEffects(Vec2F const& pos) const = 0;
   virtual bool exposedToWeather(Vec2F const& pos) const = 0;
+  virtual Maybe<String> activeWeather(Vec2F const& pos) const = 0;
   virtual bool isUnderground(Vec2F const& pos) const = 0;
   virtual bool disableDeathDrops() const = 0;
   virtual List<PhysicsForceRegion> forceRegions() const = 0;
@@ -142,6 +143,7 @@ public:
   virtual float timeOfDay() const = 0;
 
   virtual LuaRootPtr luaRoot() = 0;
+  virtual StringMap<LuaCallbacks> luaThreadCallbacks() const = 0;
 
   // Locate a unique entity, if the target is local, the promise will be
   // finished before being returned.  If the unique entity is not found, the

--- a/source/game/scripting/StarCelestialLuaBindings.cpp
+++ b/source/game/scripting/StarCelestialLuaBindings.cpp
@@ -7,11 +7,8 @@
 #include "StarJsonExtra.hpp"
 
 namespace Star {
-
-LuaCallbacks LuaBindings::makeCelestialCallbacks(Universe* universe) {
+LuaCallbacks LuaBindings::makeCelestialCallbacks(CelestialDatabasePtr celestialDatabase) {
   LuaCallbacks callbacks;
-
-  auto celestialDatabase = universe->celestialDatabase();
   
   callbacks.registerCallback("planetParameters", [celestialDatabase](Json const& coords) -> Json {
       CelestialCoordinate coordinate = CelestialCoordinate(coords);
@@ -106,6 +103,14 @@ LuaCallbacks LuaBindings::makeCelestialCallbacks(Universe* universe) {
       CelestialCoordinate coordinate = CelestialCoordinate(coords);
       return CelestialGraphics::drawSystemTwinkle(celestialDatabase, coordinate, twinkleTime);
     });
+  
+  return callbacks;
+}
+
+LuaCallbacks LuaBindings::makeCelestialCallbacks(Universe* universe) {
+  auto celestialDatabase = universe->celestialDatabase();
+  
+  LuaCallbacks callbacks = makeCelestialCallbacks(celestialDatabase);
   
   if (auto client = as<UniverseClient>(universe)) {
     auto systemWorld = client->systemWorldClient();

--- a/source/game/scripting/StarCelestialLuaBindings.hpp
+++ b/source/game/scripting/StarCelestialLuaBindings.hpp
@@ -6,8 +6,10 @@ namespace Star {
 
 STAR_CLASS(Root);
 STAR_CLASS(Universe);
+STAR_CLASS(CelestialDatabase);
 
 namespace LuaBindings {
+  LuaCallbacks makeCelestialCallbacks(CelestialDatabasePtr database);
   LuaCallbacks makeCelestialCallbacks(Universe* universe);
 }
 }

--- a/source/game/scripting/StarLuaComponents.hpp
+++ b/source/game/scripting/StarLuaComponents.hpp
@@ -199,6 +199,9 @@ public:
 protected:
   using Base::setLuaRoot;
   using Base::init;
+  
+private:
+  StringSet m_worldThreadCallbacks;
 };
 
 // Component for scripts which can be used as entity message handlers, provides
@@ -401,6 +404,11 @@ void LuaWorldComponent<Base>::init(World* world) {
 
   Base::setLuaRoot(world->luaRoot());
   Base::addCallbacks("world", LuaBindings::makeWorldCallbacks(world));
+  Base::addThreadCallbacks("world", LuaBindings::makeWorldThreadCallbacks(world));
+  for (auto& p : world->luaThreadCallbacks()) {
+    Base::addThreadCallbacks(p.first,p.second);
+    m_worldThreadCallbacks.add(p.first);
+  }
   Base::init();
 }
 
@@ -408,6 +416,11 @@ template <typename Base>
 void LuaWorldComponent<Base>::uninit() {
   Base::uninit();
   Base::removeCallbacks("world");
+  Base::removeThreadCallbacks("world");
+  for (auto& c : m_worldThreadCallbacks) {
+    Base::removeThreadCallbacks(c);
+  }
+  m_worldThreadCallbacks = {};
 }
 
 template <typename Base>

--- a/source/game/scripting/StarWorldLuaBindings.cpp
+++ b/source/game/scripting/StarWorldLuaBindings.cpp
@@ -238,32 +238,24 @@ namespace LuaBindings {
 
     return entityQueryImpl<EntityT>(world, engine, *options, selector);
   }
+  
+  // Thread-safe callbacks that can be used from any thread under the world
+  LuaCallbacks makeWorldThreadCallbacks(World* world) {
+    LuaCallbacks callbacks;
+    
+    addWorldDebugCallbacks(callbacks);
+    addWorldGeometryCallbacks(callbacks, world);
+    
+    return callbacks;
+  }
 
   LuaCallbacks makeWorldCallbacks(World* world) {
-    LuaCallbacks callbacks;
+    LuaCallbacks callbacks = makeWorldThreadCallbacks(world);
 
-    addWorldDebugCallbacks(callbacks);
     addWorldEnvironmentCallbacks(callbacks, world);
     addWorldEntityCallbacks(callbacks, world);
+    addWorldCollisionCallbacks(callbacks, world);
 
-    callbacks.registerCallbackWithSignature<float, Vec2F, Maybe<Vec2F>>("magnitude", bind(&WorldCallbacks::magnitude, world, _1, _2));
-    callbacks.registerCallbackWithSignature<Vec2F, Vec2F, Vec2F>("distance", bind(WorldCallbacks::distance, world, _1, _2));
-    callbacks.registerCallbackWithSignature<bool, PolyF, Vec2F>("polyContains", bind(WorldCallbacks::polyContains, world, _1, _2));
-    callbacks.registerCallbackWithSignature<LuaValue, LuaEngine&, LuaValue>("xwrap", bind(WorldCallbacks::xwrap, world, _1, _2));
-    callbacks.registerCallbackWithSignature<LuaValue, LuaEngine&, Variant<Vec2F, float>, Variant<Vec2F, float>>("nearestTo", bind(WorldCallbacks::nearestTo, world, _1, _2, _3));
-
-    callbacks.registerCallbackWithSignature<bool, RectF, Maybe<CollisionSet>>("rectCollision", bind(WorldCallbacks::rectCollision, world, _1, _2));
-    callbacks.registerCallbackWithSignature<bool, Vec2F, Maybe<CollisionSet>>("pointTileCollision", bind(WorldCallbacks::pointTileCollision, world, _1, _2));
-    callbacks.registerCallbackWithSignature<bool, Vec2F, Vec2F, Maybe<CollisionSet>>("lineTileCollision", bind(WorldCallbacks::lineTileCollision, world, _1, _2, _3));
-    callbacks.registerCallbackWithSignature<Maybe<pair<Vec2F, Vec2I>>, Vec2F, Vec2F, Maybe<CollisionSet>>("lineTileCollisionPoint", bind(WorldCallbacks::lineTileCollisionPoint, world, _1, _2, _3));
-    callbacks.registerCallbackWithSignature<bool, RectF, Maybe<CollisionSet>>("rectTileCollision", bind(WorldCallbacks::rectTileCollision, world, _1, _2));
-    callbacks.registerCallbackWithSignature<bool, Vec2F, Maybe<CollisionSet>>("pointCollision", bind(WorldCallbacks::pointCollision, world, _1, _2));
-    callbacks.registerCallbackWithSignature<LuaTupleReturn<Maybe<Vec2F>, Maybe<Vec2F>>, Vec2F, Vec2F, Maybe<CollisionSet>>("lineCollision", bind(WorldCallbacks::lineCollision, world, _1, _2, _3));
-    callbacks.registerCallbackWithSignature<bool, PolyF, Maybe<Vec2F>, Maybe<CollisionSet>>("polyCollision", bind(WorldCallbacks::polyCollision, world, _1, _2, _3));
-    callbacks.registerCallbackWithSignature<List<Vec2I>, Vec2F, Vec2F, Maybe<CollisionSet>, Maybe<int>>("collisionBlocksAlongLine", bind(WorldCallbacks::collisionBlocksAlongLine, world, _1, _2, _3, _4));
-    callbacks.registerCallbackWithSignature<List<pair<Vec2I, LiquidLevel>>, Vec2F, Vec2F>("liquidAlongLine", bind(WorldCallbacks::liquidAlongLine, world, _1, _2));
-    callbacks.registerCallbackWithSignature<Maybe<Vec2F>, PolyF, Vec2F, float, Maybe<CollisionSet>>("resolvePolyCollision", bind(WorldCallbacks::resolvePolyCollision, world, _1, _2, _3, _4));
-    callbacks.registerCallbackWithSignature<bool, Vec2I, Maybe<bool>, Maybe<bool>>("tileIsOccupied", bind(WorldCallbacks::tileIsOccupied, world, _1, _2, _3));
     callbacks.registerCallbackWithSignature<bool, String, Vec2I, Maybe<int>, Json>("placeObject", bind(WorldCallbacks::placeObject, world, _1, _2, _3, _4));
     callbacks.registerCallbackWithSignature<Maybe<EntityId>, Json, Vec2F, Maybe<size_t>, Json, Maybe<Vec2F>, Maybe<float>>("spawnItem", bind(WorldCallbacks::spawnItem, world, _1, _2, _3, _4, _5, _6));
     callbacks.registerCallbackWithSignature<List<EntityId>, Vec2F, String, float, Maybe<uint64_t>>("spawnTreasure", bind(WorldCallbacks::spawnTreasure, world, _1, _2, _3, _4));
@@ -272,18 +264,8 @@ namespace LuaBindings {
     callbacks.registerCallbackWithSignature<Maybe<EntityId>, Vec2F, String, Json>("spawnStagehand", bind(WorldCallbacks::spawnStagehand, world, _1, _2, _3));
     callbacks.registerCallbackWithSignature<Maybe<EntityId>, String, Vec2F, Maybe<EntityId>, Maybe<Vec2F>, bool, Json>("spawnProjectile", bind(WorldCallbacks::spawnProjectile, world, _1, _2, _3, _4, _5, _6));
     callbacks.registerCallbackWithSignature<Maybe<EntityId>, String, Vec2F, Json>("spawnVehicle", bind(WorldCallbacks::spawnVehicle, world, _1, _2, _3));
-    callbacks.registerCallbackWithSignature<float>("threatLevel", bind(&World::threatLevel, world));
-    callbacks.registerCallbackWithSignature<double>("time", bind(WorldCallbacks::time, world));
-    callbacks.registerCallbackWithSignature<uint64_t>("day", bind(WorldCallbacks::day, world));
-    callbacks.registerCallbackWithSignature<double>("timeOfDay", bind(WorldCallbacks::timeOfDay, world));
-    callbacks.registerCallbackWithSignature<float>("dayLength", bind(WorldCallbacks::dayLength, world));
     callbacks.registerCallbackWithSignature<Json, String, Json>("getProperty", bind(WorldCallbacks::getProperty, world, _1, _2));
     callbacks.registerCallbackWithSignature<void, String, Json>("setProperty", bind(WorldCallbacks::setProperty, world, _1, _2));
-    callbacks.registerCallbackWithSignature<Maybe<LiquidLevel>, Variant<RectF, Vec2I>>("liquidAt", bind(WorldCallbacks::liquidAt, world, _1));
-    callbacks.registerCallbackWithSignature<float, Vec2F>("gravity", bind(WorldCallbacks::gravity, world, _1));
-    callbacks.registerCallbackWithSignature<bool, Vec2F, LiquidId, float>("spawnLiquid", bind(WorldCallbacks::spawnLiquid, world, _1, _2, _3));
-    callbacks.registerCallbackWithSignature<Maybe<LiquidLevel>, Vec2F>("destroyLiquid", bind(WorldCallbacks::destroyLiquid, world, _1));
-    callbacks.registerCallbackWithSignature<bool, Vec2F>("isTileProtected", bind(WorldCallbacks::isTileProtected, world, _1));
     callbacks.registerCallbackWithSignature<Maybe<PlatformerAStar::Path>, Vec2F, Vec2F, ActorMovementParameters, PlatformerAStar::Parameters>("findPlatformerPath", bind(WorldCallbacks::findPlatformerPath, world, _1, _2, _3, _4));
     callbacks.registerCallbackWithSignature<PlatformerAStar::PathFinder, Vec2F, Vec2F, ActorMovementParameters, PlatformerAStar::Parameters>("platformerPathStart", bind(WorldCallbacks::platformerPathStart, world, _1, _2, _3, _4));
 
@@ -296,14 +278,6 @@ namespace LuaBindings {
             return engine.createString(worldParameters->typeName);
         }
         return engine.createString("unknown");
-      });
-
-    callbacks.registerCallback("size", [world]() -> Vec2I {
-        if (auto serverWorld = as<WorldServer>(world))
-          return (Vec2I)serverWorld->worldTemplate()->size();
-        else if (auto clientWorld = as<WorldClient>(world))
-          return (Vec2I)clientWorld->currentTemplate()->size();
-        return Vec2I();
       });
 
     callbacks.registerCallback("inSurfaceLayer", [world](Vec2I const& position) -> bool {
@@ -332,12 +306,6 @@ namespace LuaBindings {
             return worldParameters->type() == WorldParametersType::TerrestrialWorldParameters;
         }
         return false;
-      });
-
-    callbacks.registerCallback("itemDropItem", [world](EntityId const& entityId) -> Json {
-        if (auto itemDrop = world->get<ItemDrop>(entityId))
-          return itemDrop->item()->descriptor().toJson();
-        return {};
       });
 
     callbacks.registerCallback("biomeBlocksAt", [world](Vec2I position) -> Maybe<List<MaterialId>> {
@@ -669,6 +637,11 @@ namespace LuaBindings {
         }
         return {};
       });
+      callbacks.registerCallback("itemDropItem", [world](EntityId const& entityId) -> Json {
+          if (auto itemDrop = world->get<ItemDrop>(entityId))
+            return itemDrop->item()->descriptor().toJson();
+          return {};
+        });
   }
 
   void addWorldEnvironmentCallbacks(LuaCallbacks& callbacks, World* world) {
@@ -695,6 +668,15 @@ namespace LuaBindings {
     callbacks.registerCallback("environmentStatusEffects", [world](Vec2F const& position) {
         return world->environmentStatusEffects(position);
       });
+    callbacks.registerCallback("weatherStatusEffects", [world](Vec2F const& position) {
+        return world->weatherStatusEffects(position);
+      });
+    callbacks.registerCallback("exposedToWeather", [world](Vec2F const& position) {
+        return world->exposedToWeather(position);
+      });
+    callbacks.registerCallback("activeWeather", [world](Vec2F const& position) {
+        return world->activeWeather(position);
+      });
 
     callbacks.registerCallbackWithSignature<bool, List<Vec2I>, String, Vec2F, String, float, Maybe<unsigned>, Maybe<EntityId>>("damageTiles", bind(WorldEnvironmentCallbacks::damageTiles, world, _1, _2, _3, _4, _5, _6, _7));
     callbacks.registerCallbackWithSignature<bool, Vec2F, float, String, Vec2F, String, float, Maybe<unsigned>, Maybe<EntityId>>("damageTileArea", bind(WorldEnvironmentCallbacks::damageTileArea, world, _1, _2, _3, _4, _5, _6, _7, _8));
@@ -709,30 +691,68 @@ namespace LuaBindings {
         return world->material(t, layer) != EmptyMaterialId;
       });
     });
+    
+    callbacks.registerCallbackWithSignature<List<pair<Vec2I, LiquidLevel>>, Vec2F, Vec2F>("liquidAlongLine", bind(WorldEnvironmentCallbacks::liquidAlongLine, world, _1, _2));
+    callbacks.registerCallbackWithSignature<bool, Vec2I, Maybe<bool>, Maybe<bool>>("tileIsOccupied", bind(WorldEnvironmentCallbacks::tileIsOccupied, world, _1, _2, _3));
+    callbacks.registerCallbackWithSignature<float>("threatLevel", bind(&World::threatLevel, world));
+    callbacks.registerCallbackWithSignature<double>("time", bind(WorldEnvironmentCallbacks::time, world));
+    callbacks.registerCallbackWithSignature<uint64_t>("day", bind(WorldEnvironmentCallbacks::day, world));
+    callbacks.registerCallbackWithSignature<double>("timeOfDay", bind(WorldEnvironmentCallbacks::timeOfDay, world));
+    callbacks.registerCallbackWithSignature<float>("dayLength", bind(WorldEnvironmentCallbacks::dayLength, world));
+    callbacks.registerCallbackWithSignature<Maybe<LiquidLevel>, Variant<RectF, Vec2I>>("liquidAt", bind(WorldEnvironmentCallbacks::liquidAt, world, _1));
+    callbacks.registerCallbackWithSignature<float, Vec2F>("gravity", bind(WorldEnvironmentCallbacks::gravity, world, _1));
+    callbacks.registerCallbackWithSignature<bool, Vec2F, LiquidId, float>("spawnLiquid", bind(WorldEnvironmentCallbacks::spawnLiquid, world, _1, _2, _3));
+    callbacks.registerCallbackWithSignature<Maybe<LiquidLevel>, Vec2F>("destroyLiquid", bind(WorldEnvironmentCallbacks::destroyLiquid, world, _1));
+    callbacks.registerCallbackWithSignature<bool, Vec2F>("isTileProtected", bind(WorldEnvironmentCallbacks::isTileProtected, world, _1));
+  }
+  
+  void addWorldGeometryCallbacks(LuaCallbacks& callbacks, World* world) {
+
+    callbacks.registerCallback("size", [world]() -> Vec2U {
+        return world->geometry().size();
+      });
+    callbacks.registerCallbackWithSignature<float, Vec2F, Maybe<Vec2F>>("magnitude", bind(&WorldGeometryCallbacks::magnitude, world, _1, _2));
+    callbacks.registerCallbackWithSignature<Vec2F, Vec2F, Vec2F>("distance", bind(WorldGeometryCallbacks::distance, world, _1, _2));
+    callbacks.registerCallbackWithSignature<bool, PolyF, Vec2F>("polyContains", bind(WorldGeometryCallbacks::polyContains, world, _1, _2));
+    callbacks.registerCallbackWithSignature<LuaValue, LuaEngine&, LuaValue>("xwrap", bind(WorldGeometryCallbacks::xwrap, world, _1, _2));
+    callbacks.registerCallbackWithSignature<LuaValue, LuaEngine&, Variant<Vec2F, float>, Variant<Vec2F, float>>("nearestTo", bind(WorldGeometryCallbacks::nearestTo, world, _1, _2, _3));
+  }
+  
+  void addWorldCollisionCallbacks(LuaCallbacks& callbacks, World* world) {
+    callbacks.registerCallbackWithSignature<bool, RectF, Maybe<CollisionSet>>("rectCollision", bind(WorldCollisionCallbacks::rectCollision, world, _1, _2));
+    callbacks.registerCallbackWithSignature<bool, Vec2F, Maybe<CollisionSet>>("pointTileCollision", bind(WorldCollisionCallbacks::pointTileCollision, world, _1, _2));
+    callbacks.registerCallbackWithSignature<bool, Vec2F, Vec2F, Maybe<CollisionSet>>("lineTileCollision", bind(WorldCollisionCallbacks::lineTileCollision, world, _1, _2, _3));
+    callbacks.registerCallbackWithSignature<Maybe<pair<Vec2F, Vec2I>>, Vec2F, Vec2F, Maybe<CollisionSet>>("lineTileCollisionPoint", bind(WorldCollisionCallbacks::lineTileCollisionPoint, world, _1, _2, _3));
+    callbacks.registerCallbackWithSignature<bool, RectF, Maybe<CollisionSet>>("rectTileCollision", bind(WorldCollisionCallbacks::rectTileCollision, world, _1, _2));
+    callbacks.registerCallbackWithSignature<bool, Vec2F, Maybe<CollisionSet>>("pointCollision", bind(WorldCollisionCallbacks::pointCollision, world, _1, _2));
+    callbacks.registerCallbackWithSignature<LuaTupleReturn<Maybe<Vec2F>, Maybe<Vec2F>>, Vec2F, Vec2F, Maybe<CollisionSet>>("lineCollision", bind(WorldCollisionCallbacks::lineCollision, world, _1, _2, _3));
+    callbacks.registerCallbackWithSignature<bool, PolyF, Maybe<Vec2F>, Maybe<CollisionSet>>("polyCollision", bind(WorldCollisionCallbacks::polyCollision, world, _1, _2, _3));
+    callbacks.registerCallbackWithSignature<List<Vec2I>, Vec2F, Vec2F, Maybe<CollisionSet>, Maybe<int>>("collisionBlocksAlongLine", bind(WorldCollisionCallbacks::collisionBlocksAlongLine, world, _1, _2, _3, _4));
+    callbacks.registerCallbackWithSignature<Maybe<Vec2F>, PolyF, Vec2F, float, Maybe<CollisionSet>>("resolvePolyCollision", bind(WorldCollisionCallbacks::resolvePolyCollision, world, _1, _2, _3, _4));
   }
 
-  float WorldCallbacks::magnitude(World* world, Vec2F pos1, Maybe<Vec2F> pos2) {
+  float WorldGeometryCallbacks::magnitude(World* world, Vec2F pos1, Maybe<Vec2F> pos2) {
     if (pos2)
       return world->geometry().diff(pos1, *pos2).magnitude();
     else
       return pos1.magnitude();
   }
 
-  Vec2F WorldCallbacks::distance(World* world, Vec2F const& arg1, Vec2F const& arg2) {
+  Vec2F WorldGeometryCallbacks::distance(World* world, Vec2F const& arg1, Vec2F const& arg2) {
     return world->geometry().diff(arg1, arg2);
   }
 
-  bool WorldCallbacks::polyContains(World* world, PolyF const& poly, Vec2F const& pos) {
+  bool WorldGeometryCallbacks::polyContains(World* world, PolyF const& poly, Vec2F const& pos) {
     return world->geometry().polyContains(poly, pos);
   }
 
-  LuaValue WorldCallbacks::xwrap(World* world, LuaEngine& engine, LuaValue const& positionOrX) {
+  LuaValue WorldGeometryCallbacks::xwrap(World* world, LuaEngine& engine, LuaValue const& positionOrX) {
     if (auto x = engine.luaMaybeTo<float>(positionOrX))
       return LuaFloat(world->geometry().xwrap(*x));
     return engine.luaFrom<Vec2F>(world->geometry().xwrap(engine.luaTo<Vec2F>(positionOrX)));
   }
 
-  LuaValue WorldCallbacks::nearestTo(World* world, LuaEngine& engine, Variant<Vec2F, float> const& sourcePositionOrX, Variant<Vec2F, float> const& targetPositionOrX) {
+  LuaValue WorldGeometryCallbacks::nearestTo(World* world, LuaEngine& engine, Variant<Vec2F, float> const& sourcePositionOrX, Variant<Vec2F, float> const& targetPositionOrX) {
     if (targetPositionOrX.is<Vec2F>()) {
       Vec2F targetPosition = targetPositionOrX.get<Vec2F>();
       Vec2F sourcePosition;
@@ -755,7 +775,7 @@ namespace LuaBindings {
     }
   }
 
-  bool WorldCallbacks::rectCollision(World* world, RectF const& arg1, Maybe<CollisionSet> const& arg2) {
+  bool WorldCollisionCallbacks::rectCollision(World* world, RectF const& arg1, Maybe<CollisionSet> const& arg2) {
     PolyF body = PolyF(arg1);
 
     if (arg2)
@@ -764,14 +784,14 @@ namespace LuaBindings {
       return world->polyCollision(body);
   }
 
-  bool WorldCallbacks::pointTileCollision(World* world, Vec2F const& arg1, Maybe<CollisionSet> const& arg2) {
+  bool WorldCollisionCallbacks::pointTileCollision(World* world, Vec2F const& arg1, Maybe<CollisionSet> const& arg2) {
     if (arg2)
       return world->pointTileCollision(arg1, *arg2);
     else
       return world->pointTileCollision(arg1);
   }
 
-  bool WorldCallbacks::lineTileCollision(
+  bool WorldCollisionCallbacks::lineTileCollision(
       World* world, Vec2F const& arg1, Vec2F const& arg2, Maybe<CollisionSet> const& arg3) {
     Vec2F const begin = arg1;
     Vec2F const end = arg2;
@@ -782,14 +802,14 @@ namespace LuaBindings {
       return world->lineTileCollision(begin, end);
   }
 
-  Maybe<pair<Vec2F, Vec2I>> WorldCallbacks::lineTileCollisionPoint(World* world, Vec2F const& begin, Vec2F const& end, Maybe<CollisionSet> const& collisionSet) {
+  Maybe<pair<Vec2F, Vec2I>> WorldCollisionCallbacks::lineTileCollisionPoint(World* world, Vec2F const& begin, Vec2F const& end, Maybe<CollisionSet> const& collisionSet) {
     if (collisionSet)
       return world->lineTileCollisionPoint(begin, end, *collisionSet);
     else
       return world->lineTileCollisionPoint(begin, end);
   }
 
-  bool WorldCallbacks::rectTileCollision(World* world, RectF const& arg1, Maybe<CollisionSet> const& arg2) {
+  bool WorldCollisionCallbacks::rectTileCollision(World* world, RectF const& arg1, Maybe<CollisionSet> const& arg2) {
     RectI const region = RectI::integral(arg1);
 
     if (arg2)
@@ -798,11 +818,11 @@ namespace LuaBindings {
       return world->rectTileCollision(region);
   }
 
-  bool WorldCallbacks::pointCollision(World* world, Vec2F const& point, Maybe<CollisionSet> const& collisionSet) {
+  bool WorldCollisionCallbacks::pointCollision(World* world, Vec2F const& point, Maybe<CollisionSet> const& collisionSet) {
     return world->pointCollision(point, collisionSet.value(DefaultCollisionSet));
   }
 
-  LuaTupleReturn<Maybe<Vec2F>, Maybe<Vec2F>> WorldCallbacks::lineCollision(World* world, Vec2F const& start, Vec2F const& end, Maybe<CollisionSet> const& collisionSet) {
+  LuaTupleReturn<Maybe<Vec2F>, Maybe<Vec2F>> WorldCollisionCallbacks::lineCollision(World* world, Vec2F const& start, Vec2F const& end, Maybe<CollisionSet> const& collisionSet) {
     Maybe<Vec2F> point;
     Maybe<Vec2F> normal;
     auto collision = world->lineCollision(Line2F(start, end), collisionSet.value(DefaultCollisionSet));
@@ -813,7 +833,7 @@ namespace LuaBindings {
     return luaTupleReturn(point, normal);
   }
 
-  bool WorldCallbacks::polyCollision(
+  bool WorldCollisionCallbacks::polyCollision(
       World* world, PolyF const& arg1, Maybe<Vec2F> const& arg2, Maybe<CollisionSet> const& arg3) {
     PolyF body = arg1;
 
@@ -829,7 +849,7 @@ namespace LuaBindings {
       return world->polyCollision(body);
   }
 
-  List<Vec2I> WorldCallbacks::collisionBlocksAlongLine(
+  List<Vec2I> WorldCollisionCallbacks::collisionBlocksAlongLine(
       World* world, Vec2F const& arg1, Vec2F const& arg2, Maybe<CollisionSet> const& arg3, Maybe<int> const& arg4) {
     Vec2F const begin = arg1;
     Vec2F const end = arg2;
@@ -839,18 +859,7 @@ namespace LuaBindings {
     return world->collidingTilesAlongLine(begin, end, collisionSet, maxSize);
   }
 
-  List<pair<Vec2I, LiquidLevel>> WorldCallbacks::liquidAlongLine(World* world, Vec2F const& start, Vec2F const& end) {
-    List<pair<Vec2I, LiquidLevel>> levels;
-    forBlocksAlongLine<float>(start, world->geometry().diff(end, start), [&](int x, int y) {
-        auto liquidLevel = world->liquidLevel(RectF::withSize(Vec2F(x, y), Vec2F(1, 1)));
-        if (liquidLevel.liquid != EmptyLiquidId)
-          levels.append(pair<Vec2I, LiquidLevel>(Vec2I(x, y), liquidLevel));
-        return true;
-      });
-    return levels;
-  }
-
-  Maybe<Vec2F> WorldCallbacks::resolvePolyCollision(
+  Maybe<Vec2F> WorldCollisionCallbacks::resolvePolyCollision(
       World* world, PolyF poly, Vec2F const& position, float maximumCorrection, Maybe<CollisionSet> const& maybeCollisionSet) {
     struct CollisionPoly {
       PolyF poly;
@@ -921,7 +930,18 @@ namespace LuaBindings {
     return {};
   }
 
-  bool WorldCallbacks::tileIsOccupied(
+  List<pair<Vec2I, LiquidLevel>> WorldEnvironmentCallbacks::liquidAlongLine(World* world, Vec2F const& start, Vec2F const& end) {
+    List<pair<Vec2I, LiquidLevel>> levels;
+    forBlocksAlongLine<float>(start, world->geometry().diff(end, start), [&](int x, int y) {
+        auto liquidLevel = world->liquidLevel(RectF::withSize(Vec2F(x, y), Vec2F(1, 1)));
+        if (liquidLevel.liquid != EmptyLiquidId)
+          levels.append(pair<Vec2I, LiquidLevel>(Vec2I(x, y), liquidLevel));
+        return true;
+      });
+    return levels;
+  }
+
+  bool WorldEnvironmentCallbacks::tileIsOccupied(
       World* world, Vec2I const& arg1, Maybe<bool> const& arg2, Maybe<bool> const& arg3) {
     Vec2I const tile = arg1;
     bool const tileLayerBool = arg2.value(true);
@@ -1125,19 +1145,19 @@ namespace LuaBindings {
     return {};
   }
 
-  double WorldCallbacks::time(World* world) {
+  double WorldEnvironmentCallbacks::time(World* world) {
     return world->epochTime();
   }
 
-  uint64_t WorldCallbacks::day(World* world) {
+  uint64_t WorldEnvironmentCallbacks::day(World* world) {
     return world->day();
   }
 
-  double WorldCallbacks::timeOfDay(World* world) {
+  double WorldEnvironmentCallbacks::timeOfDay(World* world) {
     return world->timeOfDay() / world->dayLength();
   }
 
-  float WorldCallbacks::dayLength(World* world) {
+  float WorldEnvironmentCallbacks::dayLength(World* world) {
     return world->dayLength();
   }
 
@@ -1149,22 +1169,22 @@ namespace LuaBindings {
     world->setProperty(arg1, arg2);
   }
 
-  Maybe<LiquidLevel> WorldCallbacks::liquidAt(World* world, Variant<RectF, Vec2I> boundBoxOrPoint) {
+  Maybe<LiquidLevel> WorldEnvironmentCallbacks::liquidAt(World* world, Variant<RectF, Vec2I> boundBoxOrPoint) {
     LiquidLevel liquidLevel = boundBoxOrPoint.call([world](auto const& bbop) { return world->liquidLevel(bbop); });
     if (liquidLevel.liquid != EmptyLiquidId)
       return liquidLevel;
     return {};
   }
 
-  float WorldCallbacks::gravity(World* world, Vec2F const& arg1) {
+  float WorldEnvironmentCallbacks::gravity(World* world, Vec2F const& arg1) {
     return world->gravity(arg1);
   }
 
-  bool WorldCallbacks::spawnLiquid(World* world, Vec2F const& position, LiquidId liquid, float quantity) {
+  bool WorldEnvironmentCallbacks::spawnLiquid(World* world, Vec2F const& position, LiquidId liquid, float quantity) {
     return world->modifyTile(Vec2I::floor(position), PlaceLiquid{liquid, quantity}, true);
   }
 
-  Maybe<LiquidLevel> WorldCallbacks::destroyLiquid(World* world, Vec2F const& position) {
+  Maybe<LiquidLevel> WorldEnvironmentCallbacks::destroyLiquid(World* world, Vec2F const& position) {
     auto liquidLevel = world->liquidLevel(Vec2I::floor(position));
     if (liquidLevel.liquid != EmptyLiquidId) {
       if (world->modifyTile(Vec2I::floor(position), PlaceLiquid{EmptyLiquidId, 0}, true))
@@ -1173,7 +1193,7 @@ namespace LuaBindings {
     return {};
   }
 
-  bool WorldCallbacks::isTileProtected(World* world, Vec2F const& position) {
+  bool WorldEnvironmentCallbacks::isTileProtected(World* world, Vec2F const& position) {
     return world->isTileProtected(Vec2I::floor(position));
   }
 

--- a/source/game/scripting/StarWorldLuaBindings.hpp
+++ b/source/game/scripting/StarWorldLuaBindings.hpp
@@ -21,30 +21,16 @@ STAR_CLASS(ScriptedEntity);
 namespace LuaBindings {
   typedef function<Json(ScriptedEntityPtr const& entity, String const& functionName, JsonArray const& args)> CallEntityScriptFunction;
 
+  LuaCallbacks makeWorldThreadCallbacks(World* world);
   LuaCallbacks makeWorldCallbacks(World* world);
 
   void addWorldDebugCallbacks(LuaCallbacks& callbacks);
   void addWorldEntityCallbacks(LuaCallbacks& callbacks, World* world);
   void addWorldEnvironmentCallbacks(LuaCallbacks& callbacks, World* world);
+  void addWorldGeometryCallbacks(LuaCallbacks& callbacks, World* world);
+  void addWorldCollisionCallbacks(LuaCallbacks& callbacks, World* world);
 
   namespace WorldCallbacks {
-    float magnitude(World* world, Vec2F pos1, Maybe<Vec2F> pos2);
-    Vec2F distance(World* world, Vec2F const& arg1, Vec2F const& arg2);
-    bool polyContains(World* world, PolyF const& poly, Vec2F const& pos);
-    LuaValue xwrap(World* world, LuaEngine& engine, LuaValue const& positionOrX);
-    LuaValue nearestTo(World* world, LuaEngine& engine, Variant<Vec2F, float> const& sourcePositionOrX, Variant<Vec2F, float> const& targetPositionOrX);
-    bool rectCollision(World* world, RectF const& arg1, Maybe<CollisionSet> const& arg2);
-    bool pointTileCollision(World* world, Vec2F const& arg1, Maybe<CollisionSet> const& arg2);
-    bool lineTileCollision(World* world, Vec2F const& arg1, Vec2F const& arg2, Maybe<CollisionSet> const& arg3);
-    Maybe<pair<Vec2F, Vec2I>> lineTileCollisionPoint(World* world, Vec2F const& start, Vec2F const& end, Maybe<CollisionSet> const& maybeCollisionSet);
-    bool rectTileCollision(World* world, RectF const& arg1, Maybe<CollisionSet> const& arg2);
-    bool pointCollision(World* world, Vec2F const& point, Maybe<CollisionSet> const& collisionSet);
-    LuaTupleReturn<Maybe<Vec2F>, Maybe<Vec2F>> lineCollision(World* world, Vec2F const& start, Vec2F const& end, Maybe<CollisionSet> const& maybeCollisionSet);
-    bool polyCollision(World* world, PolyF const& arg1, Maybe<Vec2F> const& arg2, Maybe<CollisionSet> const& arg3);
-    List<Vec2I> collisionBlocksAlongLine(World* world, Vec2F const& arg1, Vec2F const& arg2, Maybe<CollisionSet> const& arg3, Maybe<int> const& arg4);
-    List<pair<Vec2I, LiquidLevel>> liquidAlongLine(World* world, Vec2F const& start, Vec2F const& end);
-    Maybe<Vec2F> resolvePolyCollision(World* world, PolyF poly, Vec2F const& position, float maximumCorrection, Maybe<CollisionSet> const& collisionSet);
-    bool tileIsOccupied(World* world, Vec2I const& arg1, Maybe<bool> const& arg2, Maybe<bool> const& arg3);
     bool placeObject(World* world, String const& arg1, Vec2I const& arg2, Maybe<int> const& arg3, Json const& arg4);
     Maybe<EntityId> spawnItem(World* world, Json const& itemType, Vec2F const& worldPosition, Maybe<size_t> const& inputCount, Json const& inputParameters, Maybe<Vec2F> const& initialVelocity, Maybe<float> const& intangibleTime);
     List<EntityId> spawnTreasure(World* world, Vec2F const& position, String const& pool, float level, Maybe<uint64_t> seed);
@@ -53,17 +39,8 @@ namespace LuaBindings {
     Maybe<EntityId> spawnStagehand(World* world, Vec2F const& spawnPosition, String const& typeName, Json const& overrides);
     Maybe<EntityId> spawnProjectile(World* world, String const& arg1, Vec2F const& arg2, Maybe<EntityId> const& arg3, Maybe<Vec2F> const& arg4, bool arg5, Json const& arg6);
     Maybe<EntityId> spawnVehicle(World* world, String const& vehicleName, Vec2F const& pos, Json const& extraConfig);
-    double time(World* world);
-    uint64_t day(World* world);
-    double timeOfDay(World* world);
-    float dayLength(World* world);
     Json getProperty(World* world, String const& arg1, Json const& arg2);
     void setProperty(World* world, String const& arg1, Json const& arg2);
-    Maybe<LiquidLevel> liquidAt(World* world, Variant<RectF, Vec2I> boundBoxOrPoint);
-    float gravity(World* world, Vec2F const& arg1);
-    bool spawnLiquid(World* world, Vec2F const& arg1, LiquidId arg2, float arg3);
-    Maybe<LiquidLevel> destroyLiquid(World* world, Vec2F const& position);
-    bool isTileProtected(World* world, Vec2F const& position);
     Maybe<PlatformerAStar::Path> findPlatformerPath(World* world, Vec2F const& start, Vec2F const& end, ActorMovementParameters actorMovementParameters, PlatformerAStar::Parameters searchParameters);
     PlatformerAStar::PathFinder platformerPathStart(World* world, Vec2F const& start, Vec2F const& end, ActorMovementParameters actorMovementParameters, PlatformerAStar::Parameters searchParameters);
   }
@@ -90,6 +67,27 @@ namespace LuaBindings {
     LuaString fidelity(World* world, LuaEngine& engine);
     Maybe<LuaValue> callScriptContext(World* world, String const& contextName, String const& function, LuaVariadic<LuaValue> const& args);
     bool sendPacket(WorldServer* world, ConnectionId clientId, String const& packetType, Json const& packetData);
+  }
+  
+  namespace WorldGeometryCallbacks {
+    float magnitude(World* world, Vec2F pos1, Maybe<Vec2F> pos2);
+    Vec2F distance(World* world, Vec2F const& arg1, Vec2F const& arg2);
+    bool polyContains(World* world, PolyF const& poly, Vec2F const& pos);
+    LuaValue xwrap(World* world, LuaEngine& engine, LuaValue const& positionOrX);
+    LuaValue nearestTo(World* world, LuaEngine& engine, Variant<Vec2F, float> const& sourcePositionOrX, Variant<Vec2F, float> const& targetPositionOrX);
+  }
+  
+  namespace WorldCollisionCallbacks {
+    bool rectCollision(World* world, RectF const& arg1, Maybe<CollisionSet> const& arg2);
+    bool pointTileCollision(World* world, Vec2F const& arg1, Maybe<CollisionSet> const& arg2);
+    bool lineTileCollision(World* world, Vec2F const& arg1, Vec2F const& arg2, Maybe<CollisionSet> const& arg3);
+    Maybe<pair<Vec2F, Vec2I>> lineTileCollisionPoint(World* world, Vec2F const& start, Vec2F const& end, Maybe<CollisionSet> const& maybeCollisionSet);
+    bool rectTileCollision(World* world, RectF const& arg1, Maybe<CollisionSet> const& arg2);
+    bool pointCollision(World* world, Vec2F const& point, Maybe<CollisionSet> const& collisionSet);
+    LuaTupleReturn<Maybe<Vec2F>, Maybe<Vec2F>> lineCollision(World* world, Vec2F const& start, Vec2F const& end, Maybe<CollisionSet> const& maybeCollisionSet);
+    bool polyCollision(World* world, PolyF const& arg1, Maybe<Vec2F> const& arg2, Maybe<CollisionSet> const& arg3);
+    List<Vec2I> collisionBlocksAlongLine(World* world, Vec2F const& arg1, Vec2F const& arg2, Maybe<CollisionSet> const& arg3, Maybe<int> const& arg4);
+    Maybe<Vec2F> resolvePolyCollision(World* world, PolyF poly, Vec2F const& position, float maximumCorrection, Maybe<CollisionSet> const& collisionSet);
   }
 
   namespace WorldDebugCallbacks {
@@ -183,6 +181,17 @@ namespace LuaBindings {
     bool replaceMaterials(World* world, List<Vec2I> const& tilePositions, String const& layer, String const& materialName, Maybe<int> const& hueShift, bool enableDrops);
     bool replaceMaterialArea(World* world, Vec2F center, float radius, String const& layer, String const& materialName, Maybe<int> const& hueShift, bool enableDrops);
     bool placeMod(World* world, Vec2I const& arg1, String const& arg2, String const& arg3, Maybe<int> const& arg4, bool arg5);
+    List<pair<Vec2I, LiquidLevel>> liquidAlongLine(World* world, Vec2F const& start, Vec2F const& end);
+    bool tileIsOccupied(World* world, Vec2I const& arg1, Maybe<bool> const& arg2, Maybe<bool> const& arg3);
+    double time(World* world);
+    uint64_t day(World* world);
+    double timeOfDay(World* world);
+    float dayLength(World* world);
+    Maybe<LiquidLevel> liquidAt(World* world, Variant<RectF, Vec2I> boundBoxOrPoint);
+    float gravity(World* world, Vec2F const& arg1);
+    bool spawnLiquid(World* world, Vec2F const& arg1, LiquidId arg2, float arg3);
+    Maybe<LiquidLevel> destroyLiquid(World* world, Vec2F const& position);
+    bool isTileProtected(World* world, Vec2F const& position);
   }
 }
 


### PR DESCRIPTION
adds `world.activeWeather`, `world.exposedToWeather`, `world.weatherStatusEffects`

also adds a reduced version of `world` with only geometry/debug bindings to scriptable threads

celestial and universe are now shared with entity scriptable threads too, client subworlds and scriptable threads get a reduced version of `celestial` on threads